### PR TITLE
Rails-encode array values in params.

### DIFF
--- a/lib/gds_api/base.rb
+++ b/lib/gds_api/base.rb
@@ -60,8 +60,17 @@ private
   def query_string(params)
     return "" if params.empty?
 
-    "?" << params.sort.map { |kv|
-      kv.map { |a| CGI.escape(a.to_s) }.join("=")
-    }.join("&")
+    param_pairs = params.sort.map { |key, value|
+      case value
+      when Array
+        value.map { |v|
+          "#{CGI.escape(key+'[]')}=#{CGI.escape(v.to_s)}"
+        }
+      else
+        "#{CGI.escape(key.to_s)}=#{CGI.escape(value.to_s)}"
+      end
+    }.flatten
+
+    "?#{param_pairs.join("&")}"
   end
 end

--- a/test/gds_api_base_test.rb
+++ b/test/gds_api_base_test.rb
@@ -25,6 +25,18 @@ class GdsApiBaseTest < MiniTest::Unit::TestCase
     assert_equal "a=+&b=%2F", u.query
   end
 
+  def test_should_construct_escaped_query_string_for_rails
+    api = ConcreteApi.new('http://foo')
+
+    url = api.url_for_slug("slug", "b" => ['123'])
+    u = URI.parse(url)
+    assert_equal "b%5B%5D=123", u.query
+
+    url = api.url_for_slug("slug", "b" => ['123', '456'])
+    u = URI.parse(url)
+    assert_equal "b%5B%5D=123&b%5B%5D=456", u.query
+  end
+
   def test_should_not_add_a_question_mark_if_there_are_no_parameters
     api = ConcreteApi.new('http://foo')
     url = api.url_for_slug("slug")


### PR DESCRIPTION
This allows array values in params, e.g. from filters.
