### PR TITLE
Add more generic rummager helpers.

### DIFF
--- a/lib/gds_api/test_helpers/rummager.rb
+++ b/lib/gds_api/test_helpers/rummager.rb
@@ -51,11 +51,21 @@ module GdsApi
       end
 
       def rummager_has_no_policies_for_any_organisation
+        puts "`rummager_has_no_policies_for_any_organisation` has been deprecated in favour of `rummager_has_no_policies_for_any_type`"
+        rummager_has_no_policies_for_any_type
+      end
+
+      def rummager_has_no_policies_for_any_type
         stub_request(:get, %r{/unified_search.json})
           .to_return(body: no_search_results_found)
       end
 
-      def rummager_has_new_policies_for_every_organisation(options = {})
+      def rummager_has_new_policies_for_every_organisation(*args)
+        puts "`rummager_has_new_policies_for_every_organisation` has been deprecated in favour of `rummager_has_new_policies_for_every_type`"
+        rummager_has_new_policies_for_every_type(*args)
+      end
+
+      def rummager_has_new_policies_for_every_type(options = {})
         if count = options[:count]
           stub_request(:get, %r{/unified_search.json.*count=#{count}.*})
             .to_return(body: first_n_results(new_policies_results, n: count))


### PR DESCRIPTION
The `organisation` policy helpers were already
generic, this names them so and deprecates the old
ones.

Required for https://trello.com/c/07dhHmwK/58-2-policies-on-ministers-pages