### PR TITLE
Register latest change fields with Panopticon

### DIFF
--- a/lib/gds_api/panopticon/registerer.rb
+++ b/lib/gds_api/panopticon/registerer.rb
@@ -43,6 +43,8 @@ module GdsApi
           :specialist_sectors,
           :organisation_ids,
           :indexable_content,
+          :public_timestamp,
+          :latest_change_note,
         ]
 
         deprecated_params = {

--- a/test/panopticon_registerer_test.rb
+++ b/test/panopticon_registerer_test.rb
@@ -66,7 +66,9 @@ describe GdsApi::Panopticon::Registerer do
       need_ids: ["100001", "100002"],
       primary_section: "tax/vat",
       sections: ["tax/vat", "tax/capital-gains"],
-      specialist_sectors: ["oil-and-gas/wells", "oil-and-gas/licensing"]
+      specialist_sectors: ["oil-and-gas/wells", "oil-and-gas/licensing"],
+      public_timestamp: "2014-01-01T12:00:00+00:00",
+      latest_change_note: 'Added more stubble',
     )
 
     GdsApi::Panopticon::Registerer.new(
@@ -81,7 +83,9 @@ describe GdsApi::Panopticon::Registerer do
         need_ids: ["100001", "100002"],
         primary_section: "tax/vat",
         sections: ["tax/vat", "tax/capital-gains"],
-        specialist_sectors: ["oil-and-gas/wells", "oil-and-gas/licensing"]
+        specialist_sectors: ["oil-and-gas/wells", "oil-and-gas/licensing"],
+        public_timestamp: DateTime.parse('2014-01-01 12:00:00 +00:00'),
+        latest_change_note: 'Added more stubble',
       )
     )
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/82952014

This changes the Panopticon Registerer to include the `public_timestamp` and `latest_change_note` fields as optional fields when registering an artefact with Panopticon.

An additional commit changes the formatting of the `optional_params` array to make it easier to read and diff.
