### PR TITLE
Refactor business support api helper

### DIFF
--- a/test/business_support_api_test.rb
+++ b/test/business_support_api_test.rb
@@ -15,12 +15,13 @@ describe GdsApi::BusinessSupportApi do
     it "should return all schemes when called with no facets" do
       business_support_api_has_schemes([:scheme1, :scheme2, :scheme3])
       response = @api.schemes
-      assert_equal ["scheme1", "scheme2", "scheme3"], response['results']
+      assert_equal [{"title" => "scheme1"}, {"title" => "scheme2"}, {"title" => "scheme3"}], response['results']
     end
     it "should return schemes for applicable facets"  do
       business_support_api_has_scheme(:scottish_manufacturing, {locations: 'scotland', sectors: 'manufacturing', support_types: 'grant,loan'})
       response = @api.schemes({locations: 'scotland', sectors: 'manufacturing', support_types: 'grant,loan'})
-      assert_equal ["scottish_manufacturing"], response["results"]
+      assert_equal 1, response["results"].size
+      assert_equal "scottish_manufacturing", response["results"].first["title"]
     end
     it "should return an empty result when facets are not applicable" do
       business_support_api_has_scheme(:super_secret, {locations: 'the moon', sectors: 'espionage'})

--- a/test/content_api_test.rb
+++ b/test/content_api_test.rb
@@ -620,7 +620,8 @@ describe GdsApi::ContentApi do
         response = @api.business_support_schemes(:locations => "england", :sectors => "farming").to_hash
 
         assert_equal 2, response["total"]
-        assert_equal [s1, s3], response["results"]
+        assert_equal s1["title"], response["results"].first["title"]
+        assert_equal s3["title"], response["results"].last["title"]
       end
     end
   end


### PR DESCRIPTION
Make the business support api helper behave like the API.
The previous method of stubbing and retrieving a stub depended on
an exact match of facet keys and values. The API searches facet values
based on an $in clause. See https://github.com/alphagov/govuk_content_models/blob/master/app/models/business_support_edition.rb#L67
Also sanitises stub facets for backwards compatibility.
