### PR TITLE
Adapter for ContentRegister

### DIFF
--- a/lib/gds_api/content_register.rb
+++ b/lib/gds_api/content_register.rb
@@ -1,0 +1,15 @@
+require_relative 'base'
+require_relative 'exceptions'
+
+class GdsApi::ContentRegister < GdsApi::Base
+
+  def entries(format)
+    get_json!(entries_url(format))
+  end
+
+  private
+
+  def entries_url(format)
+    "#{endpoint}/entries?format=#{format}"
+  end
+end

--- a/lib/gds_api/helpers.rb
+++ b/lib/gds_api/helpers.rb
@@ -2,6 +2,7 @@ require 'gds_api/asset_manager'
 require 'gds_api/business_support_api'
 require 'gds_api/collections_api'
 require 'gds_api/content_api'
+require 'gds_api/content_register'
 require 'gds_api/content_store'
 require 'gds_api/fact_cave'
 require 'gds_api/imminence'
@@ -29,6 +30,10 @@ module GdsApi
 
     def content_api(options = {})
       @content_api ||= GdsApi::ContentApi.new(Plek.current.find("contentapi"), options)
+    end
+
+    def content_register(options = {})
+      @content_register ||= GdsApi::ContentRegister.new(Plek.current.find("content-register"), options)
     end
 
     def content_store(options = {})


### PR DESCRIPTION
This commit adds an API adapter for content register. A way of seeing what content item sits at a certain base_path. This follows the example of the Content Store. 

I'm opening this before adding tests because I want to discuss with someone what I should be testing against this class and also what test_helpers I should be providing. 

I get that it makes sense to provide a test helper with the Content Store to stub a request and return some data with the `content_store_has_item` helper but I'm not sure what I should be doing with this. Should I provide a helper to return `n` of a certain format? Or should it provide similar functionality to `content_store_has_item` in that it should allow you to stub an array of Content Registrations?