### PR TITLE
Add support-api /anonymous-feedback endpoint

### DIFF
--- a/lib/gds_api/support_api.rb
+++ b/lib/gds_api/support_api.rb
@@ -17,4 +17,9 @@ class GdsApi::SupportApi < GdsApi::Base
     date_string = date.strftime("%Y-%m-%d")
     get_json!("#{endpoint}/anonymous-feedback/problem-reports/#{date_string}/totals")
   end
+
+  def anonymous_feedback(options = {})
+    uri = "#{endpoint}/anonymous-feedback" + query_string(options)
+    get_json!(uri)
+  end
 end

--- a/lib/gds_api/test_helpers/support_api.rb
+++ b/lib/gds_api/test_helpers/support_api.rb
@@ -1,3 +1,4 @@
+require 'cgi'
 require 'plek'
 
 module GdsApi
@@ -33,6 +34,12 @@ module GdsApi
 
       def support_api_isnt_available
         stub_request(:post, /#{SUPPORT_API_ENDPOINT}\/.*/).to_return(:status => 503)
+      end
+
+      def stub_anonymous_feedback(params, response_body = {})
+        stub_http_request(:get, "#{SUPPORT_API_ENDPOINT}/anonymous-feedback").
+          with(query: params).
+          to_return(status: 200, body: response_body.to_json)
       end
     end
   end

--- a/test/support_api_test.rb
+++ b/test/support_api_test.rb
@@ -63,4 +63,20 @@ describe GdsApi::SupportApi do
 
     assert_raises(GdsApi::HTTPServerError) { @api.create_service_feedback({}) }
   end
+
+  describe "GET /anonymous-feedback" do
+    it "fetches anonymous feedback" do
+      stub_get = stub_anonymous_feedback(
+        path_prefix: "/vat-rates",
+        page: 55,
+      )
+
+      result = @api.anonymous_feedback(
+        path_prefix: "/vat-rates",
+        page: 55,
+      )
+
+      assert_requested(stub_get)
+    end
+  end
 end


### PR DESCRIPTION
**This exposes the endpoint being added by https://github.com/alphagov/support-api/pull/48**.

This endpoint allows frontend apps to fetch pages of anonymous feedback.

/cc @mikejustdoit @binaryberry @boffbowsh 