### PR TITLE
Add areas_for_type method to Imminence API adapter

### DIFF
--- a/lib/gds_api/imminence.rb
+++ b/lib/gds_api/imminence.rb
@@ -42,6 +42,11 @@ class GdsApi::Imminence < GdsApi::Base
     get_json(url)
   end
 
+  def areas_for_type(type)
+    url = "#{@endpoint}/areas/#{type}.json"
+    get_json(url)
+  end
+
 private
   def self.extract_location_hash(location)
     # Deal with all known location formats:

--- a/test/imminence_api_test.rb
+++ b/test/imminence_api_test.rb
@@ -187,4 +187,31 @@ EOS
     assert_equal "LBO", areas_from_response.first["type"]
     assert_equal 12, areas_from_response.first["id"]
   end
+
+  def test_areas_by_type
+    areas = [
+      { "id" => 122, "type" => "EUR", "name" => "Yorkshire and the Humber", "country_name" => "England" },
+      { "id" => 665, "type" => "EUR", "name" => "London", "country_name" => "England" }
+    ]
+    results = {
+      "_response_info" => {"status" => "ok"},
+      "total" => areas.size, "startIndex" => 1, "pageSize" => areas.size,
+      "currentPage" => 1, "pages" => 1, "results" => areas
+    }
+
+    stub_request(:get, "#{ROOT}/areas/EUR.json").
+      with(headers: GdsApi::JsonClient::DEFAULT_REQUEST_HEADERS).
+      to_return(status: 200, body: results.to_json )
+
+    response = api_client.areas_for_type("EUR")
+
+    assert_equal "ok", response["_response_info"]["status"]
+    areas_from_response = response["results"]
+    assert_equal 2, areas_from_response.size
+    assert_equal "EUR", areas_from_response.first["type"]
+    assert_equal "EUR", areas_from_response.last["type"]
+    assert_equal 122, areas_from_response.first["id"]
+    assert_equal 665, areas_from_response.last["id"]
+  end
+
 end


### PR DESCRIPTION
Exposes the `areas_for_type` method on the Imminence API.
This enables lookups of Mapit area codes from publishing tools
without going directly to Mapit.
