### PR TITLE
Version 16.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 16.3.4
+
+* Update content API test helper `#content_api_has_artefacts_with_a_tag` to
+  guard against missing keys
+
 # 16.3.3
 
 * Extend content API test helper `#content_api_has_artefacts_with_a_tag` to

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '16.3.3'
+  VERSION = '16.3.4'
 end


### PR DESCRIPTION
Update content API test helper `#content_api_has_artefacts_with_a_tag` to guard against missing keys.
