### PR TITLE
Omit base_path from publishing_api request bodies

### DIFF
--- a/lib/gds_api/test_helpers/content_item_helpers.rb
+++ b/lib/gds_api/test_helpers/content_item_helpers.rb
@@ -10,7 +10,8 @@ module GdsApi
           "format" => "guide",
           "need_ids" => ["100001"],
           "public_updated_at" => "2014-05-06T12:01:00+00:00",
-          "base_path" => base_path,
+          # base_path is added in as necessary (ie for content-store GET responses)
+          # "base_path" => base_path,
           "details" => {
             "body" => "Some content for #{base_path}",
           }

--- a/lib/gds_api/test_helpers/content_store.rb
+++ b/lib/gds_api/test_helpers/content_store.rb
@@ -23,6 +23,10 @@ module GdsApi
       def content_store_isnt_available
         stub_request(:any, /#{CONTENT_STORE_ENDPOINT}\/.*/).to_return(:status => 503)
       end
+
+      def content_item_for_base_path(base_path)
+        super.merge({ base_path: base_path })
+      end
     end
   end
 end


### PR DESCRIPTION
This field is deprecated, soon to be rejected.

I couldn't see a clean alternative to duplicating the implementation.

This should be a major version bump as the API for the test helpers has changed in an incompatible way.