### PR TITLE
Split out the artefact test helpers for the Content API

### DIFF
--- a/lib/gds_api/test_helpers/content_api.rb
+++ b/lib/gds_api/test_helpers/content_api.rb
@@ -98,14 +98,13 @@ module GdsApi
         )
         sort_orders = ["alphabetical", "curated"]
         sort_orders.each do |order|
-          urls = [
-            "#{CONTENT_API_ENDPOINT}/with_tag.json?sort=#{order}&tag=#{CGI.escape(slug)}",
-            "#{CONTENT_API_ENDPOINT}/with_tag.json?sort=#{order}&#{CGI.escape(tag_type)}=#{CGI.escape(slug)}"
-          ]
-
-          urls.each do |url|
-            stub_request(:get, url).to_return(status: 200, body: body.to_json, headers: {})
+          if tag_type == "section"
+            section_url = "#{CONTENT_API_ENDPOINT}/with_tag.json?sort=#{order}&tag=#{CGI.escape(slug)}"
+            stub_request(:get, section_url).to_return(status: 200, body: body.to_json, headers: {})
           end
+
+          url = "#{CONTENT_API_ENDPOINT}/with_tag.json?sort=#{order}&#{CGI.escape(tag_type)}=#{CGI.escape(slug)}"
+          stub_request(:get, url).to_return(status: 200, body: body.to_json, headers: {})
         end
       end
 


### PR DESCRIPTION
The remaining test helpers in the Content API that assume that all tags are sections are the artefact test helpers. This pull request decouples those in the same way as #106 and #108 - creating new test helpers that are not specific to section tags, and changing the existing test helpers to call these (maintaining existing behaviour).

I've also moved all the legacy test helpers together in one place, and added a comment block above to explain what they are there for.

This _should_ be the final part of decoupling the Content API adapter from the 'section' tag type. :palm_tree: 
