### PR TITLE
Permit the industry_sectors attribute when registering with Panopticon

### DIFF
--- a/lib/gds_api/panopticon/registerer.rb
+++ b/lib/gds_api/panopticon/registerer.rb
@@ -27,7 +27,7 @@ module GdsApi
         if rendering_app
           hash[:rendering_app] = rendering_app
         end
-        [:need_id, :section, :indexable_content, :paths, :prefixes].each do |attr_name|
+        [:need_id, :section, :industry_sectors, :indexable_content, :paths, :prefixes].each do |attr_name|
           if record.respond_to? attr_name
             hash[attr_name] = record.send(attr_name)
           end


### PR DESCRIPTION
When registering an artefact with Panopticon, allow the industry_sectors attribute (when present) to be passed through into the request body, so that we can assign industry sector tags to artefacts.
