### PR TITLE
Add publishing API intent endpoints

### DIFF
--- a/lib/gds_api/base.rb
+++ b/lib/gds_api/base.rb
@@ -21,7 +21,7 @@ class GdsApi::Base
   def_delegators :client, :get_json, :get_json!,
                           :post_json, :post_json!,
                           :put_json, :put_json!,
-                          :delete_json!,
+                          :delete_json, :delete_json!,
                           :get_raw, :get_raw!,
                           :put_multipart,
                           :post_multipart

--- a/lib/gds_api/publishing_api.rb
+++ b/lib/gds_api/publishing_api.rb
@@ -7,9 +7,22 @@ class GdsApi::PublishingApi < GdsApi::Base
     put_json!(content_item_url(base_path), payload)
   end
 
+  def put_intent(base_path, payload)
+    put_json!(intent_url(base_path), payload)
+  end
+
+  def destroy_intent(base_path)
+    delete_json(intent_url(base_path))
+  end
+
+
   private
 
   def content_item_url(base_path)
     "#{endpoint}/content#{base_path}"
+  end
+
+  def intent_url(base_path)
+    "#{endpoint}/publish-intent#{base_path}"
   end
 end

--- a/lib/gds_api/test_helpers/intent_helpers.rb
+++ b/lib/gds_api/test_helpers/intent_helpers.rb
@@ -1,0 +1,14 @@
+module GdsApi
+  module TestHelpers
+    module IntentHelpers
+
+      def intent_for_base_path(base_path)
+        {
+          "base_path" => base_path,
+          "publish_time" => "2014-05-06T12:01:00+00:00",
+        }
+      end
+    end
+  end
+end
+

--- a/lib/gds_api/test_helpers/publishing_api.rb
+++ b/lib/gds_api/test_helpers/publishing_api.rb
@@ -1,11 +1,13 @@
 require 'gds_api/test_helpers/json_client_helper'
 require 'gds_api/test_helpers/content_item_helpers'
+require 'gds_api/test_helpers/intent_helpers'
 require 'json'
 
 module GdsApi
   module TestHelpers
     module PublishingApi
       include ContentItemHelpers
+      include IntentHelpers
 
       PUBLISHING_API_ENDPOINT = Plek.current.find('publishing-api')
 
@@ -15,12 +17,37 @@ module GdsApi
         stub_request(:put, url).with(body: body).to_return(status: 201, body: body, headers: {})
       end
 
+      def stub_publishing_api_put_intent(base_path, body = intent_for_base_path(base_path))
+        url = PUBLISHING_API_ENDPOINT + "/publish-intent" + base_path
+        body = body.to_json unless body.is_a?(String)
+        stub_request(:put, url).with(body: body).to_return(status: 201, body: body, headers: {})
+      end
+
+      def stub_publishing_api_destroy_intent(base_path)
+        url = PUBLISHING_API_ENDPOINT + "/publish-intent" + base_path
+        response_body = {base_path: base_path}.to_json
+        stub_request(:delete, url).to_return(status: 201, body: response_body)
+      end
+
       def stub_default_publishing_api_put()
         stub_request(:put, %r{\A#{PUBLISHING_API_ENDPOINT}/content})
       end
 
+      def stub_default_publishing_api_put_intent()
+        stub_request(:put, %r{\A#{PUBLISHING_API_ENDPOINT}/publish-intent})
+      end
+
       def assert_publishing_api_put_item(base_path, attributes = {})
         url = PUBLISHING_API_ENDPOINT + "/content" + base_path
+        assert_publishing_api_put(url, attributes)
+      end
+
+      def assert_publishing_api_put_intent(base_path, attributes = {})
+        url = PUBLISHING_API_ENDPOINT + "/publish-intent" + base_path
+        assert_publishing_api_put(url, attributes)
+      end
+
+      def assert_publishing_api_put(url, attributes = {})
         if attributes.empty?
           assert_requested(:put, url)
         else

--- a/test/publishing_api_test.rb
+++ b/test/publishing_api_test.rb
@@ -18,4 +18,20 @@ describe GdsApi::PublishingApi do
       assert_equal base_path, response["base_path"]
     end
   end
+
+  describe "intent" do
+    it "should create the intent" do
+      base_path = "/test-intent"
+      stub_publishing_api_put_intent(base_path)
+      response = @api.put_intent(base_path, intent_for_base_path(base_path))
+      assert_equal base_path, response["base_path"]
+    end
+
+    it "should delete an intent" do
+      base_path = "/test-intent"
+      stub_publishing_api_destroy_intent(base_path)
+      response = @api.destroy_intent(base_path)
+      assert_equal base_path, response["base_path"]
+    end
+  end
 end


### PR DESCRIPTION
Provides #put_intent and #destroy_intent, plus test helpers.
