### PR TITLE
Fix JSON requests which have no body

### DIFF
--- a/lib/gds_api/json_client.rb
+++ b/lib/gds_api/json_client.rb
@@ -98,7 +98,7 @@ module GdsApi
     def do_json_request(method, url, params = nil, &create_response)
 
       begin
-        response = do_request_with_cache(method, url, params.to_json)
+        response = do_request_with_cache(method, url, (params.to_json if params))
 
       rescue RestClient::ResourceNotFound => e
         raise GdsApi::HTTPNotFound.new(e.http_code)

--- a/test/json_client_test.rb
+++ b/test/json_client_test.rb
@@ -347,6 +347,12 @@ class JsonClientTest < MiniTest::Spec
     assert_equal({}, @client.put_json(url, payload).to_hash)
   end
 
+  def test_does_not_encode_json_if_payload_is_nil
+    url = "http://some.endpoint/some.json"
+    stub_request(:put, url).with(body: nil).to_return(:body => "{}", :status => 200)
+    assert_equal({}, @client.put_json(url, nil).to_hash)
+  end
+
   def test_can_build_custom_response_object
     url = "http://some.endpoint/some.json"
     stub_request(:get, url).to_return(:body => "Hello there!")


### PR DESCRIPTION
The changes to the JsonClient led to an issue where an empty params
payload would be sent as a literal "null". This fixes the behaviour.
