### PR TITLE
Release 16.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 16.1.0
+
+* Allow the `start` and `count` arguments to be provided to the Collections API
+  adapter for a sub-topic.
+
 # 16.0.0
 
 * Pass correct parameters to assert_requested in email alert API endpoint helpers.

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '16.0.0'
+  VERSION = '16.1.0'
 end


### PR DESCRIPTION
This releases the change added in #239, adding support for the `start` and `count` arguments to the Collections API adapter.
