### PR TITLE
Adapter for sending drafts to publishing API

### DIFF
--- a/lib/gds_api/publishing_api.rb
+++ b/lib/gds_api/publishing_api.rb
@@ -3,6 +3,10 @@ require_relative 'exceptions'
 
 class GdsApi::PublishingApi < GdsApi::Base
 
+  def put_draft_content_item(base_path, payload)
+    put_json!(draft_content_item_url(base_path), payload)
+  end
+
   def put_content_item(base_path, payload)
     put_json!(content_item_url(base_path), payload)
   end
@@ -17,6 +21,10 @@ class GdsApi::PublishingApi < GdsApi::Base
 
 
   private
+
+  def draft_content_item_url(base_path)
+    "#{endpoint}/draft-content#{base_path}"
+  end
 
   def content_item_url(base_path)
     "#{endpoint}/content#{base_path}"

--- a/lib/gds_api/test_helpers/publishing_api.rb
+++ b/lib/gds_api/test_helpers/publishing_api.rb
@@ -11,8 +11,12 @@ module GdsApi
 
       PUBLISHING_API_ENDPOINT = Plek.current.find('publishing-api')
 
-      def stub_publishing_api_put_item(base_path, body = content_item_for_base_path(base_path))
-        url = PUBLISHING_API_ENDPOINT + "/content" + base_path
+      def stub_publishing_api_put_draft_item(base_path, body = content_item_for_base_path(base_path))
+        stub_publishing_api_put_item(base_path, body, '/draft-content')
+      end
+
+      def stub_publishing_api_put_item(base_path, body = content_item_for_base_path(base_path), resource_path = '/content')
+        url = PUBLISHING_API_ENDPOINT + resource_path + base_path
         body = body.to_json unless body.is_a?(String)
         stub_request(:put, url).with(body: body).to_return(status: 201, body: body, headers: {})
       end

--- a/test/publishing_api_test.rb
+++ b/test/publishing_api_test.rb
@@ -12,9 +12,19 @@ describe GdsApi::PublishingApi do
 
   describe "item" do
     it "should create the item" do
-      base_path = "/test-to-publishing-api"
+      base_path = "/test-content-item"
       stub_publishing_api_put_item(base_path)
       response = @api.put_content_item(base_path, content_item_for_base_path(base_path))
+      assert_equal base_path, response["base_path"]
+    end
+  end
+
+  describe "draft item" do
+    it "should create the draft item" do
+      base_path = "/test-draft-content-item"
+      stub_publishing_api_put_draft_item(base_path)
+
+      response = @api.put_draft_content_item(base_path, content_item_for_base_path(base_path))
       assert_equal base_path, response["base_path"]
     end
   end


### PR DESCRIPTION
https://trello.com/c/PbCzGBIB

Content designers need a way to preview content they're drafting.
When draft content is saved, publishing applications can push it
to a draft instance of the content store, from where it can be
previewed on the draft site.

To begin with, this call will return an empty 200 OK response,
unless there's an instance of draft content store configured in
the environment and Publishing API is told about it by setting
DRAFT_CONTENT_STORE in the environment.

See related Publishing API change:
https://github.com/alphagov/publishing-api/pull/22