### PR TITLE
Add panopticon support for `primary_section` and `sections`.

### DIFF
--- a/lib/gds_api/panopticon/registerer.rb
+++ b/lib/gds_api/panopticon/registerer.rb
@@ -30,9 +30,24 @@ module GdsApi
         end
 
         optional_params = [
-          :need_id, :need_ids, :section, :specialist_sectors, :organisation_ids,
-          :indexable_content, :paths, :prefixes
+          :need_id, :need_ids,
+          :section, :primary_section, :sections,
+          :specialist_sectors,
+          :organisation_ids,
+          :indexable_content,
+          :paths, :prefixes
         ]
+
+        deprecated_params = {
+          section: [:primary_section, :sections]
+        }
+
+        deprecated_params.each do |attr_name, replacements|
+          if record.respond_to?(attr_name)
+            replacements = Array(replacements)
+            logger.warn "#{attr_name} has been deprecated in favour of #{replacements.join(' and ')}"
+          end
+        end
 
         optional_params.each do |attr_name|
           if record.respond_to? attr_name

--- a/test/panopticon_registerer_test.rb
+++ b/test/panopticon_registerer_test.rb
@@ -63,7 +63,10 @@ describe GdsApi::Panopticon::Registerer do
       name: 'A guide to beards',
       description: '5 tips for keeping your beard in check',
       state: 'draft',
-      need_ids: ["100001", "100002"]
+      need_ids: ["100001", "100002"],
+      primary_section: "tax/vat",
+      sections: ["tax/vat", "tax/capital-gains"],
+      specialist_sectors: ["oil-and-gas/wells", "oil-and-gas/licensing"]
     )
 
     GdsApi::Panopticon::Registerer.new(
@@ -75,7 +78,37 @@ describe GdsApi::Panopticon::Registerer do
         title: 'A guide to beards',
         description: '5 tips for keeping your beard in check',
         state: 'draft',
-        need_ids: ["100001", "100002"]
+        need_ids: ["100001", "100002"],
+        primary_section: "tax/vat",
+        sections: ["tax/vat", "tax/capital-gains"],
+        specialist_sectors: ["oil-and-gas/wells", "oil-and-gas/licensing"]
+      )
+    )
+
+    assert_requested(request)
+  end
+
+  it "should support deprecated fields" do
+    request = stub_artefact_registration('beards',
+      slug: 'beards',
+      owning_app: 'whitehall',
+      kind: 'detailed-guide',
+      name: 'A guide to beards',
+      description: '5 tips for keeping your beard in check',
+      state: 'draft',
+      section: "tax/vat",
+    )
+
+    GdsApi::Panopticon::Registerer.new(
+      owning_app: 'whitehall',
+      kind: 'detailed-guide'
+    ).register(
+      OpenStruct.new(
+        slug: 'beards',
+        title: 'A guide to beards',
+        description: '5 tips for keeping your beard in check',
+        state: 'draft',
+        section: "tax/vat",
       )
     )
 


### PR DESCRIPTION
See https://github.com/alphagov/panopticon/blob/master/app/controllers/artefacts_controller.rb#L193 for final usage.

Deprecated `section` in favour of the split fields.

Cannot currently find anywhere that `section` is still used.
