### PR TITLE
Release 16.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 16.3.1
+
+* Add test helper method to stub gone route registration.
+
 # 16.3.0
 
 * Add support for registering gone routes with the router.

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '16.3.0'
+  VERSION = '16.3.1'
 end


### PR DESCRIPTION
Add test helper method to stub gone route registration, releases https://github.com/alphagov/gds-api-adapters/pull/244
