### PR TITLE
Remove old policy test helpers for rummager.

### DIFF
--- a/lib/gds_api/test_helpers/rummager.rb
+++ b/lib/gds_api/test_helpers/rummager.rb
@@ -50,38 +50,18 @@ module GdsApi
         run_example_query
       end
 
-      def rummager_has_no_policies_for_any_organisation
-        puts "`rummager_has_no_policies_for_any_organisation` has been deprecated in favour of `rummager_has_no_policies_for_any_type`"
-        rummager_has_no_policies_for_any_type
-      end
-
       def rummager_has_no_policies_for_any_type
         stub_request(:get, %r{/unified_search.json})
           .to_return(body: no_search_results_found)
       end
 
-      def rummager_has_new_policies_for_every_organisation(*args)
-        puts "`rummager_has_new_policies_for_every_organisation` has been deprecated in favour of `rummager_has_new_policies_for_every_type`"
-        rummager_has_new_policies_for_every_type(*args)
-      end
-
-      def rummager_has_new_policies_for_every_type(options = {})
+      def rummager_has_policies_for_every_type(options = {})
         if count = options[:count]
           stub_request(:get, %r{/unified_search.json.*count=#{count}.*})
             .to_return(body: first_n_results(new_policies_results, n: count))
         else
           stub_request(:get, %r{/unified_search.json})
             .to_return(body: new_policies_results)
-        end
-      end
-
-      def rummager_has_old_policies_for_every_organisation(options = {})
-        if count = options[:count]
-          stub_request(:get, %r{/unified_search.json.*count=#{count}.*})
-            .to_return(body: first_n_results(old_policies_results, n: count))
-        else
-          stub_request(:get, %r{/unified_search.json})
-            .to_return(body: old_policies_results)
         end
       end
 


### PR DESCRIPTION
These were used in Whitehall and are now unnecessary.