### PR TITLE
Support: don't pass headers through

### DIFF
--- a/lib/gds_api/support.rb
+++ b/lib/gds_api/support.rb
@@ -1,24 +1,24 @@
 require_relative 'base'
 
 class GdsApi::Support < GdsApi::Base
-  def create_foi_request(request_details, options = {})
-    post_json!("#{base_url}/foi_requests", { :foi_request => request_details }, options[:headers] || {})
+  def create_foi_request(request_details)
+    post_json!("#{base_url}/foi_requests", { :foi_request => request_details })
   end
 
-  def create_problem_report(request_details, options = {})
-    post_json!("#{base_url}/anonymous_feedback/problem_reports", { :problem_report => request_details }, options[:headers] || {})
+  def create_problem_report(request_details)
+    post_json!("#{base_url}/anonymous_feedback/problem_reports", { :problem_report => request_details })
   end
 
-  def create_named_contact(request_details, options = {})
-    post_json!("#{base_url}/named_contacts", { :named_contact => request_details }, options[:headers] || {})
+  def create_named_contact(request_details)
+    post_json!("#{base_url}/named_contacts", { :named_contact => request_details })
   end
 
-  def create_anonymous_long_form_contact(request_details, options = {})
-    post_json!("#{base_url}/anonymous_feedback/long_form_contacts", { :long_form_contact => request_details }, options[:headers] || {})
+  def create_anonymous_long_form_contact(request_details)
+    post_json!("#{base_url}/anonymous_feedback/long_form_contacts", { :long_form_contact => request_details })
   end
 
-  def create_service_feedback(request_details, options = {})
-    post_json!("#{base_url}/anonymous_feedback/service_feedback", { :service_feedback => request_details }, options[:headers] || {})
+  def create_service_feedback(request_details)
+    post_json!("#{base_url}/anonymous_feedback/service_feedback", { :service_feedback => request_details })
   end
 
   def feedback_url(slug)

--- a/test/support_api_test.rb
+++ b/test/support_api_test.rb
@@ -22,16 +22,6 @@ describe GdsApi::Support do
     assert_requested(stub_post)
   end
 
-  it "can add a custom header onto the FOI request to the support app" do
-    stub_request(:post, "#{@base_api_url}/foi_requests")
-
-    @api.create_foi_request({}, headers: { "X-Varnish" => "12345"})
-
-    assert_requested(:post, %r{/foi_requests}) do |request|
-      request.headers["X-Varnish"] == "12345"
-    end
-  end
-
   it "throws an exception when the support app isn't available" do
     support_isnt_available
 
@@ -62,16 +52,6 @@ describe GdsApi::Support do
     assert_requested(stub_post)
   end
 
-  it "can add a custom header onto the problem_report request to the support app" do
-    stub_request(:post, "#{@base_api_url}/anonymous_feedback/problem_reports")
-
-    @api.create_problem_report({}, headers: { "X-Varnish" => "12345"})
-
-    assert_requested(:post, %r{/problem_reports}) do |request|
-      request.headers["X-Varnish"] == "12345"
-    end
-  end
-
   it "can create a named contact" do
     request_details = {certain: "details"}
 
@@ -82,16 +62,6 @@ describe GdsApi::Support do
     @api.create_named_contact(request_details)
 
     assert_requested(stub_post)
-  end
-
-  it "can add a custom header onto the named_contact request to the support app" do
-    stub_request(:post, "#{@base_api_url}/named_contacts")
-
-    @api.create_named_contact({}, headers: { "X-Varnish" => "12345"})
-
-    assert_requested(:post, %r{/named_contacts}) do |request|
-      request.headers["X-Varnish"] == "12345"
-    end
   end
 
   it "throws an exception when the support app isn't available" do
@@ -110,16 +80,6 @@ describe GdsApi::Support do
     @api.create_service_feedback(request_details)
 
     assert_requested(stub_post)
-  end
-
-  it "can add a custom header onto the service feedback to the support app" do
-    stub_request(:post, "#{@base_api_url}/anonymous_feedback/service_feedback")
-
-    @api.create_service_feedback({}, headers: { "X-Varnish" => "12345"})
-
-    assert_requested(:post, %r{/service_feedback}) do |request|
-      request.headers["X-Varnish"] == "12345"
-    end
   end
 
   it "throws an exception when the support app isn't available" do


### PR DESCRIPTION
This was added to allow the passing of the X-Varnish header on requests
to the Support app, but the govuk_request_id work has made that redundant.
