### PR TITLE
Release 18.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-# (Unreleased)
+# 18.3.0
 
 * Add assert_publishing_api_put_draft_item to publishing_api_helpers
+* Bump rest-client for security fixes
 
 # 18.2.0
 

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '18.2.0'
+  VERSION = '18.3.0'
 end


### PR DESCRIPTION
Includes https://github.com/alphagov/gds-api-adapters/pull/291 and https://github.com/alphagov/gds-api-adapters/pull/292