### PR TITLE
Add specific HTTPForbidden exception.

### DIFF
--- a/lib/gds_api/exceptions.rb
+++ b/lib/gds_api/exceptions.rb
@@ -33,6 +33,9 @@ module GdsApi
   class HTTPGone < HTTPClientError
   end
 
+  class HTTPForbidden < HTTPClientError
+  end
+
   class NoBearerToken < BaseError; end
 
   module ExceptionHandling
@@ -51,6 +54,8 @@ module GdsApi
       code = error.http_code
 
       case code
+      when 403
+        GdsApi::HTTPForbidden.new(code, message, details)
       when 404
         GdsApi::HTTPNotFound.new(code, message, details)
       when 410

--- a/test/json_client_test.rb
+++ b/test/json_client_test.rb
@@ -326,6 +326,14 @@ class JsonClientTest < MiniTest::Spec
     end
   end
 
+  def test_get_bang_should_raise_http_forbidden_if_403_returned_from_endpoint
+    url = "http://some.endpoint/some.json"
+    stub_request(:get, url).to_return(:body => "{}", :status => 403)
+    assert_raises GdsApi::HTTPForbidden do
+      @client.get_json!(url)
+    end
+  end
+
   def test_get_should_be_nil_if_404_returned_from_endpoint
     url = "http://some.endpoint/some.json"
     stub_request(:get, url).to_return(:body => "{}", :status => 404)


### PR DESCRIPTION
This is raised when a 403 Forbidden response is received from the endpoint.