### PR TITLE
Version 17.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 17.1.0
+
+* Add a test helper to stub Rummager's behaviour when queueing is enabled.
+
 # 17.0.1
 
 * Change the order of the ContentAPI `tags` request stubs as the first matching

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '17.0.1'
+  VERSION = '17.1.0'
 end


### PR DESCRIPTION
Releases https://github.com/alphagov/gds-api-adapters/pull/261
