### PR TITLE
Guard against :tag key not being present

### DIFF
--- a/lib/gds_api/test_helpers/content_api.rb
+++ b/lib/gds_api/test_helpers/content_api.rb
@@ -184,7 +184,7 @@ module GdsApi
           puts "Passing a key of :draft outside of the 'tag' options hash is being deprecated. Please use tag: { draft: bool }"
         end
 
-        draft = options.fetch(:draft) { options[:tag][:draft] || false }
+        draft = options[:draft] || (options[:tag] && options[:tag][:draft])
 
         body = plural_response_base.merge(
           "results" => artefact_slugs.map do |artefact_slug|


### PR DESCRIPTION
The helper would fail on the :tag key being absent
