### PR TITLE
Version 17.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 17.0.0
+
+* Change the matching behaviour of ContentAPI test helpers to loosen their
+  param requirements.
+* Add a `bust_cache` option for the ContentAPI `tags` endpoint.
+
 # 16.5.0
 
 * Add Whitehall and Publisher endpoints for reindexing editions tagged to topics.

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '16.5.0'
+  VERSION = '17.0.0'
 end


### PR DESCRIPTION
Releases https://github.com/alphagov/gds-api-adapters/pull/256
