### PR TITLE
Allow 'sort' option when requesting tags from Content API 

### DIFF
--- a/lib/gds_api/content_api.rb
+++ b/lib/gds_api/content_api.rb
@@ -39,8 +39,14 @@ class GdsApi::ContentApi < GdsApi::Base
     get_list!("#{base_url}/tags.json?type=#{CGI.escape(tag_type)}&root_sections=true")
   end
 
-  def child_tags(tag_type, parent_tag)
-    get_list!("#{base_url}/tags.json?type=#{CGI.escape(tag_type)}&parent_id=#{CGI.escape(parent_tag)}")
+  def child_tags(tag_type, parent_tag, options={})
+    params = [
+      "type=#{CGI.escape(tag_type)}",
+      "parent_id=#{CGI.escape(parent_tag)}",
+    ]
+    params << "sort=#{options[:sort]}" if options.has_key?(:sort)
+
+    get_list!("#{base_url}/tags.json?#{params.join('&')}")
   end
 
   def tag(tag, tag_type=nil)

--- a/lib/gds_api/test_helpers/content_api.rb
+++ b/lib/gds_api/test_helpers/content_api.rb
@@ -101,6 +101,19 @@ module GdsApi
         stub_request(:get, url).to_return(status: 200, body: body.to_json, headers: {})
       end
 
+      def content_api_has_sorted_child_tags(tag_type, parent_slug_or_hash, sort_order, child_tag_ids)
+        parent_tag = tag_hash(parent_slug_or_hash, tag_type)
+        child_tags = child_tag_ids.map { |id|
+          tag_hash(id, tag_type).merge(parent: parent_tag)
+        }
+        body = plural_response_base.merge(
+          "results" => child_tags.map { |s| tag_result(s, tag_type) }
+        )
+
+        url = "#{CONTENT_API_ENDPOINT}/tags.json?parent_id=#{CGI.escape(parent_tag[:slug])}&sort=#{sort_order}&type=#{tag_type}"
+        stub_request(:get, url).to_return(status: 200, body: body.to_json, headers: {})
+      end
+
       def content_api_has_artefacts_with_a_tag(tag_type, slug, artefact_slugs=[])
         body = plural_response_base.merge(
           "results" => artefact_slugs.map do |artefact_slug|

--- a/test/content_api_test.rb
+++ b/test/content_api_test.rb
@@ -325,6 +325,14 @@ describe GdsApi::ContentApi do
       assert_equal "#{@base_api_url}/tags/genres/indie%2Findie-rock.json", first_section.id
     end
 
+    it "returns a sorted list of child tags of a given type" do
+      content_api_has_sorted_child_tags("genre", "indie", "alphabetical", ["indie/indie-rock"])
+      response = @api.child_tags("genre", "indie", sort: "alphabetical")
+
+      first_section = response.first
+      assert_equal "#{@base_api_url}/tags/genres/indie%2Findie-rock.json", first_section.id
+    end
+
     it "returns artefacts given a section" do
       content_api_has_artefacts_in_a_section("crime-and-justice", ["complain-about-a-claims-company"])
       response = @api.with_tag("crime-and-justice")


### PR DESCRIPTION
This changes the Content API adapter to support the `sort` parameter when making requests for tags and child tags.
