### PR TITLE
Link back to pre filtered Finder

### DIFF
--- a/lib/gds_api/finder_schema.rb
+++ b/lib/gds_api/finder_schema.rb
@@ -8,8 +8,11 @@ class GdsApi::FinderSchema
   def user_friendly_values(document_attributes)
     document_attributes.each_with_object({}) do |(k, v), values|
       values.store(
-        user_friendly_facet_label(k.to_s),
-        user_friendly_facet_value(k.to_s, v),
+        k.to_s,
+        {
+          label: user_friendly_facet_label(k.to_s),
+          values: user_friendly_facet_value(k.to_s, v),
+        }
       )
     end
   end
@@ -29,7 +32,10 @@ class GdsApi::FinderSchema
 
   def user_friendly_facet_value(facet_key, value)
     Array(value).map { |value|
-      find_schema_allowed_value_label(facet_key, value)
+      {
+        label: find_schema_allowed_value_label(facet_key, value),
+        slug: value,
+      }
     }
   end
 

--- a/test/finder_schema_test.rb
+++ b/test/finder_schema_test.rb
@@ -49,8 +49,24 @@ describe GdsApi::FinderSchema do
 
     let(:formatted_attrs) {
       {
-        "Case type" => ["CA98 and civil cartels"],
-        "Market sector" => ["Aerospace"],
+        "case_type" => {
+          :label => "Case type",
+          :values => [
+            {
+              :label => "CA98 and civil cartels",
+              :slug => "ca98-and-civil-cartels"
+            }
+          ]
+        }, 
+        "market_sector" => {
+          :label => "Market sector",
+          :values => [
+            {
+              :label => "Aerospace",
+              :slug=>"aerospace"
+            }
+          ]
+        }
       }
     }
 
@@ -83,7 +99,15 @@ describe GdsApi::FinderSchema do
 
       let(:formatted_attrs) {
         {
-          "Market sector" => ["Aerospace"],
+          "market_sector" => {
+            :label => "Market sector",
+            :values => [
+              {
+                :label => "Aerospace",
+                :slug=>"aerospace"
+              }
+            ]
+          }
         }
       }
 


### PR DESCRIPTION
In order to link back to a pre-filtered Finder we need to provide the key of the metadata values as a slug from the Finder Schema object. [Ticket](https://trello.com/c/DnCneU7s/190-metadata-on-specialist-documents-links-back-to-pre-filtered-finder-2).
