### PR TITLE
Revert escaping slugs in the ContentAPI requests.

### DIFF
--- a/lib/gds_api/content_api.rb
+++ b/lib/gds_api/content_api.rb
@@ -21,11 +21,11 @@ class GdsApi::ContentApi < GdsApi::Base
   end
 
   def artefact(slug)
-    get_json("#{base_url}/#{CGI.escape(slug)}.json")
+    get_json("#{base_url}/#{slug}.json")
   end
 
   def artefact_with_snac_code(slug, snac)
-    get_json("#{base_url}/#{CGI.escape(slug)}.json?snac=#{CGI.escape(snac)}")
+    get_json("#{base_url}/#{slug}.json?snac=#{CGI.escape(snac)}")
   end
 
   def local_authority(snac_code)


### PR DESCRIPTION
This is breaking tests in frontend for 'done'/completed transaction pages which have a slash in
the slug, as they are being escaped.
