### PR TITLE
Version 17.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 17.0.1
+
+* Change the order of the ContentAPI `tags` request stubs as the first matching
+  stub is used.
+* Loosens the live `tags` stub to allow cachebust, as per the draft version.
+
 # 17.0.0
 
 * Change the matching behaviour of ContentAPI test helpers to loosen their

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '17.0.0'
+  VERSION = '17.0.1'
 end


### PR DESCRIPTION
Releases https://github.com/alphagov/gds-api-adapters/pull/258
