### PR TITLE
Stub HTTP calls to draft versions of tags request.

### DIFF
--- a/lib/gds_api/test_helpers/content_api.rb
+++ b/lib/gds_api/test_helpers/content_api.rb
@@ -90,8 +90,12 @@ module GdsApi
           "results" => slugs_or_tags.map { |tag| tag_result(tag, tag_type) }
         )
 
-        url = "#{CONTENT_API_ENDPOINT}/tags.json?type=#{tag_type}"
-        stub_request(:get, url).to_return(status: 200, body: body.to_json, headers: {})
+        [
+          "#{CONTENT_API_ENDPOINT}/tags.json?type=#{tag_type}",
+          "#{CONTENT_API_ENDPOINT}/tags.json?draft=true&type=#{tag_type}"
+        ].each do |url|
+          stub_request(:get, url).to_return(status: 200, body: body.to_json, headers: {})
+        end
       end
 
       def content_api_has_sorted_tags(tag_type, sort_order, slugs_or_tags)


### PR DESCRIPTION
Calls that don't care about drafts still need to mock the "everything including drafts" call.
