### PR TITLE
Bump version to 14.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 14.9.0
+
+* Add problem reports endpoint to `support-api`
+
 # 14.8.0
 
 * Add `support-api` endpoint for getting problem report daily totals

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '14.8.0'
+  VERSION = '14.9.0'
 end


### PR DESCRIPTION
This picks up https://github.com/alphagov/gds-api-adapters/pull/219.
