### PR TITLE
Version 12.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 12.4.0
+
+* Add `rummager_has_no_services_and_info_data_for_organisation`
+
 # 12.3.0
 
 * Add "draft" option to the content_api.tags method.

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '12.3.0'
+  VERSION = '12.4.0'
 end


### PR DESCRIPTION
Adds `rummager_has_no_services_and_info_data_for_organisation` to
Rummager test helpers
