### PR TITLE
Support API: adapter for creating problem reports

### DIFF
--- a/lib/gds_api/support_api.rb
+++ b/lib/gds_api/support_api.rb
@@ -1,6 +1,10 @@
 require_relative 'base'
 
 class GdsApi::SupportApi < GdsApi::Base
+  def create_problem_report(request_details)
+    post_json!("#{endpoint}/anonymous-feedback/problem-reports", { :problem_report => request_details })
+  end
+
   def create_service_feedback(request_details)
     post_json!("#{endpoint}/anonymous-feedback/service-feedback", { :service_feedback => request_details })
   end

--- a/lib/gds_api/test_helpers/support_api.rb
+++ b/lib/gds_api/test_helpers/support_api.rb
@@ -5,6 +5,12 @@ module GdsApi
     module SupportApi
       SUPPORT_API_ENDPOINT = Plek.current.find('support-api')
 
+      def stub_support_api_problem_report_creation(request_details = nil)
+        post_stub = stub_http_request(:post, "#{SUPPORT_API_ENDPOINT}/anonymous-feedback/problem-reports")
+        post_stub.with(:body => { problem_report: request_details }) unless request_details.nil?
+        post_stub.to_return(:status => 202)
+      end
+
       def stub_support_api_service_feedback_creation(feedback_details = nil)
         post_stub = stub_http_request(:post, "#{SUPPORT_API_ENDPOINT}/anonymous-feedback/service-feedback")
         post_stub.with(:body => { service_feedback: feedback_details }) unless feedback_details.nil?

--- a/test/support_api_test.rb
+++ b/test/support_api_test.rb
@@ -10,6 +10,18 @@ describe GdsApi::SupportApi do
     @api = GdsApi::SupportApi.new(@base_api_url)
   end
 
+  it "can report a problem" do
+    request_details = {certain: "details"}
+
+    stub_post = stub_request(:post, "#{@base_api_url}/anonymous-feedback/problem-reports").
+      with(:body => {"problem_report" => request_details}.to_json).
+      to_return(:status => 201)
+
+    @api.create_problem_report(request_details)
+
+    assert_requested(stub_post)
+  end
+
   it "can pass service feedback" do
     request_details = {"transaction-completed-values"=>"1", "details"=>"abc"}
 


### PR DESCRIPTION
This adds the adapter for the [Support API problem report endpoint](https://github.com/alphagov/support-api/pull/19).
