### PR TITLE
Rewrite Response#method_missing

### DIFF
--- a/lib/gds_api/response.rb
+++ b/lib/gds_api/response.rb
@@ -74,8 +74,8 @@ module GdsApi
       @ostruct ||= self.class.build_ostruct_recursively(to_hash)
     end
 
-    def method_missing(method)
-      to_ostruct.send(method)
+    def method_missing(method_sym, *arguments, &block)
+      to_ostruct.public_send(method_sym, *arguments, &block)
     end
 
     def respond_to_missing?(method, include_private)


### PR DESCRIPTION
If called passing parameters and/or a block, the method returned a
'wrong number of arguments' error.

It is an unwanted behaviour and this PR removes it.