### PR TITLE
Allow multiple metadata attributes

### DIFF
--- a/lib/gds_api/finder_schema.rb
+++ b/lib/gds_api/finder_schema.rb
@@ -9,7 +9,7 @@ class GdsApi::FinderSchema
     document_attributes.each_with_object({}) do |(k, v), values|
       values.store(
         user_friendly_facet_label(k.to_s),
-        find_schema_allowed_value_entry(k.to_s, v)
+        user_friendly_facet_value(k.to_s, v),
       )
     end
   end
@@ -27,7 +27,13 @@ class GdsApi::FinderSchema
     find_facet(facet_key.to_s).fetch("name")
   end
 
-  def find_schema_allowed_value_entry(facet_key, value)
+  def user_friendly_facet_value(facet_key, value)
+    Array(value).map { |value|
+      find_schema_allowed_value_label(facet_key, value)
+    }
+  end
+
+  def find_schema_allowed_value_label(facet_key, value)
     value_label_pair = allowed_values_for(facet_key)
       .find { |schema_value|
         schema_value.fetch("value") == value

--- a/test/finder_schema_test.rb
+++ b/test/finder_schema_test.rb
@@ -49,8 +49,8 @@ describe GdsApi::FinderSchema do
 
     let(:formatted_attrs) {
       {
-        "Case type" => "CA98 and civil cartels",
-        "Market sector" => "Aerospace",
+        "Case type" => ["CA98 and civil cartels"],
+        "Market sector" => ["Aerospace"],
       }
     }
 
@@ -71,6 +71,24 @@ describe GdsApi::FinderSchema do
         }.must_raise(
           GdsApi::FinderSchema::NotFoundError,
           "market sector 'does-not-exist' not found in cma-cases schema")
+      end
+    end
+
+    describe "when a value is an array of values" do
+      let(:document_attrs) {
+        {
+          market_sector: ["aerospace"],
+        }
+      }
+
+      let(:formatted_attrs) {
+        {
+          "Market sector" => ["Aerospace"],
+        }
+      }
+
+      it "formats the given keys and values" do
+        schema.user_friendly_values(document_attrs).must_equal(formatted_attrs)
       end
     end
   end


### PR DESCRIPTION
This change will allow the api adapters to translate multiple metadata attributes as will as individual ones. We realise converting all values to an array is not the best solution although we are happy with this change until we are sure of how we expect this to work.
