### PR TITLE
Version 12.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 12.3.0
+
+* Add "draft" option to the content_api.tags method.
+
 # 12.2.0
 
 Add .expires_in, .expires_at to GDSApi::Response

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '12.2.0'
+  VERSION = '12.3.0'
 end


### PR DESCRIPTION
Adds draft functionality to the `content_api.tags` method without breaking backwards compatibility.
