### PR TITLE
Add get_feedback_url to Support.

### DIFF
--- a/lib/gds_api/support.rb
+++ b/lib/gds_api/support.rb
@@ -21,6 +21,10 @@ class GdsApi::Support < GdsApi::Base
     post_json!("#{base_url}/anonymous_feedback/service_feedback", { :service_feedback => request_details }, options[:headers] || {})
   end
 
+  def feedback_url(slug)
+    "#{base_url}/anonymous_feedback?path=#{slug}"
+  end
+
   private
   def base_url
     endpoint

--- a/test/support_api_test.rb
+++ b/test/support_api_test.rb
@@ -127,4 +127,10 @@ describe GdsApi::Support do
 
     assert_raises(GdsApi::HTTPErrorResponse) { @api.create_service_feedback({}) }
   end
+
+  it "gets the correct feedback URL" do
+    assert_equal("#{@base_api_url}/anonymous_feedback?path=foo",
+                 @api.feedback_url('foo'))
+
+  end
 end


### PR DESCRIPTION
Part of [story](https://www.pivotaltracker.com/story/show/65741612) to add anonymous feedback information to Maslow.
