### PR TITLE
support: /anonymous_feedback/service_feedback

### DIFF
--- a/lib/gds_api/support.rb
+++ b/lib/gds_api/support.rb
@@ -17,8 +17,8 @@ class GdsApi::Support < GdsApi::Base
     post_json!("#{base_url}/anonymous_feedback/long_form_contacts", { :long_form_contact => request_details }, options[:headers] || {})
   end
 
-  def create_transactions(request_details, options = {})
-    post_json!("#{base_url}/anonymous_feedback/transactions", { :transactions => request_details }, options[:headers] || {})
+  def create_service_feedback(request_details, options = {})
+    post_json!("#{base_url}/anonymous_feedback/service_feedback", { :service_feedback => request_details }, options[:headers] || {})
   end
 
   private

--- a/lib/gds_api/test_helpers/support.rb
+++ b/lib/gds_api/test_helpers/support.rb
@@ -27,9 +27,9 @@ module GdsApi
         post_stub.to_return(:status => 201)
       end
 
-      def stub_support_transactions_creation(request_details = nil)
-        post_stub = stub_http_request(:post, "#{SUPPORT_ENDPOINT}/anonymous_feedback/transactions")
-        post_stub.with(:body => {"transactions" => request_details}) unless request_details.nil?
+      def stub_support_service_feedback_creation(feedback_details = nil)
+        post_stub = stub_http_request(:post, "#{SUPPORT_ENDPOINT}/anonymous_feedback/service_feedback")
+        post_stub.with(:body => { service_feedback: feedback_details }) unless feedback_details.nil?
         post_stub.to_return(:status => 201)
       end
 

--- a/test/support_api_test.rb
+++ b/test/support_api_test.rb
@@ -100,24 +100,24 @@ describe GdsApi::Support do
     assert_raises(GdsApi::HTTPErrorResponse) { @api.create_problem_report({}) }
   end
 
-  it "can pass transaction feedback" do
+  it "can pass service feedback" do
     request_details = {"transaction-completed-values"=>"1", "details"=>"abc"}
 
-    stub_post = stub_request(:post, "#{@base_api_url}/anonymous_feedback/transactions").
-      with(:body => {"transactions" => request_details}.to_json).
+    stub_post = stub_request(:post, "#{@base_api_url}/anonymous_feedback/service_feedback").
+      with(:body => {"service_feedback" => request_details}.to_json).
       to_return(:status => 201)
 
-    @api.create_transactions(request_details)
+    @api.create_service_feedback(request_details)
 
     assert_requested(stub_post)
   end
 
-  it "can add a custom header onto the transaction feedback to the support app" do
-    stub_request(:post, "#{@base_api_url}/anonymous_feedback/transactions")
+  it "can add a custom header onto the service feedback to the support app" do
+    stub_request(:post, "#{@base_api_url}/anonymous_feedback/service_feedback")
 
-    @api.create_transactions({}, headers: { "X-Varnish" => "12345"})
+    @api.create_service_feedback({}, headers: { "X-Varnish" => "12345"})
 
-    assert_requested(:post, %r{/transactions}) do |request|
+    assert_requested(:post, %r{/service_feedback}) do |request|
       request.headers["X-Varnish"] == "12345"
     end
   end
@@ -125,8 +125,6 @@ describe GdsApi::Support do
   it "throws an exception when the support app isn't available" do
     support_isnt_available
 
-    assert_raises(GdsApi::HTTPErrorResponse) { @api.create_transactions({}) }
+    assert_raises(GdsApi::HTTPErrorResponse) { @api.create_service_feedback({}) }
   end
-
-
 end


### PR DESCRIPTION
users can fill out a form on 'transaction done' pages with a rating and
comment; this is processed by the 'feedback' app and submitted via a
JSON API to the 'support' app
