### PR TITLE
Version 14.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 14.3.0
+
+* Add "does not have" stubs for content api tags.
+* Expand collections api test helpers.
+
 # 14.2.0
 
 * Adds basic collections API client and test helpers

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '14.2.0'
+  VERSION = '14.3.0'
 end


### PR DESCRIPTION
Releases https://github.com/alphagov/gds-api-adapters/pull/199 and https://github.com/alphagov/gds-api-adapters/pull/200
