### PR TITLE
Include latest changes in collections API endpoint.

### DIFF
--- a/lib/gds_api/collections_api.rb
+++ b/lib/gds_api/collections_api.rb
@@ -3,7 +3,7 @@ require_relative 'exceptions'
 
 class GdsApi::CollectionsApi < GdsApi::Base
 
-  def curated_lists_for(base_path)
+  def topic(base_path)
     get_json(collections_api_url(base_path))
   end
 

--- a/lib/gds_api/test_helpers/collections_api.rb
+++ b/lib/gds_api/test_helpers/collections_api.rb
@@ -6,7 +6,7 @@ module GdsApi
     module CollectionsApi
       COLLECTIONS_API_ENDPOINT = Plek.current.find('collections-api')
 
-      def collections_api_has_curated_lists_for(base_path)
+      def collections_api_has_content_for(base_path)
         url = COLLECTIONS_API_ENDPOINT + "/specialist-sectors" + base_path
 
         stub_request(:get, url).to_return(
@@ -15,12 +15,41 @@ module GdsApi
         )
       end
 
-      def collections_api_has_no_curated_lists_for(base_path)
+      def collections_api_has_no_content_for(base_path)
         url = COLLECTIONS_API_ENDPOINT + "/specialist-sectors" + base_path
 
         stub_request(:get, url).to_return(
           status: 404
         )
+      end
+
+      def collections_api_example_documents
+        [
+          {
+            title: "Oil rig safety requirements",
+            link: "http://example.com/documents/oil-rig-safety-requirements",
+            public_updated_at: "2014-10-27T09:35:57+00:00",
+            latest_change_note: "Updated topics"
+          },
+          {
+            title: "Undersea piping restrictions",
+            link: "http://example.com/documents/undersea-piping-restrictions",
+            public_updated_at: "2014-10-15T09:36:18+01:00"
+            # Change note deliberately missing
+          },
+          {
+            title: "North sea shipping lanes",
+            link: "http://example.com/documents/north-sea-shipping-lanes",
+            public_updated_at: "2014-10-04T09:36:42+01:00",
+            latest_change_note: "Corrected shipping lane"
+          },
+          {
+            title: "Oil rig staffing",
+            link: "http://example.com/documents/oil-rig-staffing",
+            public_updated_at: "2014-09-22T09:37:00+01:00",
+            latest_change_note: "Added annual leave allowances"
+          },
+        ]
       end
 
     private
@@ -82,7 +111,8 @@ module GdsApi
                   }
                 ]
               }
-            ]
+            ],
+            documents: collections_api_example_documents
           }
         }
       end

--- a/test/collections_api_test.rb
+++ b/test/collections_api_test.rb
@@ -10,11 +10,11 @@ describe GdsApi::CollectionsApi do
     @api = GdsApi::CollectionsApi.new(@base_api_url)
   end
 
-  describe "curated_lists_for" do
+  describe "topic" do
     it "should return the curated lists for a given base path" do
       base_path = "/test/base-path"
-      collections_api_has_curated_lists_for(base_path)
-      response = @api.curated_lists_for(base_path)
+      collections_api_has_content_for(base_path)
+      response = @api.topic(base_path)
       assert_equal base_path, response["base_path"]
     end
   end


### PR DESCRIPTION
Renames the helpers to reflect the inclusion of extra content.

Part of https://www.pivotaltracker.com/story/show/79185352
