### PR TITLE
Add ContentAPI method for /artefacts.json

### DIFF
--- a/lib/gds_api/content_api.rb
+++ b/lib/gds_api/content_api.rb
@@ -56,6 +56,10 @@ class GdsApi::ContentApi < GdsApi::Base
     get_json(url)
   end
 
+  def artefacts
+    get_list!("#{base_url}/artefacts.json")
+  end
+
   def local_authority(snac_code)
     get_json("#{base_url}/local_authorities/#{CGI.escape(snac_code)}.json")
   end


### PR DESCRIPTION
This will be used by the mirrorer, and mean that it will support
pagination when it's enabled.
