### PR TITLE
Update need ID key to reflect usage in the API

### DIFF
--- a/lib/gds_api/test_helpers/need_api.rb
+++ b/lib/gds_api/test_helpers/need_api.rb
@@ -41,7 +41,7 @@ module GdsApi
       end
 
       def need_api_has_need(need)
-        need_id = need["need_id"] || need[:need_id]
+        need_id = need["id"] || need[:id]
         raise ArgumentError, "Test need is missing an ID" unless need_id
 
         url = NEED_API_ENDPOINT + "/needs/#{need_id}"

--- a/test/need_api_test.rb
+++ b/test/need_api_test.rb
@@ -132,7 +132,7 @@ describe GdsApi::NeedApi do
   describe "viewing needs" do
     it "should return a need response" do
       need = {
-        need_id: 100500,
+        id: 100500,
         role: "parent",
         goal: "do things",
         benefit: "good things"


### PR DESCRIPTION
The API uses `id` as the key, rather than `need_id`.
