### PR TITLE
'named_contact' and 'long_form_anonymous_feedback' endpoints in support app

### DIFF
--- a/lib/gds_api/support.rb
+++ b/lib/gds_api/support.rb
@@ -13,6 +13,10 @@ class GdsApi::Support < GdsApi::Base
     post_json!("#{base_url}/named_contacts", { :named_contact => request_details }, options[:headers] || {})
   end
 
+  def create_anonymous_long_form_contact(request_details, options = {})
+    post_json!("#{base_url}/anonymous_feedback/long_form_contacts", { :long_form_contact => request_details }, options[:headers] || {})
+  end
+
   private
   def base_url
     endpoint

--- a/lib/gds_api/test_helpers/support.rb
+++ b/lib/gds_api/test_helpers/support.rb
@@ -21,6 +21,12 @@ module GdsApi
         post_stub.to_return(:status => 201)
       end
 
+      def stub_support_long_form_anonymous_contact_creation(request_details = nil)
+        post_stub = stub_http_request(:post, "#{SUPPORT_ENDPOINT}/anonymous_feedback/long_form_contacts")
+        post_stub.with(:body => { long_form_contact: request_details }) unless request_details.nil?
+        post_stub.to_return(:status => 201)
+      end
+
       def support_isnt_available
         stub_request(:post, /#{SUPPORT_ENDPOINT}\/.*/).to_return(:status => 503)
       end

--- a/test/support_api_test.rb
+++ b/test/support_api_test.rb
@@ -50,6 +50,18 @@ describe GdsApi::Support do
     assert_requested(stub_post)
   end
 
+  it "can submit long-form anonymous feedback" do
+    request_details = {certain: "details"}
+
+    stub_post = stub_request(:post, "#{@base_api_url}/anonymous_feedback/long_form_contacts").
+      with(:body => {"long_form_contact" => request_details}.to_json).
+      to_return(:status => 201)
+
+    @api.create_anonymous_long_form_contact(request_details)
+
+    assert_requested(stub_post)
+  end
+
   it "can add a custom header onto the problem_report request to the support app" do
     stub_request(:post, "#{@base_api_url}/anonymous_feedback/problem_reports")
 


### PR DESCRIPTION
This PR exposes the endpoints added by https://github.com/alphagov/support/pull/99 and https://github.com/alphagov/support/pull/101
