### PR TITLE
Bump version to 14.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 14.7.0
+
+* Add long-form contact endpoint to `support-api`
+
 # 14.6.0
 
 * Add extra layer of inheritance for HTTP Exception classes to provide HTTPServerError and HTTPClientError in order to allow applications to to catch ranges of Server/Client type errors.

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '14.6.0'
+  VERSION = '14.7.0'
 end


### PR DESCRIPTION
This includes the long-form contact endpoint for `support-api`.
