### PR TITLE
Bump to version 17.2.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 17.2.0
+
+* Add PublishingApi intent endpoints and test helpers.
+
 # 17.1.0
 
 * Add a test helper to stub Rummager's behaviour when queueing is enabled.

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '17.1.0'
+  VERSION = '17.2.0'
 end


### PR DESCRIPTION
Add PublishingApi intent endpoints and test helpers.
