### PR TITLE
Release 17.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 17.6.0
+
+* Add publishing API method to `PUT` draft content items, to be stored only in draft content-store.
+
 # 17.5.0
 
 * Add ability to pass `n` to some PublishingAPI test helpers to say how many times

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '17.5.0'
+  VERSION = '17.6.0'
 end


### PR DESCRIPTION
Add publishing API method to `PUT` draft content items, to be stored only in draft content-store.

Releases: https://github.com/alphagov/gds-api-adapters/pull/278