### PR TITLE
Reduce public API for `email-alert-api`.

### DIFF
--- a/lib/gds_api/email_alert_api.rb
+++ b/lib/gds_api/email_alert_api.rb
@@ -9,6 +9,12 @@ class GdsApi::EmailAlertApi < GdsApi::Base
     create_subscriber_list(attributes)
   end
 
+  def send_alert(publication)
+    post_json!("#{endpoint}/notifications", publication)
+  end
+
+private
+
   def search_subscriber_list_by_tags(tags)
     get_json!("#{endpoint}/subscriber_lists?" + nested_query_string(tags: tags))
   end
@@ -16,12 +22,6 @@ class GdsApi::EmailAlertApi < GdsApi::Base
   def create_subscriber_list(attributes)
     post_json!("#{endpoint}/subscriber_lists", attributes)
   end
-
-  def send_alert(publication)
-    post_json!("#{endpoint}/notifications", publication)
-  end
-
-private
 
   def nested_query_string(params)
     Rack::Utils.build_nested_query(params)

--- a/test/email_alert_api_test.rb
+++ b/test/email_alert_api_test.rb
@@ -16,7 +16,6 @@ describe GdsApi::EmailAlertApi do
   }
 
   describe "alerts" do
-    let(:path) { "/alerts" }
     let(:subject) { "Email subject" }
     let(:publication_params) {
       {
@@ -42,7 +41,6 @@ describe GdsApi::EmailAlertApi do
   end
 
   describe "subscriber lists" do
-    let(:path){ "/subscriber_lists" }
     let(:expected_subscription_url) { "a subscription url" }
 
     describe "#find_or_create_subscriber_list_by_tags" do
@@ -96,87 +94,6 @@ describe GdsApi::EmailAlertApi do
             expected_subscription_url,
             subscriber_list_attrs.fetch("subscription_url"),
           )
-        end
-      end
-    end
-
-    describe "#create_subscriber_list" do
-      let(:params) {
-        {
-          "title" => title,
-          "tags" => tags,
-        }
-      }
-
-      before do
-        email_alert_api_creates_subscriber_list(
-          "title" => title,
-          "tags" => tags,
-          "subscription_url" => expected_subscription_url,
-        )
-      end
-
-      describe "with valid attributes" do
-        it "creates the list and returns its attributes" do
-          subscriber_list_attrs = api_client.create_subscriber_list(params)
-            .to_hash
-            .fetch("subscriber_list")
-
-          assert_equal(
-            expected_subscription_url,
-            subscriber_list_attrs.fetch("subscription_url"),
-          )
-        end
-      end
-
-      describe "with invalid attributes or list with tag set exists" do
-        before do
-          email_alert_api_refuses_to_create_subscriber_list
-        end
-
-        it "raises ClientError" do
-          assert_raises(GdsApi::HTTPClientError) {
-            api_client.create_subscriber_list(params)
-          }
-        end
-      end
-    end
-
-    describe "#search_subscriber_list_by_tags" do
-      let(:path) { "/subscriber_lists" }
-
-      describe "a subscriber list with that tag set already exists" do
-        before do
-          email_alert_api_has_subscriber_list(
-            "title" => "Some Title",
-            "tags" => tags,
-            "subscription_url" => expected_subscription_url,
-          )
-        end
-
-        it "returns the subscriber list attributes" do
-          subscriber_list_attrs = api_client.search_subscriber_list_by_tags(tags)
-            .to_hash
-            .fetch("subscriber_list")
-
-          assert_equal(
-            expected_subscription_url,
-            subscriber_list_attrs.fetch("subscription_url"),
-          )
-        end
-      end
-
-      describe "a subscriber list with that tag set does not exist" do
-        before do
-          email_alert_api_does_not_have_subscriber_list(
-            "tags" => tags,
-          )
-        end
-
-        it "raises" do
-          assert_raises(GdsApi::HTTPNotFound) {
-            api_client.search_subscriber_list_by_tags(tags)
-          }
         end
       end
     end


### PR DESCRIPTION
These endpoints have never been used publicly and are only helpers for the find_or_create method.
