### PR TITLE
Add a test helper for need search results

### DIFF
--- a/lib/gds_api/test_helpers/need_api.rb
+++ b/lib/gds_api/test_helpers/need_api.rb
@@ -31,6 +31,15 @@ module GdsApi
         stub_request(:get, url).to_return(status: 200, body: body.to_json, headers: {})
       end
 
+      def need_api_has_needs_for_search(search_term, needs)
+        url = NEED_API_ENDPOINT + "/needs?q=#{search_term}"
+
+        body = response_base.merge(
+          "results" => needs
+        )
+        stub_request(:get, url).to_return(status: 200, body: body.to_json, headers: {})
+      end
+
       def need_api_has_needs(needs)
         url = NEED_API_ENDPOINT + "/needs"
 


### PR DESCRIPTION
This won’t reflect reality until alphagov/govuk_need_api#23 is merged, but won’t break anything before then.
