### PR TITLE
organisation_summary method for new Support API endpoint

### DIFF
--- a/lib/gds_api/support_api.rb
+++ b/lib/gds_api/support_api.rb
@@ -23,7 +23,8 @@ class GdsApi::SupportApi < GdsApi::Base
     get_json!(uri)
   end
 
-  def organisation_summary(organisation_slug)
-    get_json!("#{endpoint}/anonymous-feedback/organisations/#{organisation_slug}")
+  def organisation_summary(organisation_slug, options = {})
+    uri = "#{endpoint}/anonymous-feedback/organisations/#{organisation_slug}" + query_string(options)
+    get_json!(uri)
   end
 end

--- a/lib/gds_api/support_api.rb
+++ b/lib/gds_api/support_api.rb
@@ -22,4 +22,8 @@ class GdsApi::SupportApi < GdsApi::Base
     uri = "#{endpoint}/anonymous-feedback" + query_string(options)
     get_json!(uri)
   end
+
+  def organisation_summary(organisation_slug)
+    get_json!("#{endpoint}/anonymous-feedback/organisations/#{organisation_slug}")
+  end
 end

--- a/lib/gds_api/test_helpers/support_api.rb
+++ b/lib/gds_api/test_helpers/support_api.rb
@@ -42,8 +42,9 @@ module GdsApi
           to_return(status: 200, body: response_body.to_json)
       end
 
-      def stub_anonymous_feedback_organisation_summary(slug, response_body = {})
+      def stub_anonymous_feedback_organisation_summary(slug, ordering = nil, response_body = {})
         uri = "#{SUPPORT_API_ENDPOINT}/anonymous-feedback/organisations/#{slug}"
+        uri << "?ordering=#{ordering}" if ordering
         stub_http_request(:get, uri).
           to_return(status: 200, body: response_body.to_json)
       end

--- a/lib/gds_api/test_helpers/support_api.rb
+++ b/lib/gds_api/test_helpers/support_api.rb
@@ -41,6 +41,12 @@ module GdsApi
           with(query: params).
           to_return(status: 200, body: response_body.to_json)
       end
+
+      def stub_anonymous_feedback_organisation_summary(slug, response_body = {})
+        uri = "#{SUPPORT_API_ENDPOINT}/anonymous-feedback/organisations/#{slug}"
+        stub_http_request(:get, uri).
+          to_return(status: 200, body: response_body.to_json)
+      end
     end
   end
 end

--- a/test/support_api_test.rb
+++ b/test/support_api_test.rb
@@ -79,4 +79,16 @@ describe GdsApi::SupportApi do
       assert_requested(stub_get)
     end
   end
+
+  describe "GET /anonymous-feedback/organisations/:organisation_slug" do
+    it "fetches organisation summary" do
+      slug = "hm-revenue-customs"
+
+      stub_get = stub_anonymous_feedback_organisation_summary(slug)
+
+      @api.organisation_summary(slug)
+
+      assert_requested(stub_get)
+    end
+  end
 end

--- a/test/support_api_test.rb
+++ b/test/support_api_test.rb
@@ -90,5 +90,16 @@ describe GdsApi::SupportApi do
 
       assert_requested(stub_get)
     end
+
+    it "accepts an ordering parameter" do
+      slug = "hm-revenue-customs"
+      ordering = "last_30_days"
+
+      stub_get = stub_anonymous_feedback_organisation_summary(slug, ordering)
+
+      @api.organisation_summary(slug, ordering: ordering)
+
+      assert_requested(stub_get)
+    end
   end
 end


### PR DESCRIPTION
This matches the new endpoint added in https://github.com/alphagov/support-api/pull/53 and will be consumed by the `support` app.