### PR TITLE
Expose http response headers to clients

### DIFF
--- a/lib/gds_api/response.rb
+++ b/lib/gds_api/response.rb
@@ -40,6 +40,10 @@ module GdsApi
       @http_response.code
     end
 
+    def headers
+      @http_response.headers
+    end
+
     def to_hash
       @parsed ||= transform_parsed(JSON.parse(@http_response.body))
     end

--- a/test/response_test.rb
+++ b/test/response_test.rb
@@ -5,7 +5,7 @@ describe GdsApi::Response do
 
   describe "accessing HTTP response details" do
     before :each do
-      @mock_http_response = stub(:body => "A Response body", :code => 200)
+      @mock_http_response = stub(:body => "A Response body", :code => 200, :headers => {'cache-control' => 'public'})
       @response = GdsApi::Response.new(@mock_http_response)
     end
 
@@ -15,6 +15,10 @@ describe GdsApi::Response do
 
     it "should return the status code" do
       assert_equal 200, @response.code
+    end
+
+    it "should pass-on the response headers" do
+      assert_equal({'cache-control' => 'public'}, @response.headers)
     end
   end
 


### PR DESCRIPTION
www.agileplannerapp.com/boards/173808/cards/4800

Response object should share the HTTP response
headers it received, so that clients can determine
how to cache content received, f.ex. base expiry
time on the Cache-Control and Expires headers.
