### PR TITLE
Extend content api test helpers to support options

### DIFF
--- a/lib/gds_api/test_helpers/content_api.rb
+++ b/lib/gds_api/test_helpers/content_api.rb
@@ -181,7 +181,7 @@ module GdsApi
 
       def content_api_has_artefacts_with_a_tag(tag_type, slug, artefact_slugs=[], options={tag: {}, artefact: {}})
         if options.has_key?(:draft)
-          p "Passing a key of :draft outside of the 'tag' options hash is being deprecated. Please use tag: { draft: bool }"
+          puts "Passing a key of :draft outside of the 'tag' options hash is being deprecated. Please use tag: { draft: bool }"
         end
 
         draft = options.fetch(:draft) { options[:tag][:draft] || false }


### PR DESCRIPTION
- Extend `#content_api_has_artefacts_with_a_tag` to take a options hash.
  This allows the interface to be flexible enough for a wider range of
  testing situations, i.e. artefacts in a specific format.
