### PR TITLE
Support 'start' and 'count' params in Collections API

### DIFF
--- a/lib/gds_api/collections_api.rb
+++ b/lib/gds_api/collections_api.rb
@@ -3,13 +3,13 @@ require_relative 'exceptions'
 
 class GdsApi::CollectionsApi < GdsApi::Base
 
-  def topic(base_path)
-    get_json(collections_api_url(base_path))
+  def topic(base_path, options={})
+    get_json(collections_api_url(base_path, options))
   end
 
 private
 
-  def collections_api_url(base_path)
-    "#{endpoint}/specialist-sectors#{base_path}"
+  def collections_api_url(base_path, options={})
+    "#{endpoint}/specialist-sectors#{base_path}#{query_string(options)}"
   end
 end

--- a/lib/gds_api/test_helpers/collections_api.rb
+++ b/lib/gds_api/test_helpers/collections_api.rb
@@ -6,8 +6,9 @@ module GdsApi
     module CollectionsApi
       COLLECTIONS_API_ENDPOINT = Plek.current.find('collections-api')
 
-      def collections_api_has_content_for(base_path)
-        url = COLLECTIONS_API_ENDPOINT + "/specialist-sectors" + base_path
+      def collections_api_has_content_for(base_path, options={})
+        params = options.any? ? "?#{Rack::Utils.build_nested_query(options)}" : ''
+        url = COLLECTIONS_API_ENDPOINT + "/specialist-sectors" + base_path + params
 
         stub_request(:get, url).to_return(
           status: 200,

--- a/test/collections_api_test.rb
+++ b/test/collections_api_test.rb
@@ -17,5 +17,14 @@ describe GdsApi::CollectionsApi do
       response = @api.topic(base_path)
       assert_equal base_path, response["base_path"]
     end
+
+    it 'accepts "start" and "count" parameters for pagination' do
+      base_path = "/test/base-path"
+
+      collections_api_has_content_for(base_path, start: '10', count: '20')
+      response = @api.topic(base_path, start: 10, count: 20)
+
+      assert_equal base_path, response['base_path']
+    end
   end
 end


### PR DESCRIPTION
The second part of [this story](https://www.pivotaltracker.com/n/projects/1110932/stories/79185504).

This changes the Collections API adapter and test helper to support the `start` and `count` parameters, which are used for pagination, and were added in alphagov/collections-api#12.
