### PR TITLE
Fix constant warnings in Ruby 2.0.0 and above

### DIFF
--- a/lib/gds_api/response.rb
+++ b/lib/gds_api/response.rb
@@ -24,8 +24,6 @@ module GdsApi
     extend Forwardable
     include Enumerable
 
-    WEB_URL_KEYS = ["web_url"]
-
     def_delegators :to_hash, :[], :"<=>", :each
 
     def initialize(http_response, options = {})
@@ -70,7 +68,7 @@ module GdsApi
       when Hash
         Hash[value.map { |k, v|
           # NOTE: Don't bother transforming if the value is nil
-          if WEB_URL_KEYS.include?(k) && v
+          if 'web_url' == k && v
             # Use relative URLs to route when the web_url value is on the
             # same domain as the site root. Note that we can't just use the
             # `route_to` method, as this would give us technically correct


### PR DESCRIPTION
Since some of our projects upgraded to Ruby 2.x we've started seeing warnings like:

```
/home/deploy/project/shared/bundle/ruby/2.0.0/gems/gds-api-adapters-7.20.0/lib/gds_api/response.rb:27: warning: already initialized constant GdsApi::Response::WEB_URL_KEYS
/data/vhost/project/shared/bundle/ruby/2.0.0/gems/gds-api-adapters-7.20.0/lib/gds_api/response.rb:27:
warning: previous definition of WEB_URL_KEYS was here
```

in our logs. This is apparently due to Ruby 2.x's behaviour when [using `require` within a symlinked path](https://bugs.ruby-lang.org/issues/4403).

One workaround would be to [turn off `$VERBOSE` logging](http://stackoverflow.com/questions/9236264/how-to-disable-warning-for-redefining-a-constant-when-loading-a-file), but that means we'd miss out on legitimate warnings.

Given that this constant was only used in this single place (I couldn't find it in any other projects), and contained a single value, I've simply refactored it out.
