### PR TITLE
Add a test helper for Rummager-with-queueing

### DIFF
--- a/lib/gds_api/test_helpers/rummager.rb
+++ b/lib/gds_api/test_helpers/rummager.rb
@@ -7,6 +7,11 @@ module GdsApi
         stub_request(:post, %r{#{Plek.new.find('search')}/documents})
       end
 
+      def stub_any_rummager_post_with_queueing_enabled
+        stub_request(:post, %r{#{Plek.new.find('search')}/documents}) \
+          .to_return(status: [202, "Accepted"])
+      end
+
       def assert_rummager_posted_item(attributes)
         url = Plek.new.find('search') + "/documents"
         assert_requested(:post, url) do |req|


### PR DESCRIPTION
Rummager returns 202 on POST if a feature flag is enabled, because it
queues the change:

https://github.com/alphagov/rummager/blob/cc0e9c95db9098b0dbc3dd12124d1eef5a153ae7/app.rb#L460-L466

This queueing is disabled in development, so this request returns a
different status code from in production. We need to be able to test
that other applications interact with Rummager as expected in all
environments, so this commit adds a test helper to simulate Rummager's
behaviour when queueing is enabled.
