### PR TITLE
Bump `gem_publisher` to show publishing errors

### DIFF
--- a/gds-api-adapters.gemspec
+++ b/gds-api-adapters.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rack-test'
   s.add_development_dependency 'simplecov', '~> 0.5.4'
   s.add_development_dependency 'simplecov-rcov'
-  s.add_development_dependency 'gem_publisher', '~> 1.1.1'
+  s.add_development_dependency 'gem_publisher', '~> 1.5.0'
   s.add_development_dependency 'timecop', '~> 0.5.1'
   s.add_development_dependency 'pry'
 end


### PR DESCRIPTION
The older versions of `gem_publisher` don't include output from `STDOUT` when gem publishing fails, but some tools write errors to `STDOUT` instead of `STDERR`. Because we have an older version of the gem, we're not seeing these errors.