### PR TITLE
Define GdsApi module if not already defined

### DIFF
--- a/lib/gds_api/govuk_request_id.rb
+++ b/lib/gds_api/govuk_request_id.rb
@@ -1,15 +1,17 @@
-class GdsApi::GovukRequestId
-  class << self
-    def set?
-      !(value.nil? || value.empty?)
-    end
+module GdsApi
+  class GovukRequestId
+    class << self
+      def set?
+        !(value.nil? || value.empty?)
+      end
 
-    def value
-      Thread.current[:govuk_request_id]
-    end
+      def value
+        Thread.current[:govuk_request_id]
+      end
 
-    def value=(new_id)
-      Thread.current[:govuk_request_id] = new_id
+      def value=(new_id)
+        Thread.current[:govuk_request_id] = new_id
+      end
     end
   end
 end


### PR DESCRIPTION
[this diff](https://github.com/alphagov/gds-api-adapters/commit/54fef3952e09886506e9ddfb07c00e1090cd2082?w=1) is clearer.
