### PR TITLE
Fix stubbing for multiple business support schemes

### DIFF
--- a/lib/gds_api/test_helpers/business_support_api.rb
+++ b/lib/gds_api/test_helpers/business_support_api.rb
@@ -11,13 +11,13 @@ module GdsApi
       BUSINESS_SUPPORT_API_ENDPOINT = Plek.current.find('business-support-api')
 
       def setup_business_support_api_schemes_stubs
-        @stubbed_content_api_business_support_schemes = {}
+        @stubbed_business_support_schemes = {}
         stub_request(:get, %r{\A#{BUSINESS_SUPPORT_API_ENDPOINT}/business-support-schemes\.json}).to_return do |request|
           if request.uri.query_values
-            key = request.uri.query_values.values.sort.hash
-            results = @stubbed_content_api_business_support_schemes[key] || []
+            key = facet_key(request.uri.query_values)
+            results = @stubbed_business_support_schemes[key] || []
           else
-            results = @stubbed_content_api_business_support_schemes.values.flatten
+            results = @stubbed_business_support_schemes['default']
           end
           {:body => plural_response_base.merge("results" => results, "total" => results.size).to_json}
         end
@@ -25,11 +25,11 @@ module GdsApi
       end
 
       def business_support_api_has_scheme(scheme, facets={})
-        key = facets.values.sort.hash
-        unless @stubbed_content_api_business_support_schemes[key]
-          @stubbed_content_api_business_support_schemes[key] = []
+        key = facet_key(facets)
+        unless @stubbed_business_support_schemes.has_key?(key)
+          @stubbed_business_support_schemes[key] = []
         end
-        @stubbed_content_api_business_support_schemes[key] << scheme
+        @stubbed_business_support_schemes[key] << scheme
       end
 
       def business_support_api_has_schemes(schemes, facets={})
@@ -43,6 +43,14 @@ module GdsApi
         stub_request(:get, %r{\A#{BUSINESS_SUPPORT_API_ENDPOINT}/business-support-schemes/#{slug}\.json}).to_return do |request|
           {:body => response_base.merge(:format => 'business_support', :title => title, :details => scheme).to_json}
         end
+      end
+
+      private
+
+      def facet_key(facets)
+        key = 'default'
+        key = facets.values.sort.hash.to_s if facets and !facets.empty?
+        key
       end
     end
   end


### PR DESCRIPTION
There's a bug when stubbing multiple business support schemes with no facet options due to how the test helper stores the stubs, added a default key for schemes to be returned where no facets are specified.
