### PR TITLE
Raise an ArgumentError if required params missing

### DIFF
--- a/lib/gds_api/rummager.rb
+++ b/lib/gds_api/rummager.rb
@@ -5,12 +5,12 @@ module GdsApi
   class Rummager < Base
 
     def search(query, extra_params={})
-      return [] if query.nil? || query == ""
+      raise ArgumentError.new("Query cannot be blank") if query.nil? || query.strip.empty?
       get_json!(search_url(:search, query, extra_params))
     end
 
     def advanced_search(args)
-      return [] if args.nil? || args.empty?
+      raise ArgumentError.new("Args cannot be blank") if args.nil? || args.empty?
       request_path = "#{base_url}/advanced_search?#{Rack::Utils.build_nested_query(args)}"
       get_json!(request_path)
     end

--- a/test/rummager_test.rb
+++ b/test/rummager_test.rb
@@ -37,17 +37,15 @@ describe GdsApi::Rummager do
   end
 
   it "should return an empty set of results without making request if query is empty" do
-    results = GdsApi::Rummager.new("http://example.com").search("")
-
-    assert_equal [], results
-    assert_not_requested :get, /example.com/
+    assert_raises(ArgumentError) do
+      GdsApi::Rummager.new("http://example.com").search("")
+    end
   end
 
   it "should return an empty set of results without making request if query is nil" do
-    results = GdsApi::Rummager.new("http://example.com").search(nil)
-
-    assert_equal [], results
-    assert_not_requested :get, /example.com/
+    assert_raises(ArgumentError) do
+      GdsApi::Rummager.new("http://example.com").search(nil)
+    end
   end
 
   it "should request the search results in JSON format" do
@@ -116,17 +114,15 @@ describe GdsApi::Rummager do
   end
 
   it "#advanced_search should return an empty set of results without making request if arguments are empty" do
-    results = GdsApi::Rummager.new("http://example.com").advanced_search({})
-
-    assert_equal [], results
-    assert_not_requested :get, /example.com/
+    assert_raises(ArgumentError) do
+      GdsApi::Rummager.new("http://example.com").advanced_search({})
+    end
   end
 
   it "#advanced_search should return an empty set of results without making request if arguments is nil" do
-    results = GdsApi::Rummager.new("http://example.com").advanced_search(nil)
-
-    assert_equal [], results
-    assert_not_requested :get, /example.com/
+    assert_raises(ArgumentError) do
+      results = GdsApi::Rummager.new("http://example.com").advanced_search(nil)
+    end
   end
 
   it "#advanced_search should request the search results in JSON format" do


### PR DESCRIPTION
Until now, we've been returning empty resultset if required params were missing. There are some problems with
this:
- for `search` it assumed the response was array, but this is being changed to hash
- for `advanced_search` it assumed the response was array, but it is hash
- it puts unnecessary knowledge of rummager into this gem

Alternatives to this change:
- pass it to rummager and let it decide what to do (more network IO)
- raise a custom error class (maybe inheriting from `ArgumentError`)
