### PR TITLE
Version 14.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 14.10.0
+
+* Add email alert API support
+
 # 14.9.0
 
 * Add problem reports endpoint to `support-api`

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '14.9.0'
+  VERSION = '14.10.0'
 end


### PR DESCRIPTION
Merges https://github.com/alphagov/gds-api-adapters/pull/222, adding support for the email alert API
