### PR TITLE
Add Content API method to fetch tag content in groups

### DIFF
--- a/lib/gds_api/content_api.rb
+++ b/lib/gds_api/content_api.rb
@@ -49,10 +49,13 @@ class GdsApi::ContentApi < GdsApi::Base
     get_json("#{url}/#{CGI.escape(tag)}.json")
   end
 
-  def with_tag(tag, tag_type=nil)
+  def with_tag(tag, tag_type=nil, options={})
     tag_key = key_for_tag_type(tag_type)
 
-    get_list!("#{base_url}/with_tag.json?#{tag_key}=#{CGI.escape(tag)}")
+    url = "#{base_url}/with_tag.json?#{tag_key}=#{CGI.escape(tag)}"
+    url << "&group_by=#{CGI.escape(options[:group_by])}" if options.has_key?(:group_by)
+
+    get_list!(url)
   end
 
   def curated_list(tag, tag_type=nil)

--- a/lib/gds_api/list_response.rb
+++ b/lib/gds_api/list_response.rb
@@ -22,6 +22,13 @@ module GdsApi
     # over the response directly
     def_delegators :results, :each, :to_ary
 
+    def results
+      # support group_by results from the content api by checking if there is a
+      # grouped_results key present first. if it's not, then fallback to the
+      # results key
+      to_ostruct.grouped_results || to_ostruct.results
+    end
+
     def has_next_page?
       ! page_link("next").nil?
     end

--- a/lib/gds_api/test_helpers/content_api.rb
+++ b/lib/gds_api/test_helpers/content_api.rb
@@ -137,6 +137,25 @@ module GdsApi
           .to_return(status: 200, body: body.to_json, headers: {})
       end
 
+      def content_api_has_grouped_artefacts_with_a_tag(tag_type, tag_id, group_by, grouped_artefact_slugs={})
+        body = plural_response_base.merge(
+          "grouped_results" => grouped_artefact_slugs.map {|name,artefact_slugs|
+            {
+              "name" => name,
+              "formats" => [name.downcase],
+              "items" => artefact_slugs.map {|artefact_slug|
+                artefact_for_slug(artefact_slug)
+              }
+            }
+          }
+        )
+
+        endpoint = "#{CONTENT_API_ENDPOINT}/with_tag.json"
+        stub_request(:get, endpoint)
+          .with(:query => { tag_type => tag_id, "group_by" => group_by })
+          .to_return(status: 200, body: body.to_json, headers: {})
+      end
+
       def content_api_has_an_artefact(slug, body = artefact_for_slug(slug))
         ArtefactStub.new(slug).with_response_body(body).stub
       end

--- a/test/content_api_test.rb
+++ b/test/content_api_test.rb
@@ -370,6 +370,30 @@ describe GdsApi::ContentApi do
 
       assert_equal "Is this love", response.first.title
     end
+
+    it "returns artefacts in groups for a tag and tag type" do
+      content_api_has_grouped_artefacts_with_a_tag(
+        "genre",
+        "reggae",
+        "format",
+        {
+          "Tracks" => ["is-this-love", "three-little-birds"],
+          "Albums" => ["kaya", "exodus"],
+        }
+      )
+      response = @api.with_tag("reggae", "genre", group_by: "format")
+
+      # expect two groups to be returned
+      assert_equal 2, response.results.size
+
+      assert_equal 2, response.results[0].items.size
+      assert_equal "Is this love", response.results[0].items[0].title
+      assert_equal "Three little birds", response.results[0].items[1].title
+
+      assert_equal 2, response.results[1].items.size
+      assert_equal "Kaya", response.results[1].items[0].title
+      assert_equal "Exodus", response.results[1].items[1].title
+    end
   end
 
   describe "licence" do


### PR DESCRIPTION
This adds a new method to the adapter for the Content API which makes requests to `/with_tag.json` including the `group_by` parameter. This also includes a new test helper to stub these requests correctly, given a mapping of groups and artefacts.
