### PR TITLE
Add AAIB and IDF schemas to TestHelpers::FinderApi

### DIFF
--- a/lib/gds_api/test_helpers/finder_api.rb
+++ b/lib/gds_api/test_helpers/finder_api.rb
@@ -5,16 +5,29 @@ module GdsApi
     module FinderApi
       FINDER_API_ENDPOINT = Plek.current.find('finder-api')
 
-      def finder_api_has_schema(finder_slug, schema_fixture = FinderApi.schema_fixture)
+      def finder_api_has_schema(finder_slug)
         stub_request(:get, "#{FINDER_API_ENDPOINT}/finders/#{finder_slug}/schema.json")
           .with(:headers => {'Content-Type'=>'application/json'})
-          .to_return(:status => 200, :body => schema_fixture)
+          .to_return(:status => 200, :body => schema_fixture(finder_slug))
       end
 
-      def self.schema_fixture
+    private
+      def schema_fixture(finder_slug)
+        case finder_slug
+        when "aaib-reports"
+          schema_content("aaib-report-schema.json")
+        when "international-development-funds"
+          schema_content('international-development-funding-schema.json')
+        when "cma-cases"
+          schema_content('cma-case-schema.json')
+        else raise "Unknown schema type: #{schema_type}"
+        end
+      end
+
+      def schema_content(filename)
         File.read(
           File.expand_path(
-            "../../../../test/fixtures/finder_api/cma-case-schema.json",
+            "../../../../test/fixtures/finder_api/#{filename}",
             __FILE__
           )
         )

--- a/test/fixtures/finder_api/aaib-reports-schema.json
+++ b/test/fixtures/finder_api/aaib-reports-schema.json
@@ -1,0 +1,35 @@
+{
+  "slug": "aaib-reports",
+  "name": "Air Accidents Investigation Branch reports",
+  "document_noun": "report",
+  "facets": [
+    {
+      "key": "aircraft_category",
+      "name": "Aircraft category",
+      "type": "multi-select",
+      "include_blank": false,
+      "allowed_values": [
+        {"label": "Commercial - fixed wing", "value": "commercial-fixed-wing"},
+        {"label": "Commercial - rotorcraft", "value": "commercial-rotorcraft"},
+        {"label": "General aviation - fixed wing", "value": "general-aviation-fixed-wing"},
+        {"label": "General aviation - rotorcraft", "value": "general-aviation-rotorcraft"},
+        {"label": "Sport aviation and balloons", "value": "sport-aviation-and-balloons"}
+      ]
+    },
+    {
+      "key": "report_type",
+      "name": "Report type",
+      "type": "multi-select",
+      "include_blank": false,
+      "allowed_values": [
+        {"label": "Annual safety report", "value": "annual-safety-report"},
+        {"label": "Bulletin - Correspondence investigation", "value": "correspondence-investigation"},
+        {"label": "Bulletin - Field investigation", "value": "field-investigation"},
+        {"label": "Bulletin - Pre-1997 uncategorised monthly report", "value": "pre-1997-monthly-report"},
+        {"label": "Foreign report", "value": "foreign-report"},
+        {"label": "Formal report", "value": "formal-report"},
+        {"label": "Special bulletin", "value": "special-bulletin"}
+      ]
+    }
+  ]
+}

--- a/test/fixtures/finder_api/cma-case-schema.json
+++ b/test/fixtures/finder_api/cma-case-schema.json
@@ -6,14 +6,15 @@
     {
         "key": "case_type",
         "name": "Case type",
-        "type": "single-select",
+        "type": "multi-select",
         "include_blank": "All case types",
+        "preposition": "of type",
         "allowed_values": [
           {"label": "CA98 and civil cartels", "value": "ca98-and-civil-cartels"},
-          {"label": "Consumer enforcement", "value": "consumer-enforcement"},
           {"label": "Criminal cartels", "value": "criminal-cartels"},
           {"label": "Markets", "value": "markets"},
           {"label": "Mergers", "value": "mergers"},
+          {"label": "Consumer enforcement", "value": "consumer-enforcement"},
           {"label": "Regulatory references and appeals", "value": "regulatory-references-and-appeals"},
           {"label": "Reviews of orders and undertakings", "value": "review-of-orders-and-undertakings"}
         ]
@@ -24,17 +25,20 @@
       "name": "Case state",
       "type": "single-select",
       "include_blank": false,
+      "preposition": "which are",
       "allowed_values": [
         {"label": "Open", "value": "open"},
-        {"label": "Closed", "value": "closed"}
+        {"label": "Closed", "value": "closed"},
+        {"label": "All", "value": "", "non_described": true }
       ]
     },
 
     {
       "key": "market_sector",
       "name": "Market sector",
-      "type": "single-select",
+      "type": "multi-select",
       "include_blank": false,
+      "preposition": "about",
       "allowed_values": [
         {"label": "Aerospace", "value": "aerospace"},
         {"label": "Agriculture, environment and natural resources", "value": "agriculture-environment-and-natural-resources"},
@@ -71,31 +75,32 @@
     {
       "key": "outcome_type",
       "name": "Outcome",
-      "type": "single-select",
+      "type": "multi-select",
       "include_blank": false,
+      "preposition": "with outcome",
       "allowed_values": [
-        {"label": "CA98 - administrative priorities", "value": "ca98-administrative-priorities"},
-        {"label": "CA98 - commitment", "value": "ca98-commitment"},
+        {"label": "CA98 - no grounds for action", "value": "ca98-no-grounds-for-action-non-infringement"},
         {"label": "CA98 - infringement Chapter I", "value": "ca98-infringement-chapter-i"},
         {"label": "CA98 - infringement Chapter II", "value": "ca98-infringement-chapter-ii"},
-        {"label": "CA98 - no grounds for action/non-infringement", "value": "ca98-no-grounds-for-action-non-infringement"},
-        {"label": "Consumer enforcement - court order", "value": "consumer-enforcement-court-order"},
-        {"label": "Consumer enforcement - no action", "value": "consumer-enforcement-no-action"},
-        {"label": "Consumer enforcement - undertakings", "value": "consumer-enforcement-undertakings"},
+        {"label": "CA98 - administrative priorities", "value": "ca98-administrative-priorities"},
+        {"label": "CA98 - commitments", "value": "ca98-commitment"},
         {"label": "Criminal cartels - verdict", "value": "criminal-cartels-verdict"},
         {"label": "Markets - phase 1 no enforcement action", "value": "markets-phase-1-no-enforcement-action"},
-        {"label": "Markets - phase 1 referral", "value": "markets-phase-1-referral"},
         {"label": "Markets - phase 1 undertakings in lieu of reference", "value": "markets-phase-1-undertakings-in-lieu-of-reference"},
-        {"label": "Markets - phase 2 adverse effect on competition leading to remedies", "value": "markets-phase-2-adverse-effect-on-competition-leading-to-remedies"},
+        {"label": "Markets - phase 1 referral", "value": "markets-phase-1-referral"},
         {"label": "Markets - phase 2 clearance - no adverse effect on competition", "value": "markets-phase-2-clearance-no-adverse-effect-on-competition"},
+        {"label": "Markets - phase 2 adverse effect on competition leading to remedies", "value": "markets-phase-2-adverse-effect-on-competition-leading-to-remedies"},
         {"label": "Markets - phase 2 decision to dispense with procedural obligations", "value": "markets-phase-2-decision-to-dispense-with-procedural-obligations"},
-        {"label": "Mergers - phase 1 clearance with undertakings in lieu", "value": "mergers-phase-1-clearance-with-undertakings-in-lieu"},
         {"label": "Mergers - phase 1 clearance", "value": "mergers-phase-1-clearance"},
-        {"label": "Mergers - phase 1 found not to qualify", "value": "mergers-phase-1-found-not-to-qualify"},
+        {"label": "Mergers - phase 1 clearance with undertakings in lieu", "value": "mergers-phase-1-clearance-with-undertakings-in-lieu"},
         {"label": "Mergers - phase 1 referral", "value": "mergers-phase-1-referral"},
-        {"label": "Mergers - phase 2 clearance with remedies", "value": "mergers-phase-2-clearance-with-remedies"},
+        {"label": "Mergers - phase 1 found not to qualify", "value": "mergers-phase-1-found-not-to-qualify"},
         {"label": "Mergers - phase 2 clearance", "value": "mergers-phase-2-clearance"},
+        {"label": "Mergers - phase 2 clearance with remedies", "value": "mergers-phase-2-clearance-with-remedies"},
         {"label": "Mergers - phase 2 prohibition", "value": "mergers-phase-2-prohibition"},
+        {"label": "Consumer enforcement - no action", "value": "consumer-enforcement-no-action"},
+        {"label": "Consumer enforcement - court order", "value": "consumer-enforcement-court-order"},
+        {"label": "Consumer enforcement - undertakings", "value": "consumer-enforcement-undertakings"},
         {"label": "Regulatory references and appeals - final determination", "value": "regulatory-references-and-appeals-final-determination"}
       ]
     }

--- a/test/fixtures/finder_api/international-development-funding-schema.json
+++ b/test/fixtures/finder_api/international-development-funding-schema.json
@@ -1,0 +1,247 @@
+{
+  "slug": "international-development-funding",
+  "name": "International development funding",
+  "document_noun": "fund",
+  "facets": [
+    {
+      "key": "application_state",
+      "name": "Applications",
+      "type": "single-select",
+      "include_blank": false,
+      "preposition": "which are",
+      "allowed_values": [
+        {"label": "Open", "value": "open"},
+        {"label": "Closed", "value": "closed"},
+        {"label": "All", "value": "", "non_described": true }
+      ]
+    },
+    {
+      "key": "location",
+      "name": "Countries and regions",
+      "type": "multi-select",
+      "include_blank": false,
+      "preposition": "for",
+      "allowed_values": [
+        {
+          "label": "Afghanistan",
+          "value": "afghanistan"
+        },
+        {
+          "label": "Bangladesh",
+          "value": "bangladesh"
+        },
+        {
+          "label": "Burma",
+          "value": "burma"
+        },
+        {
+          "label": "Democratic Republic of Congo",
+          "value": "democratic-republic-of-congo"
+        },
+        {
+          "label": "Ethiopia",
+          "value": "ethiopia"
+        },
+        {
+          "label": "Ghana",
+          "value": "ghana"
+        },
+        {
+          "label": "India",
+          "value": "india"
+        },
+        {
+          "label": "Kenya",
+          "value": "kenya"
+        },
+        {
+          "label": "Kyrgyzstan",
+          "value": "kyrgyzstan"
+        },
+        {
+          "label": "Liberia",
+          "value": "liberia"
+        },
+        {
+          "label": "Malawi",
+          "value": "malawi"
+        },
+        {
+          "label": "Mozambique",
+          "value": "mozambique"
+        },
+        {
+          "label": "Nepal",
+          "value": "nepal"
+        },
+        {
+          "label": "Nigeria",
+          "value": "nigeria"
+        },
+        {
+          "label": "The Occupied Palestinian Territories",
+          "value": "the-occupied-palestinian-territories"
+        },
+        {
+          "label": "Pakistan",
+          "value": "pakistan"
+        },
+        {
+          "label": "Rwanda",
+          "value": "rwanda"
+        },
+        {
+          "label": "Sierra Leone",
+          "value": "sierra-leone"
+        },
+        {
+          "label": "Somalia",
+          "value": "somalia"
+        },
+        {
+          "label": "South Africa",
+          "value": "south-africa"
+        },
+        {
+          "label": "Sudan",
+          "value": "sudan"
+        },
+        {
+          "label": "South Sudan",
+          "value": "south-sudan"
+        },
+        {
+          "label": "Tajikistan",
+          "value": "tajikistan"
+        },
+        {
+          "label": "Tanzania",
+          "value": "tanzania"
+        },
+        {
+          "label": "Uganda",
+          "value": "uganda"
+        },
+        {
+          "label": "Yemen",
+          "value": "yemen"
+        },
+        {
+          "label": "Zambia",
+          "value": "zambia"
+        },
+        {
+          "label": "Zimbabwe",
+          "value": "zimbabwe"
+        }
+      ]
+    },
+    {
+      "key": "idf_sector",
+      "name": "Sector",
+      "type": "multi-select",
+      "include_blank": false,
+      "preposition": "for",
+      "allowed_values": [
+        {
+          "label": "Education",
+          "value": "education"
+        },
+        {
+          "label": "Health",
+          "value": "health"
+        },
+        {
+          "label": "Humanitarian emergencies/disasters",
+          "value": "humanitarian-emergencies-disasters"
+        },
+        {
+          "label": "Disabilities",
+          "value": "disabilities"
+        },
+        {
+          "label": "Climate change",
+          "value": "climate-change"
+        },
+        {
+          "label": "Girls and women",
+          "value": "girls-and-women"
+        },
+        {
+          "label": "Water and sanitation",
+          "value": "water-and-sanitation"
+        },
+        {
+          "label": "Empowerment and accountability",
+          "value": "empowerment-and-accountability"
+        },
+        {
+          "label": "Private sector/commercial",
+          "value": "private-sector-commercial"
+        },
+        {
+          "label": "Livelihoods",
+          "value": "livelihoods"
+        },
+        {
+          "label": "Peace and access to justice",
+          "value": "peace-and-access-to-justice"
+        }
+      ]
+    },
+    {
+      "key": "eligible_entities",
+      "name": "Eligible organisations",
+      "type": "multi-select",
+      "include_blank": false,
+      "preposition": "open to",
+      "allowed_values": [
+        {
+          "label": "Non-governmental organisations (NGOs)",
+          "value": "non-governmental-organisations"
+        },
+        {
+          "label": "UK-based non-profit organisations",
+          "value": "uk-based-non-profit-organisations"
+        },
+        {
+          "label": "UK-based small and diaspora organisations",
+          "value": "uk-based-small-and-diaspora-organisations"
+        },
+        {
+          "label": "Companies",
+          "value": "companies"
+        },
+        {
+          "label": "Local government",
+          "value": "local-government"
+        },
+        {
+          "label": "Educational institutions",
+          "value": "educational-institutions"
+        },
+        {
+          "label": "Individuals",
+          "value": "individuals"
+        },
+        {
+          "label": "Humanitarian relief organisations",
+          "value": "humanitarian-relief-organisations"
+        }
+      ]
+    },
+    {
+      "key": "value_of_fund",
+      "name": "Value of fund",
+      "type": "multi-select",
+      "include_blank": false,
+      "preposition": "with value",
+      "allowed_values": [
+        {"label": "Up to £100,000", "value": "up-to-100000"},
+        {"label": "£100,001 to £500,000", "value": "100001-500000"},
+        {"label": "£500,001 to £1,000,000", "value": "500001-to-1000000"},
+        {"label": "More than £1,000,000", "value": "more-than-1000000"}
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Previously, the finder_api_has_schema method would either default to using its internal CMA case schema (which was outdated) or allow a schema to be passed in.

Now we're dealing with more than just CMA cases, we needed to use schemas of different types, and rather than force consumers to store the schemas themselves and pass them up, I decided to store them in the (already extant) fixtures dir within gds-api-adapters.

Potentially I could modify this approach to use dependency injection to inject a factory which is then used to generate the desired schema (which defaults to 'via slug inspection and local fixtures', but could then be overridden by consumers) -- but I think that would unnecessarily overcomplicate things. Input welcome.

This was driven by https://github.com/alphagov/specialist-frontend/pull/34
