### PR TITLE
Add GdsApi::ContentRegister#put_entry method

### DIFF
--- a/lib/gds_api/content_register.rb
+++ b/lib/gds_api/content_register.rb
@@ -3,13 +3,21 @@ require_relative 'exceptions'
 
 class GdsApi::ContentRegister < GdsApi::Base
 
+  def put_entry(content_id, entry)
+    put_json!(entry_url(content_id), entry)
+  end
+
   def entries(format)
     get_json!(entries_url(format))
   end
 
-  private
+private
 
   def entries_url(format)
     "#{endpoint}/entries?format=#{format}"
+  end
+
+  def entry_url(content_id)
+    "#{endpoint}/entry/#{content_id}"
   end
 end

--- a/lib/gds_api/test_helpers/content_register.rb
+++ b/lib/gds_api/test_helpers/content_register.rb
@@ -1,0 +1,23 @@
+require 'gds_api/test_helpers/json_client_helper'
+require 'json'
+
+module GdsApi
+  module TestHelpers
+    module ContentRegister
+      CONTENT_REGISTER_ENDPOINT = Plek.find('content-register')
+
+      def stub_content_register_put_entry(content_id, entry)
+        response_body = entry.merge(content_id: content_id).to_json
+
+        stub_request(:put, content_register_entry_url_for(content_id)).
+          to_return(status: 201, body: response_body)
+      end
+
+    private
+
+      def content_register_entry_url_for(content_id)
+        CONTENT_REGISTER_ENDPOINT + "/entry/" + content_id
+      end
+    end
+  end
+end

--- a/test/content_register_test.rb
+++ b/test/content_register_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+require 'gds_api/content_register'
+require 'gds_api/test_helpers/content_register'
+
+describe GdsApi::ContentRegister do
+  include GdsApi::TestHelpers::ContentRegister
+
+  before do
+    @api_adapter = GdsApi::ContentRegister.new(Plek.find("content-register"))
+  end
+
+  describe "#put_entry method" do
+    it "creates an entry in the content register" do
+      content_id = SecureRandom.uuid
+      entry = {
+        "format" => 'organisation',
+        "title" => 'Organisation',
+        "base_path" => "/government/organisations/organisation"
+      }
+
+      stub_content_register_put_entry(content_id, entry)
+
+      response = @api_adapter.put_entry(content_id, entry)
+      assert_equal 201, response.code
+    end
+  end
+end


### PR DESCRIPTION
This endpoint is used by publishing tools to register content items with the content register.