### PR TITLE
Clarify cache behaviour

### DIFF
--- a/lib/gds_api/json_client.rb
+++ b/lib/gds_api/json_client.rb
@@ -12,6 +12,9 @@ module GdsApi
 
     # Cache TTL will be overridden for a given request/response by the Expires
     # header if it is included in the response.
+    #
+    # LRUCache doesn't respect a cache size of 0, and instead effectively
+    # creates a cache with a size of 1.
     def self.cache(size=DEFAULT_CACHE_SIZE, ttl=DEFAULT_CACHE_TTL)
       @cache ||= LRUCache.new(max_size: size, ttl: ttl)
     end
@@ -29,7 +32,7 @@ module GdsApi
 
       @logger = options[:logger] || GdsApi::Base.logger
 
-      if options[:disable_cache]
+      if options[:disable_cache] || (options[:cache_size] == 0)
         @cache = NullCache.new
       else
         cache_size = options[:cache_size] || DEFAULT_CACHE_SIZE

--- a/test/gds_api_base_test.rb
+++ b/test/gds_api_base_test.rb
@@ -57,7 +57,16 @@ class GdsApiBaseTest < MiniTest::Unit::TestCase
   end
 
   def test_disabling_cache
+    # Ensure that there is a non-null cache by default
+    GdsApi::JsonClient.cache = true
     api = ConcreteApi.new("http://bar", disable_cache: true)
+    assert api.client.cache.is_a? GdsApi::NullCache
+  end
+
+  def test_disabling_cache_old_style
+    # Ensure that there is a non-null cache by default
+    GdsApi::JsonClient.cache = true
+    api = ConcreteApi.new("http://bar", cache_size: 0)
     assert api.client.cache.is_a? GdsApi::NullCache
   end
 


### PR DESCRIPTION
I had to look carefully at the code to figure out why my TTL was being ignored, so I added a comment.

I also found that LRUCache doesn't correctly handle a `max_size` of 0.
