### PR TITLE
Add adapter method to Content API's /for_need endpoint

### DIFF
--- a/lib/gds_api/content_api.rb
+++ b/lib/gds_api/content_api.rb
@@ -43,6 +43,10 @@ class GdsApi::ContentApi < GdsApi::Base
     get_list!("#{base_url}/with_tag.json?tag=#{CGI.escape(tag)}&sort=#{sort_by}")
   end
 
+  def for_need(need_id)
+    get_list("#{base_url}/for_need/#{CGI.escape(need_id.to_s)}.json")
+  end
+
   def artefact(slug, params={})
     url = "#{base_url}/#{CGI.escape(slug)}.json"
     query = params.map { |k,v| "#{k}=#{v}" }

--- a/lib/gds_api/test_helpers/content_api.rb
+++ b/lib/gds_api/test_helpers/content_api.rb
@@ -296,6 +296,15 @@ module GdsApi
         raise "Need a licence identifier" if details[:licence_identifier].nil?
         @stubbed_content_api_licences << details
       end
+
+      def content_api_has_artefacts_for_need_id(need_id, artefacts)
+        url = "#{CONTENT_API_ENDPOINT}/for_need/#{CGI.escape(need_id.to_s)}.json"
+        body = plural_response_base.merge(
+          'results' => artefacts
+        )
+
+        stub_request(:get, url).to_return(status: 200, body: body.to_json, headers: [])
+      end
     end
   end
 end

--- a/test/content_api_test.rb
+++ b/test/content_api_test.rb
@@ -254,6 +254,22 @@ describe GdsApi::ContentApi do
     end
   end
 
+  describe "artefacts for need" do
+    it "should fetch artefacts with a given need id" do
+      content_api_has_artefacts_for_need_id(100123, [
+        { "format" => "answer", "web_url" => "http://www.gov.uk/burrito" },
+        { "format" => "guide", "web_url" => "http://www.gov.uk/burrito-standard" },
+        { "format" => "transaction", "web_url" => "http://www.gov.uk/local-burrito-place" }
+      ])
+
+      response = @api.for_need(100123)
+
+      assert_equal 3, response.count
+      assert_equal ["http://www.gov.uk/burrito", "http://www.gov.uk/burrito-standard", "http://www.gov.uk/local-burrito-place" ], response.map(&:web_url)
+      assert_equal ["answer", "guide", "transaction" ], response.map(&:format)
+    end
+  end
+
   describe "tags" do
     it "should produce an artefact with the provided tag" do
       tag = "crime-and-justice"


### PR DESCRIPTION
Making a request to `/for_need/<need_id>.json` in the Content API returns all the artefacts which meet the given need ID. 

This pull request adds an adapter method for this endpoint, and a corresponding test helper.
