### PR TITLE
Make content_api_has_root_sections test helper more flexible

### DIFF
--- a/lib/gds_api/test_helpers/content_api.rb
+++ b/lib/gds_api/test_helpers/content_api.rb
@@ -6,6 +6,8 @@ module GdsApi
     module ContentApi
       CONTENT_API_ENDPOINT = 'https://contentapi.test.alphagov.co.uk'
 
+      # Takes an array of slugs, or hashes with section details (including a slug).
+      # Will stub out content_api calls for tags of type section to return these sections
       def content_api_has_root_sections(slugs_or_sections)
         sections = slugs_or_sections.map {|s| s.is_a?(Hash) ? s : {:slug => s} }
         body = plural_response_base.merge(


### PR DESCRIPTION
This now allows passing either an array of slugs, or an array of hashes
with section details.
