### PR TITLE
Bump version to 18.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 18.8.0
+
+* Support API: add adapter for `/anonymous-feedback` feed endpoint
+
 # 18.7.0
 
 * Change name of Rummager policy-tagging test helpers to reflect the fact that

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '18.7.0'
+  VERSION = '18.8.0'
 end


### PR DESCRIPTION
* support-api: add adapter for `/anonymous-feedback` endpoint (https://github.com/alphagov/gds-api-adapters/pull/304)