### PR TITLE
Remove `include`s for exception-handling module.

### DIFF
--- a/lib/gds_api/asset_manager.rb
+++ b/lib/gds_api/asset_manager.rb
@@ -2,7 +2,6 @@ require_relative 'base'
 require_relative 'exceptions'
 
 class GdsApi::AssetManager < GdsApi::Base
-  include GdsApi::ExceptionHandling
 
   # Creates an asset given attributes
   #

--- a/lib/gds_api/business_support_api.rb
+++ b/lib/gds_api/business_support_api.rb
@@ -3,7 +3,6 @@ require_relative 'exceptions'
 require_relative 'list_response'
 
 class GdsApi::BusinessSupportApi < GdsApi::Base
-  include GdsApi::ExceptionHandling
 
   def schemes(options = {})
     get_list!(url_for_slug('business-support-schemes', options))

--- a/lib/gds_api/content_api.rb
+++ b/lib/gds_api/content_api.rb
@@ -3,7 +3,6 @@ require_relative 'exceptions'
 require_relative 'list_response'
 
 class GdsApi::ContentApi < GdsApi::Base
-  include GdsApi::ExceptionHandling
 
   def initialize(endpoint_url, options = {})
     # If the `web_urls_relative_to` option is given, the adapter will convert

--- a/lib/gds_api/content_store.rb
+++ b/lib/gds_api/content_store.rb
@@ -2,7 +2,6 @@ require_relative 'base'
 require_relative 'exceptions'
 
 class GdsApi::ContentStore < GdsApi::ContentApi
-  include GdsApi::ExceptionHandling
 
   def content_item(base_path)
     get_json(content_item_url(base_path))

--- a/lib/gds_api/gov_uk_delivery.rb
+++ b/lib/gds_api/gov_uk_delivery.rb
@@ -3,7 +3,6 @@ require_relative 'exceptions'
 require 'json'
 
 class GdsApi::GovUkDelivery < GdsApi::Base
-  include GdsApi::ExceptionHandling
 
   def initialize(endpoint_url, options={})
     super(endpoint_url, options.merge({timeout: 10}))

--- a/lib/gds_api/mapit.rb
+++ b/lib/gds_api/mapit.rb
@@ -2,7 +2,6 @@ require_relative 'base'
 require_relative 'exceptions'
 
 class GdsApi::Mapit < GdsApi::Base
-  include GdsApi::ExceptionHandling
 
   def location_for_postcode(postcode)
     response = get_json("#{base_url}/postcode/#{CGI.escape postcode}.json")


### PR DESCRIPTION
This module is only necessary when a class uses the `ignoring` or `ignoring_missing` methods directly.
