### PR TITLE
Remove disable_timeout option

### DIFF
--- a/lib/gds_api/json_client.rb
+++ b/lib/gds_api/json_client.rb
@@ -21,6 +21,10 @@ module GdsApi
     attr_accessor :logger, :options, :cache
 
     def initialize(options = {})
+      if options[:disable_timeout] or options[:timeout].to_i < 0
+        raise "It is no longer possible to disable the timeout."
+      end
+
       @logger = options[:logger] || GdsApi::Base.logger
 
       if options[:disable_cache]

--- a/test/json_client_test.rb
+++ b/test/json_client_test.rb
@@ -504,4 +504,13 @@ class JsonClientTest < MiniTest::Spec
       @client.post_multipart("http://some.endpoint/some.json", {"a" => "123"})
     end
   end
+
+  def test_should_raise_error_if_attempting_to_disable_timeout
+    assert_raises RuntimeError do
+      GdsApi::JsonClient.new(:disable_timeout => true)
+    end
+    assert_raises RuntimeError do
+      GdsApi::JsonClient.new(:timeout => -1)
+    end
+  end
 end


### PR DESCRIPTION
This is bad, and can cause thing to block for ages.  It should never be used, and therefore it should be removed.
