### PR TITLE
Require exception classes

### DIFF
--- a/lib/gds-api-adapters.rb
+++ b/lib/gds-api-adapters.rb
@@ -1,1 +1,2 @@
 require 'gds_api/railtie' if defined?(Rails)
+require 'gds_api/exceptions'


### PR DESCRIPTION
We were referencing the `GdsApi::BaseError` class in our code, without explicitly requiring 'gds_api/exceptions'. In development mode this wasn't a problem, because an adapter class, which does require it, was always loaded first. When we deployed to preview however, the load order was different because Rails and  the application couldn't boot because the constant was undefined.
