### PR TITLE
Fix inheritance of content-store client.

### DIFF
--- a/lib/gds_api/content_store.rb
+++ b/lib/gds_api/content_store.rb
@@ -1,7 +1,7 @@
 require_relative 'base'
 require_relative 'exceptions'
 
-class GdsApi::ContentStore < GdsApi::ContentApi
+class GdsApi::ContentStore < GdsApi::Base
 
   def content_item(base_path)
     get_json(content_item_url(base_path))


### PR DESCRIPTION
It wasn't requiring `gds_api/content_api`, which was causing issues in
some circumstances. It doesn't actually need to inherit from
`GdsApi::ContentApi`, so this changes it to just inherit from `GdsApi::Base`
