### PR TITLE
Change the second variable in the first example to `publisher_api`

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ app.
 Example usage:
 
     publisher_api = GdsApi::Publisher.new("environment")
-    ostruct_publication = publisher.publication_for_slug('my-published-item')
+    ostruct_publication = publisher_api.publication_for_slug('my-published-item')
 
     panopticon_api = GdsApi::Panopticon.new("environment")
     ostruct_metadata = panopticon_api.artefact_for_slug('my-published-item')


### PR DESCRIPTION
- This fixes an `undefined local variable` error if someone were to
  run the example from the README verbatim.
