### PR TITLE
Add an artefact! method that can raise exceptions

### DIFF
--- a/lib/gds_api/content_api.rb
+++ b/lib/gds_api/content_api.rb
@@ -75,16 +75,11 @@ class GdsApi::ContentApi < GdsApi::Base
   end
 
   def artefact(slug, params={})
-    url = "#{base_url}/#{CGI.escape(slug)}.json"
-    query = params.map { |k,v| "#{k}=#{v}" }
-    if query.any?
-      url += "?#{query.join("&")}"
-    end
+    get_json(artefact_url(slug, params))
+  end
 
-    if params[:edition] && ! options.include?(:bearer_token)
-      raise GdsApi::NoBearerToken
-    end
-    get_json(url)
+  def artefact!(slug, params={})
+    get_json!(artefact_url(slug, params))
   end
 
   def artefacts
@@ -151,5 +146,18 @@ class GdsApi::ContentApi < GdsApi::Base
 
     def key_for_tag_type(tag_type)
       tag_type.nil? ? "tag" : CGI.escape(tag_type)
+    end
+
+    def artefact_url(slug, params)
+      url = "#{base_url}/#{CGI.escape(slug)}.json"
+      query = params.map { |k,v| "#{k}=#{v}" }
+      if query.any?
+        url += "?#{query.join("&")}"
+      end
+
+      if params[:edition] && ! options.include?(:bearer_token)
+        raise GdsApi::NoBearerToken
+      end
+      url
     end
 end

--- a/test/content_api_test.rb
+++ b/test/content_api_test.rb
@@ -190,6 +190,13 @@ describe GdsApi::ContentApi do
       end
     end
 
+    it "should raise a 410 if an artefact has been archived" do
+      content_api_has_an_archived_artefact("atlantis")
+      assert_raises GdsApi::HTTPGone do
+        @api.artefact!("atlantis")
+      end
+    end
+
     it "should be able to fetch artefacts with a '/' in the slug" do
       content_api_has_an_artefact("foreign-travel-advice/aruba")
       response = @api.artefact("foreign-travel-advice/aruba")


### PR DESCRIPTION
After 68c5e678 was merged, .artefact will just return nil when it has been archived. Certain Apps (like Frontend) expect a 410 to be returned, so this commit adds artefact! which will raise an exception.
