### PR TITLE
Version bump to 14.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 14.1.0
+
+* Add rummager test helper for stubbing sub-sector organisations (`rummager_has_specialist_sector_organisations`).
+
 # 14.0.0
 
 * Split content item write API from the content store client into a new publishing API client.

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '14.0.0'
+  VERSION = '14.1.0'
 end


### PR DESCRIPTION
Add rummager test helper for checking specialist sectors associated with
an organisation's content.

https://www.pivotaltracker.com/story/show/75807888

This releases: https://github.com/alphagov/gds-api-adapters/pull/193
