### PR TITLE
Fix content_api_has_artefacts_with_a_draft_tag helper.

### DIFF
--- a/lib/gds_api/test_helpers/content_api.rb
+++ b/lib/gds_api/test_helpers/content_api.rb
@@ -171,7 +171,7 @@ module GdsApi
 
         body = plural_response_base.merge(
           "results" => artefact_slugs.map do |artefact_slug|
-            artefact_for_slug(artefact_slug, options[:artefact])
+            artefact_for_slug(artefact_slug, options.fetch(:artefact, {}))
           end
         )
 
@@ -227,7 +227,7 @@ module GdsApi
       end
 
       def content_api_has_artefacts_with_a_draft_tag(tag_type, slug, artefact_slugs=[])
-        content_api_has_artefacts_with_a_tag(tag_type, slug, artefact_slugs, draft: true)
+        content_api_has_artefacts_with_a_tag(tag_type, slug, artefact_slugs, tag: {draft: true})
       end
 
       def content_api_has_sorted_artefacts_with_a_tag(tag_type, slug, sort_order, artefact_slugs=[])


### PR DESCRIPTION
It was broken with the changes to content_api_has_artefacts_with_a_tag
which was calling artefact_for_slug with nil instead of empty hash
causing things to blow up.

content_api_has_artefacts_with_a_draft_tag was also using the now
deprecated method of specifying that the tag is draft.