### PR TITLE
Update content_api_has_business_support_scheme helper to reflect content api output

### DIFF
--- a/lib/gds_api/test_helpers/content_api.rb
+++ b/lib/gds_api/test_helpers/content_api.rb
@@ -230,7 +230,7 @@ module GdsApi
         stub_request(:get, %r{\A#{CONTENT_API_ENDPOINT}/business_support_schemes\.json}).to_return do |request|
           if request.uri.query_values and request.uri.query_values["identifiers"]
             ids = request.uri.query_values["identifiers"].split(',')
-            results = @stubbed_content_api_business_support_schemes.select {|bs| ids.include? bs["details"]["business_support_identifier"] }
+            results = @stubbed_content_api_business_support_schemes.select {|bs| ids.include? bs["identifier"] }
           else
             results = []
           end
@@ -239,7 +239,7 @@ module GdsApi
       end
 
       def content_api_has_business_support_scheme(scheme)
-        raise "Need a licence identifier" if scheme["details"]["business_support_identifier"].nil?
+        raise "Need an identifier" if scheme["identifier"].nil?
         @stubbed_content_api_business_support_schemes << scheme
       end
 

--- a/test/content_api_test.rb
+++ b/test/content_api_test.rb
@@ -553,15 +553,11 @@ describe GdsApi::ContentApi do
     describe "test helpers" do
       it "should have representative test helpers" do
         setup_content_api_business_support_schemes_stubs
-
-        s1 = artefact_for_slug('scheme-1')
-        s1["details"].merge!("business_support_identifier" => "s1")
+        s1 = { "title" => "Scheme 1", "identifier" => "s1", "format" => "business_support" }
         content_api_has_business_support_scheme(s1)
-        s2 = artefact_for_slug('scheme-2')
-        s2["details"].merge!("business_support_identifier" => "s2")
+        s2 = { "title" => "Scheme 2", "identifier" => "s2", "format" => "business_support" }
         content_api_has_business_support_scheme(s2)
-        s3 = artefact_for_slug('scheme-3')
-        s3["details"].merge!("business_support_identifier" => "s3")
+        s3 = { "title" => "Scheme 3", "identifier" => "s3", "format" => "business_support" }
         content_api_has_business_support_scheme(s3)
 
         response = @api.business_support_schemes(['s1', 's3']).to_hash


### PR DESCRIPTION
Part of this story https://www.pivotaltracker.com/story/show/57646218
Makes the test helper setup and output for business support content resemble the data structure returned in the content api.
