### PR TITLE
Update router client to reflect simpler interface.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# development
+
+* Deprecate passing `type` to `GdsApi::Router#get_route` and `GdsApi::Router#delete_route`
+
 # 17.2.0
 
 * Add PublishingApi intent endpoints and test helpers.

--- a/lib/gds_api/router.rb
+++ b/lib/gds_api/router.rb
@@ -18,8 +18,11 @@ class GdsApi::Router < GdsApi::Base
 
   ### Routes
 
-  def get_route(path, type)
-    get_json("#{endpoint}/routes?incoming_path=#{CGI.escape(path)}&route_type=#{CGI.escape(type)}")
+  def get_route(path, type = nil)
+    if type
+      $stderr.puts "DEPRECATION WARNING: passing type to GdsApi::Router#get_route is deprecated and will be removed in a future version. Caller: #{caller[0]}"
+    end
+    get_json("#{endpoint}/routes?incoming_path=#{CGI.escape(path)}")
   end
 
   def add_route(path, type, backend_id, options = {})
@@ -41,8 +44,14 @@ class GdsApi::Router < GdsApi::Base
     response
   end
 
-  def delete_route(path, type, options = {})
-    response = delete_json!("#{endpoint}/routes?incoming_path=#{CGI.escape(path)}&route_type=#{CGI.escape(type)}")
+  def delete_route(path, options_or_deprecated_type = {}, deprecated_options = {})
+    if options_or_deprecated_type.is_a?(String)
+      $stderr.puts "DEPRECATION WARNING: passing type to GdsApi::Router#delete_route is deprecated and will be removed in a future version. Caller: #{caller[0]}"
+      options = deprecated_options
+    else
+      options = options_or_deprecated_type
+    end
+    response = delete_json!("#{endpoint}/routes?incoming_path=#{CGI.escape(path)}")
     commit_routes if options[:commit]
     response
   end

--- a/test/router_test.rb
+++ b/test/router_test.rb
@@ -149,10 +149,10 @@ describe GdsApi::Router do
       it "should return the route details" do
         route_data = {"incoming_path" => "/foo", "route_type" => "exact", "handler" => "backend", "backend_id" => "foo"}
         req = WebMock.stub_request(:get, "#{@base_api_url}/routes").
-          with(:query => {"incoming_path" => "/foo", "route_type" => "exact"}).
+          with(:query => {"incoming_path" => "/foo"}).
           to_return(:status => 200, :body => route_data.to_json, :headers => {"Content-type" => "application/json"})
 
-        response = @api.get_route("/foo", "exact")
+        response = @api.get_route("/foo")
         assert_equal 200, response.code
         assert_equal "foo", response.backend_id
 
@@ -162,10 +162,10 @@ describe GdsApi::Router do
 
       it "should return nil if nothing found" do
         req = WebMock.stub_request(:get, "#{@base_api_url}/routes").
-          with(:query => {"incoming_path" => "/foo", "route_type" => "exact"}).
+          with(:query => {"incoming_path" => "/foo"}).
           to_return(:status => 404)
 
-        response = @api.get_route("/foo", "exact")
+        response = @api.get_route("/foo")
         assert_nil response
 
         assert_requested(req)
@@ -176,10 +176,10 @@ describe GdsApi::Router do
         # The WebMock query matcher matches unescaped params.  The call blows up if they're not escaped
 
         req = WebMock.stub_request(:get, "#{@base_api_url}/routes").
-          with(:query => {"incoming_path" => "/foo bar", "route_type" => "exa ct"}).
+          with(:query => {"incoming_path" => "/foo bar"}).
           to_return(:status => 404)
 
-        response = @api.get_route("/foo bar", "exa ct")
+        response = @api.get_route("/foo bar")
         assert_nil response
 
         assert_requested(req)
@@ -352,10 +352,10 @@ describe GdsApi::Router do
       it "should allow deleting a route" do
         route_data = {"incoming_path" => "/foo", "route_type" => "exact", "handler" => "backend", "backend_id" => "foo"}
         req = WebMock.stub_request(:delete, "#{@base_api_url}/routes").
-          with(:query => {"incoming_path" => "/foo", "route_type" => "exact"}).
+          with(:query => {"incoming_path" => "/foo"}).
           to_return(:status => 200, :body => route_data.to_json, :headers => {"Content-type" => "application/json"})
 
-        response = @api.delete_route("/foo", "exact")
+        response = @api.delete_route("/foo")
         assert_equal 200, response.code
         assert_equal "foo", response.backend_id
 
@@ -365,10 +365,10 @@ describe GdsApi::Router do
 
       it "should commit the routes when asked to" do
         req = WebMock.stub_request(:delete, "#{@base_api_url}/routes").
-          with(:query => {"incoming_path" => "/foo", "route_type" => "exact"}).
+          with(:query => {"incoming_path" => "/foo"}).
           to_return(:status => 200, :body => {}.to_json, :headers => {"Content-type" => "application/json"})
 
-        @api.delete_route("/foo", "exact", :commit => true)
+        @api.delete_route("/foo", :commit => true)
 
         assert_requested(req)
         assert_requested(@commit_req)
@@ -376,12 +376,12 @@ describe GdsApi::Router do
 
       it "should raise HTTPNotFound if nothing found" do
         req = WebMock.stub_request(:delete, "#{@base_api_url}/routes").
-          with(:query => {"incoming_path" => "/foo", "route_type" => "exact"}).
+          with(:query => {"incoming_path" => "/foo"}).
           to_return(:status => 404)
 
         e = nil
         begin
-          @api.delete_route("/foo", "exact")
+          @api.delete_route("/foo")
         rescue GdsApi::HTTPNotFound => ex
           e = ex
         end
@@ -397,11 +397,11 @@ describe GdsApi::Router do
         # The WebMock query matcher matches unescaped params.  The call blows up if they're not escaped
 
         req = WebMock.stub_request(:delete, "#{@base_api_url}/routes").
-          with(:query => {"incoming_path" => "/foo bar", "route_type" => "exa ct"}).
+          with(:query => {"incoming_path" => "/foo bar"}).
           to_return(:status => 404)
 
         begin
-          @api.delete_route("/foo bar", "exa ct")
+          @api.delete_route("/foo bar")
         rescue GdsApi::HTTPNotFound
         end
 


### PR DESCRIPTION
To correspond to the changes in https://github.com/alphagov/router-api/pull/61.

This deprecates passing a type to `get_route` and `delete_route`, as they're no longer needed (and are therefore ignored).