### PR TITLE
CGI.escape slugs when requesting artefacts

### DIFF
--- a/lib/gds_api/content_api.rb
+++ b/lib/gds_api/content_api.rb
@@ -37,7 +37,7 @@ class GdsApi::ContentApi < GdsApi::Base
     edition = params[:edition]
     snac = params[:snac]
 
-    url = "#{base_url}/#{slug}.json"
+    url = "#{base_url}/#{CGI.escape(slug)}.json"
     query = params.map { |k,v| "#{k}=#{v}" }
     if query.any?
       url += "?#{query.join("&")}"

--- a/lib/gds_api/test_helpers/content_api.rb
+++ b/lib/gds_api/test_helpers/content_api.rb
@@ -135,7 +135,7 @@ module GdsApi
         singular_response_base.merge(
           "title" => titleize_slug(slug),
           "format" => "guide",
-          "id" => "#{CONTENT_API_ENDPOINT}/#{slug}.json",
+          "id" => "#{CONTENT_API_ENDPOINT}/#{CGI.escape(slug)}.json",
           "web_url" => "http://frontend.test.gov.uk/#{slug}",
           "details" => {
             "need_id" => "1234",

--- a/lib/gds_api/test_helpers/content_api/artefact_stub.rb
+++ b/lib/gds_api/test_helpers/content_api/artefact_stub.rb
@@ -41,7 +41,7 @@ module GdsApi
         
         private
           def url_without_query
-            "#{CONTENT_API_ENDPOINT}/#{slug}.json"
+            "#{CONTENT_API_ENDPOINT}/#{CGI.escape(slug)}.json"
           end
 
           # Ensure that all keys and values are strings 

--- a/test/content_api_test.rb
+++ b/test/content_api_test.rb
@@ -125,6 +125,13 @@ describe GdsApi::ContentApi do
         @api.artefact("devolution-uk", edition: 3)
       end
     end
+
+    it "should be able to fetch artefacts with a '/' in the slug" do
+      content_api_has_an_artefact("travel-advice/aruba")
+      response = @api.artefact("travel-advice/aruba")
+      assert_requested(:get, "#{@base_api_url}/travel-advice%2Faruba.json")
+      assert_equal "#{@base_api_url}/travel-advice%2Faruba.json", response["id"]
+    end
   end
 
   describe "tags" do


### PR DESCRIPTION
Also update test helpers to match this change.

This is necessary to support fetching slugs with a '/' in them
(completed transactions and travel advice).
