### PR TITLE
Fix NameError when requiring any adapter outside Bundler

### DIFF
--- a/lib/gds_api/response.rb
+++ b/lib/gds_api/response.rb
@@ -1,5 +1,6 @@
 require 'json'
 require 'ostruct'
+require 'forwardable'
 require_relative 'core-ext/openstruct'
 
 module GdsApi


### PR DESCRIPTION
Fix NameError occuring when using `extend Forwardable` for the first time outside Bundler.
(Bundler happens to load this by chance, but this prevented you from, for example
`gem install gds-api-adapters`, `irb`, `require 'gds_api/organisations'`
