### PR TITLE
Update Webmock version and Rummager tests

### DIFF
--- a/gds-api-adapters.gemspec
+++ b/gds-api-adapters.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rdoc', '3.12'
   s.add_development_dependency 'rake', '~> 0.9.2.2'
-  s.add_development_dependency 'webmock', ['>= 1.8', '<= 1.18.0'] # rummager tests fail with 1.19.0
+  s.add_development_dependency 'webmock', '~> 1.19'
   s.add_development_dependency 'mocha', '~> 0.12.4'
   s.add_development_dependency "minitest", "~> 3.4.0"
   s.add_development_dependency 'rack'

--- a/test/rummager_test.rb
+++ b/test/rummager_test.rb
@@ -135,10 +135,9 @@ describe GdsApi::Rummager do
   it "#advanced_search should issue a request for all the params supplied" do
     GdsApi::Rummager.new("http://example.com").advanced_search({keywords: "query & stuff", topics: ["1","2"], order: {public_timestamp: "desc"}})
 
-    #the actual request is "?keywords=query+%26+stuff&topic[0]=1&topic[1]=2&order[public_timestamp]=desc", but Webmock appears to be re-escaping.
     assert_requested :get, /keywords=query%20%26%20stuff/
-    assert_requested :get, /topics%5B0%5D=1&topics%5B1%5D=2/
-    assert_requested :get, /order%5Bpublic_timestamp%5D=desc/
+    assert_requested :get, /topics\[\]=1&topics\[\]=2/
+    assert_requested :get, /order\[public_timestamp\]=desc/
   end
 
   # tests for unified search
@@ -205,7 +204,7 @@ describe GdsApi::Rummager do
     )
 
     assert_requested :get, /q=query%20%26%20stuff/
-    assert_requested :get, /filter_topics%5B0%5D=1&filter_topics%5B1%5D=2/
+    assert_requested :get, /filter_topics\[\]=1&filter_topics\[\]=2/
     assert_requested :get, /order=-public_timestamp/
   end
 


### PR DESCRIPTION
- Updates Rummager tests that relied on Webmock's previous handling of
  square bracket params in urls to improve readability
- Updates and pins Webmock to >= 1.19 (because the updated Rummager tests don't
  pass with older version of Webmock)
