### PR TITLE
Don't raise errors on 410 JSON gets.

### DIFF
--- a/lib/gds_api/exceptions.rb
+++ b/lib/gds_api/exceptions.rb
@@ -23,13 +23,19 @@ module GdsApi
   class HTTPNotFound < HTTPErrorResponse
   end
 
+  class HTTPGone < HTTPErrorResponse; end
+
   class NoBearerToken < BaseError; end
 
   module ExceptionHandling
-    def ignoring(exception, &block)
+    def ignoring(exception_or_exceptions, &block)
       yield
-    rescue exception
+    rescue *exception_or_exceptions
       # Discard the exception
+    end
+
+    def ignoring_missing(&block)
+      ignoring([HTTPNotFound, HTTPGone], &block)
     end
   end
 end

--- a/lib/gds_api/json_client.rb
+++ b/lib/gds_api/json_client.rb
@@ -57,7 +57,7 @@ module GdsApi
     end
 
     def get_raw(url)
-      ignoring GdsApi::HTTPNotFound do
+      ignoring_missing do
         get_raw!(url)
       end
     end
@@ -70,7 +70,7 @@ module GdsApi
     [:get, :post, :put, :delete].each do |http_method|
       method_name = "#{http_method}_json"
       define_method method_name do |url, *args, &block|
-        ignoring GdsApi::HTTPNotFound do
+        ignoring_missing do
           send (method_name + "!"), url, *args, &block
         end
       end
@@ -106,6 +106,9 @@ module GdsApi
     rescue RestClient::ResourceNotFound => e
       raise GdsApi::HTTPNotFound.new(e.http_code)
 
+    rescue RestClient::Gone => e
+      raise GdsApi::HTTPGone.new(e.http_code)
+
     rescue RestClient::Exception => e
       raise GdsApi::HTTPErrorResponse.new(e.response.code.to_i), e.response.body
     end
@@ -123,6 +126,9 @@ module GdsApi
 
       rescue RestClient::ResourceNotFound => e
         raise GdsApi::HTTPNotFound.new(e.http_code)
+
+      rescue RestClient::Gone => e
+        raise GdsApi::HTTPGone.new(e.http_code)
 
       rescue RestClient::Exception => e
         # Attempt to parse the body as JSON if possible

--- a/test/json_client_test.rb
+++ b/test/json_client_test.rb
@@ -310,10 +310,18 @@ class JsonClientTest < MiniTest::Spec
     end
   end
 
-  def test_should_raise_http_not_found_if_404_returned_from_endpoint
+  def test_get_bang_should_raise_http_not_found_if_404_returned_from_endpoint
     url = "http://some.endpoint/some.json"
     stub_request(:get, url).to_return(:body => "{}", :status => 404)
     assert_raises GdsApi::HTTPNotFound do
+      @client.get_json!(url)
+    end
+  end
+
+  def test_get_bang_should_raise_http_gone_if_410_returned_from_endpoint
+    url = "http://some.endpoint/some.json"
+    stub_request(:get, url).to_return(:body => "{}", :status => 410)
+    assert_raises GdsApi::HTTPGone do
       @client.get_json!(url)
     end
   end
@@ -324,7 +332,13 @@ class JsonClientTest < MiniTest::Spec
     assert_nil @client.get_json(url)
   end
 
-  def test_get_should_raise_error_if_non_404_error_code_returned_from_endpoint
+  def test_get_should_be_nil_if_410_returned_from_endpoint
+    url = "http://some.endpoint/some.json"
+    stub_request(:get, url).to_return(:body => "{}", :status => 410)
+    assert_nil @client.get_json(url)
+  end
+
+  def test_get_should_raise_error_if_non_404_non_410_error_code_returned_from_endpoint
     url = "http://some.endpoint/some.json"
     stub_request(:get, url).to_return(:body => "{}", :status => 500)
     assert_raises GdsApi::HTTPErrorResponse do


### PR DESCRIPTION
When Whitehall documents are marked as "archived" in Panopticon when they're actually live, the API adapters raise an exception because the special case handling for 404s does not catch 410s.

After conversation with @alext, this code treats 410s in the same manner as 404s.
