### PR TITLE
Release 16.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 16.0.0
+
+* Pass correct parameters to assert_requested in email alert API endpoint helpers.
+* Include latest changes in collections API endpoint.
+
 # 15.2.0
 
 * Add Rummager test helpers for adding documents

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '15.2.0'
+  VERSION = '16.0.0'
 end


### PR DESCRIPTION
Releases https://github.com/alphagov/gds-api-adapters/pull/237 and https://github.com/alphagov/gds-api-adapters/pull/236
