### PR TITLE
Move content item writes into publishing api client.

### DIFF
--- a/lib/gds_api/content_store.rb
+++ b/lib/gds_api/content_store.rb
@@ -11,10 +11,6 @@ class GdsApi::ContentStore < GdsApi::Base
     get_json!(content_item_url(base_path))
   end
 
-  def put_content_item(base_path, payload)
-    put_json!(content_item_url(base_path), payload)
-  end
-
   private
 
   def content_item_url(base_path)

--- a/lib/gds_api/publishing_api.rb
+++ b/lib/gds_api/publishing_api.rb
@@ -1,0 +1,15 @@
+require_relative 'base'
+require_relative 'exceptions'
+
+class GdsApi::PublishingApi < GdsApi::Base
+
+  def put_content_item(base_path, payload)
+    put_json!(content_item_url(base_path), payload)
+  end
+
+  private
+
+  def content_item_url(base_path)
+    "#{endpoint}/content#{base_path}"
+  end
+end

--- a/lib/gds_api/test_helpers/content_item_helpers.rb
+++ b/lib/gds_api/test_helpers/content_item_helpers.rb
@@ -1,0 +1,29 @@
+
+module GdsApi
+  module TestHelpers
+    module ContentItemHelpers
+
+      def content_item_for_base_path(base_path)
+        {
+          "title" => titleize_base_path(base_path),
+          "description" => "Description for #{base_path}",
+          "format" => "guide",
+          "need_ids" => ["100001"],
+          "public_updated_at" => "2014-05-06T12:01:00+00:00",
+          "base_path" => base_path,
+          "details" => {
+            "body" => "Some content for #{base_path}",
+          }
+        }
+      end
+
+      def titleize_base_path(base_path, options = {})
+        if options[:title_case]
+          base_path.gsub("-", " ").gsub(/\b./) {|m| m.upcase }
+        else
+          base_path.gsub(%r{[-/]}, " ").strip.capitalize
+        end
+      end
+    end
+  end
+end

--- a/lib/gds_api/test_helpers/content_store.rb
+++ b/lib/gds_api/test_helpers/content_store.rb
@@ -1,15 +1,15 @@
 require 'gds_api/test_helpers/json_client_helper'
-require 'gds_api/test_helpers/common_responses'
+require 'gds_api/test_helpers/content_item_helpers'
 require 'json'
 
 module GdsApi
   module TestHelpers
     module ContentStore
-      include CommonResponses
+      include ContentItemHelpers
 
       CONTENT_STORE_ENDPOINT = Plek.current.find('content-store')
 
-      def content_store_has_item(base_path, body = item_for_base_path(base_path), expires_in = 900)
+      def content_store_has_item(base_path, body = content_item_for_base_path(base_path), expires_in = 900)
         url = CONTENT_STORE_ENDPOINT + "/content" + base_path
         body = body.to_json unless body.is_a?(String)
         stub_request(:get, url).to_return(status: 200, body: body, headers: {cache_control: "public, max-age=#{expires_in}", date: Time.now.httpdate})
@@ -18,44 +18,6 @@ module GdsApi
       def content_store_does_not_have_item(base_path)
         url = CONTENT_STORE_ENDPOINT + "/content" + base_path
         stub_request(:get, url).to_return(status: 404, headers: {})
-      end
-
-      def stub_content_store_put_item(base_path, body = item_for_base_path(base_path))
-        url = CONTENT_STORE_ENDPOINT + "/content" + base_path
-        body = body.to_json unless body.is_a?(String)
-        stub_request(:put, url).with(body: body).to_return(status: 201, body: body, headers: {})
-      end
-
-      def stub_default_content_store_put()
-        stub_request(:put, %r{\A#{CONTENT_STORE_ENDPOINT}/content})
-      end
-
-      def item_for_base_path(base_path)
-        {
-          "title" => titleize_slug(base_path),
-          "description" => "Description for #{base_path}",
-          "format" => "guide",
-          "need_ids" => ["100001"],
-          "public_updated_at" => "2014-05-06T12:01:00+00:00",
-          "base_path" => base_path,
-          "details" => {
-            "body" => "Some content for #{base_path}",
-          }
-        }
-      end
-
-      def assert_content_store_put_item(base_path, attributes = {})
-        url = CONTENT_STORE_ENDPOINT + "/content" + base_path
-        if attributes.empty?
-          assert_requested(:put, url)
-        else
-          assert_requested(:put, url) do |req|
-            data = JSON.parse(req.body)
-            attributes.to_a.all? do |key, value|
-              data[key.to_s] == value
-            end
-          end
-        end
       end
 
       def content_store_isnt_available

--- a/lib/gds_api/test_helpers/publishing_api.rb
+++ b/lib/gds_api/test_helpers/publishing_api.rb
@@ -1,0 +1,41 @@
+require 'gds_api/test_helpers/json_client_helper'
+require 'gds_api/test_helpers/content_item_helpers'
+require 'json'
+
+module GdsApi
+  module TestHelpers
+    module PublishingApi
+      include ContentItemHelpers
+
+      PUBLISHING_API_ENDPOINT = Plek.current.find('publishing-api')
+
+      def stub_publishing_api_put_item(base_path, body = content_item_for_base_path(base_path))
+        url = PUBLISHING_API_ENDPOINT + "/content" + base_path
+        body = body.to_json unless body.is_a?(String)
+        stub_request(:put, url).with(body: body).to_return(status: 201, body: body, headers: {})
+      end
+
+      def stub_default_publishing_api_put()
+        stub_request(:put, %r{\A#{PUBLISHING_API_ENDPOINT}/content})
+      end
+
+      def assert_publishing_api_put_item(base_path, attributes = {})
+        url = PUBLISHING_API_ENDPOINT + "/content" + base_path
+        if attributes.empty?
+          assert_requested(:put, url)
+        else
+          assert_requested(:put, url) do |req|
+            data = JSON.parse(req.body)
+            attributes.to_a.all? do |key, value|
+              data[key.to_s] == value
+            end
+          end
+        end
+      end
+
+      def publishing_api_isnt_available
+        stub_request(:any, /#{PUBLISHING_API_ENDPOINT}\/.*/).to_return(:status => 503)
+      end
+    end
+  end
+end

--- a/test/content_store_test.rb
+++ b/test/content_store_test.rb
@@ -17,12 +17,5 @@ describe GdsApi::ContentStore do
       response = @api.content_item(base_path)
       assert_equal base_path, response["base_path"]
     end
-
-    it "should create the item" do
-      base_path = "/test-to-content-store"
-      stub_content_store_put_item(base_path)
-      response = @api.put_content_item(base_path, item_for_base_path(base_path))
-      assert_equal base_path, response["base_path"]
-    end
   end
 end

--- a/test/publishing_api_test.rb
+++ b/test/publishing_api_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+require 'gds_api/publishing_api'
+require 'gds_api/test_helpers/publishing_api'
+
+describe GdsApi::PublishingApi do
+  include GdsApi::TestHelpers::PublishingApi
+
+  before do
+    @base_api_url = Plek.current.find("publishing-api")
+    @api = GdsApi::PublishingApi.new(@base_api_url)
+  end
+
+  describe "item" do
+    it "should create the item" do
+      base_path = "/test-to-publishing-api"
+      stub_publishing_api_put_item(base_path)
+      response = @api.put_content_item(base_path, content_item_for_base_path(base_path))
+      assert_equal base_path, response["base_path"]
+    end
+  end
+end


### PR DESCRIPTION
In order to be able to separate the publishing part of the API from
content-store in future, a 'publishing-api' vhost alias has been created
for it. This splits the api client for it into two to separate these
concerns.

This will be a major version bump due to the breaking nature of this change.
