### PR TITLE
Add a Need API test helper for paginated results

### DIFF
--- a/lib/gds_api/test_helpers/need_api.rb
+++ b/lib/gds_api/test_helpers/need_api.rb
@@ -48,6 +48,13 @@ module GdsApi
         stub_request(:get, url).to_return(status: 200, body: need.to_json, headers: {})
       end
 
+      def need_api_has_raw_response_for_page(response, page = nil)
+        url = NEED_API_ENDPOINT + "/needs"
+        url << "?page=#{page}" unless page.nil?
+
+        stub_request(:get, url).to_return(status: 200, body: response, headers: {})
+      end
+
       def need_api_has_no_need(need_id)
         url = NEED_API_ENDPOINT + "/needs/#{need_id}"
         not_found_body = {


### PR DESCRIPTION
This allows tests to stub a request for paginated results with a raw (json) response, which can contain the pagination details and links to next and previous pages.
