### PR TITLE
PP data-in for service feedback: fix url construction

### DIFF
--- a/lib/gds_api/performance_platform/data_in.rb
+++ b/lib/gds_api/performance_platform/data_in.rb
@@ -4,7 +4,7 @@ module GdsApi
   module PerformancePlatform
     class DataIn < GdsApi::Base
       def submit_service_feedback_day_aggregate(slug, request_details)
-        post_json!("#{endpoint}/#{slug}_customer_satisfaction", request_details)
+        post_json!("#{endpoint}/#{slug.gsub("-", "_")}_customer_satisfaction", request_details)
       end
     end
   end

--- a/lib/gds_api/test_helpers/performance_platform/data_in.rb
+++ b/lib/gds_api/test_helpers/performance_platform/data_in.rb
@@ -5,17 +5,22 @@ module GdsApi
         PP_DATA_IN_ENDPOINT = "http://www.performance.dev.gov.uk"
 
         def stub_service_feedback_day_aggregate_submission(slug, request_body = nil)
-          post_stub = stub_http_request(:post, "#{PP_DATA_IN_ENDPOINT}/#{slug}_customer_satisfaction")
+          post_stub = stub_http_request(:post, "#{PP_DATA_IN_ENDPOINT}/#{adjusted(slug)}_customer_satisfaction")
           post_stub.with(body: request_body) unless request_body.nil?
           post_stub.to_return(:status => 200)
         end
 
         def stub_service_feedback_bucket_unavailable_for(slug)
-          stub_request(:post, "#{PP_DATA_IN_ENDPOINT}/#{slug}_customer_satisfaction").to_return(:status => 404)
+          stub_request(:post, "#{PP_DATA_IN_ENDPOINT}/#{adjusted(slug)}_customer_satisfaction").to_return(:status => 404)
         end
 
         def stub_pp_isnt_available
           stub_request(:post, /#{PP_DATA_IN_ENDPOINT}\/.*/).to_return(:status => 503)
+        end
+
+        private
+        def adjusted(slug)
+          slug.gsub("-", "_")
         end
       end
     end

--- a/test/pp_data_in_test.rb
+++ b/test/pp_data_in_test.rb
@@ -13,9 +13,9 @@ describe GdsApi::PerformancePlatform::DataIn do
   it "can submit a day aggregate for service feedback for a particular slug" do
     request_details = {"some"=> "data"}
 
-    stub_post = stub_service_feedback_day_aggregate_submission("some_slug", request_details)
+    stub_post = stub_service_feedback_day_aggregate_submission("some-slug", request_details)
 
-    @api.submit_service_feedback_day_aggregate("some_slug", request_details)
+    @api.submit_service_feedback_day_aggregate("some-slug", request_details)
 
     assert_requested(stub_post)
   end


### PR DESCRIPTION
To submit service feedback to the PP, slugs need to be adjusted to replace dashes with underscores (<sigh>)
