### PR TITLE
Updating the test_helpers/organisations.rb to reflect API updates

### DIFF
--- a/lib/gds_api/test_helpers/organisations.rb
+++ b/lib/gds_api/test_helpers/organisations.rb
@@ -80,6 +80,9 @@ module GdsApi
           "details" => {
             "slug" => slug,
             "abbreviation" => acronymize_slug(slug),
+            "logo_formatted_name" => titleize_slug(slug, :title_case => true),
+            "organisation_brand_colour_class_name" => slug,
+            "organisation_logo_type_class_name" => (slug =~ /ministry/ ? "single-identity" : "eo"),
             "closed_at" => nil,
             "govuk_status" => (slug =~ /ministry/ ? "live" : "joining"),
           },


### PR DESCRIPTION
Adding the logo and brand class details to the helper

Making the assumption that a non ministerial department will have
the executive office brand, could make this no-identity instead
