### PR TITLE
Organisations API adapter updates

### DIFF
--- a/lib/gds_api/test_helpers/organisations.rb
+++ b/lib/gds_api/test_helpers/organisations.rb
@@ -78,7 +78,7 @@ module GdsApi
           "web_url" => "#{PUBLIC_HOST}/government/organisations/#{slug}",
           "details" => {
             "slug" => slug,
-            "acronym" => acronymize_slug(slug),
+            "abbreviation" => acronymize_slug(slug),
             "closed_at" => nil,
             "govuk_status" => (slug =~ /ministry/ ? "live" : "joining"),
           },


### PR DESCRIPTION
The acronym change here is dependent on one in Whitehall, which explains the reason for it: https://github.com/alphagov/whitehall/pull/957
