### PR TITLE
Remove the old `adapter_name` method

### DIFF
--- a/lib/gds_api/base.rb
+++ b/lib/gds_api/base.rb
@@ -44,10 +44,6 @@ class GdsApi::Base
     self.endpoint = options[:endpoint_url]
   end
 
-  def adapter_name
-    self.class.to_s.split("::").last.downcase
-  end
-
   def url_for_slug(slug, options={})
     base = "#{base_url}/#{slug}.json#{query_string(options)}"
   end

--- a/lib/gds_api/licence_application.rb
+++ b/lib/gds_api/licence_application.rb
@@ -10,10 +10,6 @@ class GdsApi::LicenceApplication < GdsApi::Base
     get_json(build_licence_url(id, snac_code))
   end
 
-  def adapter_name
-    "licensify"
-  end
-
   private
 
   def build_licence_url(id, snac_code)


### PR DESCRIPTION
This hasn't been required by the library itself since @philandstuff removed `endpoint_for_platform` in commit d1720363561ebc04d332, and no code outside the library appears to use it.
