### PR TITLE
support-api: add endpoint for creating long-form contacts

### DIFF
--- a/lib/gds_api/support_api.rb
+++ b/lib/gds_api/support_api.rb
@@ -4,4 +4,8 @@ class GdsApi::SupportApi < GdsApi::Base
   def create_service_feedback(request_details)
     post_json!("#{endpoint}/anonymous-feedback/service-feedback", { :service_feedback => request_details })
   end
+
+  def create_anonymous_long_form_contact(request_details)
+    post_json!("#{endpoint}/anonymous-feedback/long-form-contacts", { :long_form_contact => request_details })
+  end
 end

--- a/lib/gds_api/test_helpers/support_api.rb
+++ b/lib/gds_api/test_helpers/support_api.rb
@@ -9,6 +9,12 @@ module GdsApi
         post_stub.to_return(:status => 201)
       end
 
+      def stub_support_long_form_anonymous_contact_creation(request_details = nil)
+        post_stub = stub_http_request(:post, "#{SUPPORT_API_ENDPOINT}/anonymous-feedback/long-form-contacts")
+        post_stub.with(:body => { long_form_contact: request_details }) unless request_details.nil?
+        post_stub.to_return(:status => 202)
+      end
+
       def support_api_isnt_available
         stub_request(:post, /#{SUPPORT_API_ENDPOINT}\/.*/).to_return(:status => 503)
       end

--- a/test/support_api_test.rb
+++ b/test/support_api_test.rb
@@ -22,6 +22,18 @@ describe GdsApi::SupportApi do
     assert_requested(stub_post)
   end
 
+  it "can submit long-form anonymous feedback" do
+    request_details = {certain: "details"}
+
+    stub_post = stub_request(:post, "#{@base_api_url}/anonymous-feedback/long-form-contacts").
+      with(:body => {"long_form_contact" => request_details}.to_json).
+      to_return(:status => 201)
+
+    @api.create_anonymous_long_form_contact(request_details)
+
+    assert_requested(stub_post)
+  end
+
   it "throws an exception when the support app isn't available" do
     support_api_isnt_available
 


### PR DESCRIPTION
Add support for `support-api` endpoint introduced in https://github.com/alphagov/support-api/pull/16
