### PR TITLE
Update the Licensify API endpoint.

### DIFF
--- a/lib/gds_api/licence_application.rb
+++ b/lib/gds_api/licence_application.rb
@@ -2,7 +2,7 @@ require_relative "base"
 
 class GdsApi::LicenceApplication < GdsApi::Base
   def all_licences
-    get_json!("#{@endpoint}/api/licences")
+    get_json!("#{@endpoint}/apply-for-a-licence/api/licences")
   end
 
   def details_for_licence(id, snac_code = nil)
@@ -18,9 +18,9 @@ class GdsApi::LicenceApplication < GdsApi::Base
 
   def build_licence_url(id, snac_code)
     if snac_code
-      "#{@endpoint}/api/licence/#{id}/#{snac_code}"
+      "#{@endpoint}/apply-for-a-licence/api/licence/#{id}/#{snac_code}"
     else
-      "#{@endpoint}/api/licence/#{id}"
+      "#{@endpoint}/apply-for-a-licence/api/licence/#{id}"
     end
   end
 end

--- a/lib/gds_api/test_helpers/licence_application.rb
+++ b/lib/gds_api/test_helpers/licence_application.rb
@@ -3,7 +3,7 @@ require 'gds_api/test_helpers/json_client_helper'
 module GdsApi
   module TestHelpers
     module LicenceApplication
-      LICENCE_APPLICATION_ENDPOINT = "https://licensify.test.alphagov.co.uk"
+      LICENCE_APPLICATION_ENDPOINT = "https://licensify.test.alphagov.co.uk/apply-for-a-licence"
 
       def licence_exists(identifier, licence)
         licence = licence.to_json unless licence.is_a?(String)


### PR DESCRIPTION
Due to the Licensify API endpoint being moved, we'll need to update
the URL we're pointing at in API adapters.
