### PR TITLE
Add top-level format field to stub artefacts.

### DIFF
--- a/lib/gds_api/test_helpers/content_api.rb
+++ b/lib/gds_api/test_helpers/content_api.rb
@@ -54,7 +54,7 @@ module GdsApi
       def artefact_for_slug(slug)
         singular_response_base.merge(
           "title" => titleize_slug(slug),
-          "kind" => "answer",
+          "format" => "guide",
           "id" => "http://contentapi.test.gov.uk/#{slug}.json",
           "web_url" => "http://frontend.test.gov.uk/#{slug}",
           "details" => {


### PR DESCRIPTION
These are now returned by the content_api.
