### PR TITLE
Bump to 17.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 17.4.1
+
+* Add ability to pass `n` to some PublishingAPI test helpers to say how many times
+  the request should be expected.
+
 # 17.4.0
 
 * Add delete helpers to GdsApi::TestHelpers::Rummager

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '17.4.0'
+  VERSION = '17.4.1'
 end


### PR DESCRIPTION
Minor version bump to get `n` times for Publishing API test helpers.