### PR TITLE
Helper naming [major version bump needed]

### DIFF
--- a/lib/gds_api/test_helpers/imminence.rb
+++ b/lib/gds_api/test_helpers/imminence.rb
@@ -7,7 +7,7 @@ module GdsApi
       # you could redefine/override the constant or stub directly.
       IMMINENCE_API_ENDPOINT = Plek.current.find('imminence')
 
-      def imminence_has_places(latitude, longitude, details)
+      def stub_imminence_places_for_location(latitude, longitude, details)
         response = JSON.dump(details['details'])
 
         stub_request(:get, "#{IMMINENCE_API_ENDPOINT}/places/#{details['slug']}.json").
@@ -15,7 +15,7 @@ module GdsApi
         to_return(:status => 200, :body => response, :headers => {})
       end
 
-      def imminence_has_business_support_schemes(facets_hash, schemes)
+      def stub_imminence_business_support_schemes_for_filter(facets_hash, schemes)
         results = {
           "_response_info" => {"status" => "ok"},
           "description" => "Business Support Schemes!",


### PR DESCRIPTION
- Clearer test helper method naming
- Fixed a comment typo

I lost some time by misunderstanding what this helper did, hopefully the new names will make it clearer for those coming next.

I haven't provided backwards compatibility so this change to this gem's public API will require a major version bump when merged into master - ref http://semver.org/
