### PR TITLE
Publishing API responses no longer include the entity

### DIFF
--- a/lib/gds_api/test_helpers/publishing_api.rb
+++ b/lib/gds_api/test_helpers/publishing_api.rb
@@ -17,20 +17,18 @@ module GdsApi
 
       def stub_publishing_api_put_item(base_path, body = content_item_for_base_path(base_path), resource_path = '/content')
         url = PUBLISHING_API_ENDPOINT + resource_path + base_path
-        body = body.to_json unless body.is_a?(String)
-        stub_request(:put, url).with(body: body).to_return(status: 201, body: body, headers: {})
+        stub_request(:put, url).with(body: body).to_return(status: 201, body: '{}', headers: {})
       end
 
       def stub_publishing_api_put_intent(base_path, body = intent_for_base_path(base_path))
         url = PUBLISHING_API_ENDPOINT + "/publish-intent" + base_path
         body = body.to_json unless body.is_a?(String)
-        stub_request(:put, url).with(body: body).to_return(status: 201, body: body, headers: {})
+        stub_request(:put, url).with(body: body).to_return(status: 201, body: '{}', headers: {})
       end
 
       def stub_publishing_api_destroy_intent(base_path)
         url = PUBLISHING_API_ENDPOINT + "/publish-intent" + base_path
-        response_body = {base_path: base_path}.to_json
-        stub_request(:delete, url).to_return(status: 201, body: response_body)
+        stub_request(:delete, url).to_return(status: 201, body: '{}')
       end
 
       def stub_default_publishing_api_put()

--- a/test/publishing_api_test.rb
+++ b/test/publishing_api_test.rb
@@ -15,7 +15,7 @@ describe GdsApi::PublishingApi do
       base_path = "/test-content-item"
       stub_publishing_api_put_item(base_path)
       response = @api.put_content_item(base_path, content_item_for_base_path(base_path))
-      assert_equal base_path, response["base_path"]
+      assert_equal 201, response.code
     end
   end
 
@@ -25,7 +25,7 @@ describe GdsApi::PublishingApi do
       stub_publishing_api_put_draft_item(base_path)
 
       response = @api.put_draft_content_item(base_path, content_item_for_base_path(base_path))
-      assert_equal base_path, response["base_path"]
+      assert_equal 201, response.code
     end
   end
 
@@ -34,14 +34,14 @@ describe GdsApi::PublishingApi do
       base_path = "/test-intent"
       stub_publishing_api_put_intent(base_path)
       response = @api.put_intent(base_path, intent_for_base_path(base_path))
-      assert_equal base_path, response["base_path"]
+      assert_equal 201, response.code
     end
 
     it "should delete an intent" do
       base_path = "/test-intent"
       stub_publishing_api_destroy_intent(base_path)
       response = @api.destroy_intent(base_path)
-      assert_equal base_path, response["base_path"]
+      assert_equal 201, response.code
     end
   end
 end


### PR DESCRIPTION
This updates the test helpers to match.

See: https://github.com/alphagov/content-store/pull/107

@heathd and I checked every app that uses Publishing API and weren't able to find any uses of the response body, let alone the entity.