### PR TITLE
Support arbitrary search parameters

### DIFF
--- a/lib/gds_api/rummager.rb
+++ b/lib/gds_api/rummager.rb
@@ -4,9 +4,9 @@ require 'rack/utils'
 module GdsApi
   class Rummager < Base
 
-    def search(query)
+    def search(query, extra_params={})
       return [] if query.nil? || query == ""
-      get_json!(search_url(:search, query))
+      get_json!(search_url(:search, query, extra_params))
     end
 
     def advanced_search(args)
@@ -17,8 +17,12 @@ module GdsApi
 
   private
 
-    def search_url(type, query)
+    def search_url(type, query, extra_params={})
       request_path = "#{base_url}/#{type}?q=#{CGI.escape(query)}"
+      if extra_params
+        request_path << "&"
+        request_path << Rack::Utils.build_query(extra_params)
+      end
       request_path
     end
 

--- a/test/rummager_test.rb
+++ b/test/rummager_test.rb
@@ -69,6 +69,12 @@ describe GdsApi::Rummager do
     assert_requested :get, /\?q=search%20term%20with%20spaces/
   end
 
+  it "should append arbitrary parameters when supplied" do
+    GdsApi::Rummager.new("http://example.com").search("search-term", foo: "bar", zoo: "baz")
+
+    assert_requested :get, /\?foo=bar&q=search-term&zoo=baz/
+  end
+
   # tests for #advanced_search
 
   it "#advanced_search should raise an exception if the service at the search URI returns a 500" do


### PR DESCRIPTION
Right now, I want to be able to pass an `organisation_slug` parameter, but it seems like we
will want to add others in the future. By allowing arbitrary params, we reduce
the number of places changes are required to add other parameters.

This, as well as https://github.com/alphagov/gds-api-adapters/pull/64 will require a major version change.
