### PR TITLE
Pass correct parameters to assert_requested

### DIFF
--- a/test/email_alert_api_test.rb
+++ b/test/email_alert_api_test.rb
@@ -32,7 +32,7 @@ describe GdsApi::EmailAlertApi do
     it "posts a new alert" do
       assert api_client.send_alert(publication_params)
 
-      assert_requested(:post, "#{base_url}/notifications", publication_params)
+      assert_requested(:post, "#{base_url}/notifications", body: publication_params.to_json)
     end
 
     it "returns the an empty response" do


### PR DESCRIPTION
Previously, this was just passing an options hash to assert_requested,
which isn't correct usage, and would have been failing to actually check
the body.

Webmock now (as of release 1.20.3) validates the options passed to
assert_requested, and will complain if unknown keys are passed.  This
has made the error obvious.
