### PR TITLE
Bump to 19.1.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 19.1.0
+
+* Pass HTTP_X_GOVUK_AUTHENTICATED_USER in API requests.
+
 # 19.0.0
 
 * Remove old policy test helpers for rummager.

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '19.0.0'
+  VERSION = '19.1.0'
 end


### PR DESCRIPTION
Passes HTTP_X_GOVUK_AUTHENTICATED_USER in API requests.