### PR TITLE
Error if a `PUT` to content-store fails

### DIFF
--- a/lib/gds_api/content_store.rb
+++ b/lib/gds_api/content_store.rb
@@ -12,10 +12,6 @@ class GdsApi::ContentStore < GdsApi::Base
   end
 
   def put_content_item(base_path, payload)
-    put_json(content_item_url(base_path), payload)
-  end
-
-  def put_content_item!(base_path, payload)
     put_json!(content_item_url(base_path), payload)
   end
 


### PR DESCRIPTION
Based on https://github.com/alphagov/gds-api-adapters/pull/161#discussion-diff-13867565 we only want to error if a `PUT` to content-store fails
