### PR TITLE
Switch to using explicit commit for the router API.

### DIFF
--- a/lib/gds_api/router.rb
+++ b/lib/gds_api/router.rb
@@ -23,22 +23,22 @@ class GdsApi::Router < GdsApi::Base
     get_json("#{endpoint}/routes?incoming_path=#{CGI.escape(path)}&route_type=#{CGI.escape(type)}")
   end
 
-  def add_route(path, type, backend_id)
+  def add_route(path, type, backend_id, options = {})
     response = put_json!("#{endpoint}/routes", :route => {:incoming_path => path, :route_type => type, :handler => "backend", :backend_id => backend_id})
-    commit_routes
+    commit_routes unless options[:skip_commit]
     response
   end
 
-  def add_redirect_route(path, type, destination, redirect_type = "permanent")
+  def add_redirect_route(path, type, destination, redirect_type = "permanent", options = {})
     response = put_json!("#{endpoint}/routes", :route => {:incoming_path => path, :route_type => type, :handler => "redirect",
               :redirect_to => destination, :redirect_type => redirect_type})
-    commit_routes
+    commit_routes unless options[:skip_commit]
     response
   end
 
-  def delete_route(path, type)
+  def delete_route(path, type, options = {})
     response = delete_json!("#{endpoint}/routes?incoming_path=#{CGI.escape(path)}&route_type=#{CGI.escape(type)}")
-    commit_routes
+    commit_routes unless options[:skip_commit]
     response
   end
 

--- a/test/router_test.rb
+++ b/test/router_test.rb
@@ -202,6 +202,16 @@ describe GdsApi::Router do
         assert_requested(@commit_req)
       end
 
+      it "should not commit the routes when asked not to" do
+        req = WebMock.stub_request(:put, "#{@base_api_url}/routes").
+          to_return(:status => 201, :body => {}.to_json, :headers => {"Content-type" => "application/json"})
+
+        @api.add_route("/foo", "exact", "foo", :skip_commit => true)
+
+        assert_requested(req)
+        assert_not_requested(@commit_req)
+      end
+
       it "should raise an error if creating/updating the route fails" do
         route_data = {"incoming_path" => "/foo", "route_type" => "exact", "handler" => "backend", "backend_id" => "foo"}
         response_data = route_data.merge("errors" => {"backend_id" => "does not exist"})
@@ -255,6 +265,16 @@ describe GdsApi::Router do
         assert_requested(@commit_req)
       end
 
+      it "should not commit the routes when asked not to" do
+        req = WebMock.stub_request(:put, "#{@base_api_url}/routes").
+          to_return(:status => 201, :body =>{}.to_json, :headers => {"Content-type" => "application/json"})
+
+        @api.add_redirect_route("/foo", "exact", "/bar", "temporary", :skip_commit => true)
+
+        assert_requested(req)
+        assert_not_requested(@commit_req)
+      end
+
       it "should raise an error if creating/updating the redirect route fails" do
         route_data = {"incoming_path" => "/foo", "route_type" => "exact", "handler" => "redirect", "redirect_to" => "bar", "redirect_type" => "permanent"}
         response_data = route_data.merge("errors" => {"redirect_to" => "is not a valid URL path"})
@@ -292,6 +312,17 @@ describe GdsApi::Router do
 
         assert_requested(req)
         assert_requested(@commit_req)
+      end
+
+      it "should not commit the routes when asked not to" do
+        req = WebMock.stub_request(:delete, "#{@base_api_url}/routes").
+          with(:query => {"incoming_path" => "/foo", "route_type" => "exact"}).
+          to_return(:status => 200, :body => {}.to_json, :headers => {"Content-type" => "application/json"})
+
+        @api.delete_route("/foo", "exact", :skip_commit => true)
+
+        assert_requested(req)
+        assert_not_requested(@commit_req)
       end
 
       it "should raise HTTPNotFound if nothing found" do


### PR DESCRIPTION
See alphagov/router-api#28 for the corresponding change.

Also added an option to skip the commit of routes so that routes can be bulk added in an efficient manner.
