### PR TITLE
Version bump to 14.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 14.0.0
+
+* Split content item write API from the content store client into a new publishing API client.
+
 # 13.0.0
 
 * `FinderSchema#user_friendly_values` now returns a hash with the slug version

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '13.0.0'
+  VERSION = '14.0.0'
 end


### PR DESCRIPTION
Splits content item write api out of the content-store client.
