### PR TITLE
Add GdsApi::Rummager

### DIFF
--- a/lib/gds_api/rummager.rb
+++ b/lib/gds_api/rummager.rb
@@ -1,0 +1,39 @@
+module GdsApi
+  class Rummager
+    class SearchUriNotSpecified < RuntimeError; end
+    class SearchError < RuntimeError; end
+    class SearchServiceError < SearchError; end
+    class SearchTimeout < SearchError; end
+
+    attr_accessor :search_uri
+
+    def initialize(search_uri)
+      raise SearchUriNotSpecified unless search_uri
+      self.search_uri = search_uri
+    end
+
+    def search(query, format_filter = nil)
+      return [] if query.nil? || query == ""
+      JSON.parse(search_response(:search, query, format_filter).body)
+    end
+
+    def autocomplete(query, format_filter = nil)
+      return [] if query.nil? || query == ""
+      search_response(:autocomplete, query, format_filter).body
+    end
+
+    private
+
+    def search_response(type, query, format_filter = nil)
+      request_path = "/#{type}?q=#{CGI.escape(query)}"
+      request_path << "&format_filter=#{CGI.escape(format_filter)}" if format_filter
+      uri = URI("#{search_uri}#{request_path}")
+      http = Net::HTTP.new(uri.host, uri.port)
+      response = http.get(uri.request_uri, {"Accept" => "application/json"})
+      raise SearchServiceError.new("#{response.code}: #{response.body}") unless response.code == "200"
+      response
+    rescue Timeout::Error
+      raise SearchTimeout
+    end
+  end
+end

--- a/test/rummager_test.rb
+++ b/test/rummager_test.rb
@@ -1,0 +1,95 @@
+require "test_helper"
+require "gds_api/rummager"
+
+describe GdsApi::Rummager do
+  before(:each) do
+    stub_request(:get, /example.com\/search/).to_return(body: "[]")
+    stub_request(:get, /example.com\/autocomplete/).to_return(body: "[]")
+  end
+
+  it "should raise an exception if the search service uri is not set" do
+    assert_raises(GdsApi::Rummager::SearchUriNotSpecified) { GdsApi::Rummager.new(nil) }
+  end
+
+  it "should raise an exception if the service at the search URI returns a 500" do
+    stub_request(:get, /example.com\/search/).to_return(status: [500, "Internal Server Error"])
+    assert_raises(GdsApi::Rummager::SearchServiceError) do
+      GdsApi::Rummager.new("http://example.com").search("query")
+    end
+  end
+
+  it "should raise an exception if the service at the search URI returns a 404" do
+    stub_request(:get, /example.com\/search/).to_return(status: [404, "Not Found"])
+    assert_raises(GdsApi::Rummager::SearchServiceError) do
+      GdsApi::Rummager.new("http://example.com").search("query")
+    end
+  end
+
+  it "should raise an exception if the service at the search URI times out" do
+    stub_request(:get, /example.com\/search/).to_timeout
+    assert_raises(GdsApi::Rummager::SearchTimeout) do
+      GdsApi::Rummager.new("http://example.com").search("query")
+    end
+  end
+
+  it "should return the search deserialized from json" do
+    search_results = [{"title" => "document-title"}]
+    stub_request(:get, /example.com\/search/).to_return(body: search_results.to_json)
+    results = GdsApi::Rummager.new("http://example.com").search("query")
+
+    assert_equal search_results, results
+  end
+
+  it "should return an empty set of results without making request if query is empty" do
+    results = GdsApi::Rummager.new("http://example.com").search("")
+
+    assert_equal [], results
+    assert_not_requested :get, /example.com/
+  end
+
+  it "should return an empty set of results without making request if query is nil" do
+    results = GdsApi::Rummager.new("http://example.com").search(nil)
+
+    assert_equal [], results
+    assert_not_requested :get, /example.com/
+  end
+
+  it "should request the search results in JSON format" do
+    GdsApi::Rummager.new("http://example.com").search("query")
+
+    assert_requested :get, /.*/, headers: {"Accept" => "application/json"}
+  end
+
+  it "should issue a request for the search term specified" do
+    GdsApi::Rummager.new("http://example.com").search "search-term"
+
+    assert_requested :get, /\?q=search-term/
+  end
+
+  it "should add a format filter parameter to searches if provided" do
+    GdsApi::Rummager.new("http://example.com").search "search-term", "specialist_guidance"
+
+    assert_requested :get, /format_filter=specialist_guidance/
+  end
+
+  it "should add a format filter parameter to autocomplete if provided" do
+    GdsApi::Rummager.new("http://example.com").autocomplete "search-term", "specialist_guidance"
+
+    assert_requested :get, /format_filter=specialist_guidance/
+  end
+
+  it "should escape characters that would otherwise be invalid in a URI" do
+    GdsApi::Rummager.new("http://example.com").search "search term with spaces"
+
+    # FYI: the actual request is "?q=search+term+with+spaces", but Webmock appears to be re-escaping.
+    assert_requested :get, /\?q=search%20term%20with%20spaces/
+  end
+
+  it "should pass autocomplete responses back as-is" do
+    search_results_json = {"title" => "document-title"}.to_json
+    stub_request(:get, /example.com\/autocomplete/).to_return(body: search_results_json)
+    results = GdsApi::Rummager.new("http://example.com").autocomplete("test")
+
+    assert_equal search_results_json, results
+  end
+end


### PR DESCRIPTION
This is basically Whitehall::SearchClient moved and renamed. I changed the test format a bit but not what they're testing. The idea here is that this code could be used in some forthcoming mainstream work, but also that this sort of code would be good to bring into a shared place.

There is more work to do to bring this more in line with the way the other API Adapters work but I wanted to share it early.
