### PR TITLE
Don't cache cache-control "private" and "no-store" responses

### DIFF
--- a/lib/gds_api/json_client.rb
+++ b/lib/gds_api/json_client.rb
@@ -212,25 +212,14 @@ module GdsApi
     # or nil if no cache information is provided
     def response_cache_time(response)
       if response.headers[:cache_control]
-        # The Cache-control header is composed of a comma-separated string
-        # so split this apart before we look for particular values
-        cache_parts = response.headers[:cache_control].split(',').map(&:strip)
+        cache_control = Rack::Cache::CacheControl.new(response.headers[:cache_control])
 
-        # If no-cache is present, this takes precedent over any other value
-        # in this header
-        if cache_parts.any? { |part| ["no-cache","private"].include?(part) }
-          return Time.now.utc
+        if cache_control["private"] || cache_control["no-cache"]
+          Time.now.utc
+        elsif cache_control["max-age"]
+          Time.now.utc + cache_control["max-age"].to_i
         end
-
-        # Otherwise, look for a 'max-age=123' value, which is the number of
-        # seconds for which to cache the response.
-        max_age = cache_parts.map {|x| x.match(/max-age=(\d+)/) }.compact.first
-        if max_age
-          return Time.now.utc + max_age[1].to_i
-        end
-      end
-
-      if response.headers[:expires]
+      elsif response.headers[:expires]
         Time.httpdate response.headers[:expires]
       end
     end

--- a/lib/gds_api/json_client.rb
+++ b/lib/gds_api/json_client.rb
@@ -218,7 +218,9 @@ module GdsApi
 
         # If no-cache is present, this takes precedent over any other value
         # in this header
-        return Time.now.utc if cache_parts.include?("no-cache")
+        if cache_parts.any? { |part| ["no-cache","private"].include?(part) }
+          return Time.now.utc
+        end
 
         # Otherwise, look for a 'max-age=123' value, which is the number of
         # seconds for which to cache the response.

--- a/lib/gds_api/json_client.rb
+++ b/lib/gds_api/json_client.rb
@@ -214,10 +214,10 @@ module GdsApi
       if response.headers[:cache_control]
         cache_control = Rack::Cache::CacheControl.new(response.headers[:cache_control])
 
-        if cache_control["private"] || cache_control["no-cache"] || cache_control["no-store"]
+        if cache_control.private? || cache_control.no_cache? || cache_control.no_store?
           Time.now.utc
-        elsif cache_control["max-age"]
-          Time.now.utc + cache_control["max-age"].to_i
+        elsif cache_control.max_age
+          Time.now.utc + cache_control.max_age
         end
       elsif response.headers[:expires]
         Time.httpdate response.headers[:expires]

--- a/lib/gds_api/json_client.rb
+++ b/lib/gds_api/json_client.rb
@@ -214,7 +214,7 @@ module GdsApi
       if response.headers[:cache_control]
         cache_control = Rack::Cache::CacheControl.new(response.headers[:cache_control])
 
-        if cache_control["private"] || cache_control["no-cache"]
+        if cache_control["private"] || cache_control["no-cache"] || cache_control["no-store"]
           Time.now.utc
         elsif cache_control["max-age"]
           Time.now.utc + cache_control["max-age"].to_i

--- a/lib/gds_api/response.rb
+++ b/lib/gds_api/response.rb
@@ -46,9 +46,9 @@ module GdsApi
     end
 
     def expires_at
-      if headers[:date] && cache_control['max-age']
+      if headers[:date] && cache_control.max_age
         response_date = Time.parse(headers[:date])
-        response_date + cache_control['max-age'].to_i
+        response_date + cache_control.max_age
       elsif headers[:expires]
         Time.parse(headers[:expires])
       end
@@ -59,8 +59,8 @@ module GdsApi
 
       age = Time.now.utc - Time.parse(headers[:date])
 
-      if cache_control['max-age']
-        cache_control['max-age'].to_i - age.to_i
+      if cache_control.max_age
+        cache_control.max_age - age.to_i
       elsif headers[:expires]
         Time.parse(headers[:expires]).to_i - Time.now.utc.to_i
       end
@@ -68,10 +68,6 @@ module GdsApi
 
     def cache_control
       @cache_control ||= Rack::Cache::CacheControl.new(headers[:cache_control])
-    end
-
-    def cache_control_private?
-      cache_control["private"]
     end
 
     def to_hash

--- a/lib/gds_api/response.rb
+++ b/lib/gds_api/response.rb
@@ -46,28 +46,32 @@ module GdsApi
     end
 
     def expires_at
-      if headers[:date] && cache_control_headers = headers[:cache_control]
-        max_age = Rack::Cache::CacheControl.new(cache_control_headers)['max-age']
+      if headers[:date] && cache_control['max-age']
         response_date = Time.parse(headers[:date])
-
-        return response_date + max_age.to_i if max_age
+        response_date + cache_control['max-age'].to_i
+      elsif headers[:expires]
+        Time.parse(headers[:expires])
       end
-      Time.parse(headers[:expires]) if headers[:expires]
     end
 
     def expires_in
       return unless headers[:date]
 
-      max_age = Rack::Cache::CacheControl.new(headers[:cache_control])['max-age'] if headers[:cache_control]
-      max_age ||= Time.parse(headers[:expires]) - Time.parse(headers[:date]) if headers[:expires]
-      return unless max_age
-
       age = Time.now.utc - Time.parse(headers[:date])
-      max_age.to_i - age.to_i
+
+      if cache_control['max-age']
+        cache_control['max-age'].to_i - age.to_i
+      elsif headers[:expires]
+        Time.parse(headers[:expires]).to_i - Time.now.utc.to_i
+      end
+    end
+
+    def cache_control
+      @cache_control ||= Rack::Cache::CacheControl.new(headers[:cache_control])
     end
 
     def cache_control_private?
-      Rack::Cache::CacheControl.new(headers[:cache_control])["private"]
+      cache_control["private"]
     end
 
     def to_hash

--- a/lib/gds_api/response.rb
+++ b/lib/gds_api/response.rb
@@ -66,6 +66,10 @@ module GdsApi
       max_age.to_i - age.to_i
     end
 
+    def cache_control_private?
+      Rack::Cache::CacheControl.new(headers[:cache_control])["private"]
+    end
+
     def to_hash
       @parsed ||= transform_parsed(JSON.parse(@http_response.body))
     end

--- a/test/json_client_test.rb
+++ b/test/json_client_test.rb
@@ -247,6 +247,25 @@ class JsonClientTest < MiniTest::Spec
     end
   end
 
+  def test_does_not_cache_responses_with_cache_control_private
+    url = "http://some.endpoint/private.json"
+    result = {"foo" => "bar"}
+    stub_request(:get, url).to_return(
+      :body => JSON.dump(result),
+      :status => 200,
+      :headers => { "Cache-Control" => "max-age=600, private" }
+    )
+
+    response_a = GdsApi::JsonClient.new.get_json(url)
+
+    Timecop.travel( 7 * 60 - 30) do # now + 6 mins 30 secs
+      response_b = GdsApi::JsonClient.new.get_json(url)
+
+      assert_requested :get, url, times: 2
+      assert_equal response_a.to_hash, response_b.to_hash
+    end
+  end
+
   def test_should_respect_cache_control_headers_with_no_cache_and_max_age
     url = "http://some.endpoint/no_cache_and_max_age.json"
     result = {"foo" => "bar"}

--- a/test/json_client_test.rb
+++ b/test/json_client_test.rb
@@ -266,6 +266,25 @@ class JsonClientTest < MiniTest::Spec
     end
   end
 
+  def test_does_not_cache_responses_with_cache_control_no_store
+    url = "http://some.endpoint/private.json"
+    result = {"foo" => "bar"}
+    stub_request(:get, url).to_return(
+      :body => JSON.dump(result),
+      :status => 200,
+      :headers => { "Cache-Control" => "max-age=600, no-store" }
+    )
+
+    response_a = GdsApi::JsonClient.new.get_json(url)
+
+    Timecop.travel( 7 * 60 - 30) do # now + 6 mins 30 secs
+      response_b = GdsApi::JsonClient.new.get_json(url)
+
+      assert_requested :get, url, times: 2
+      assert_equal response_a.to_hash, response_b.to_hash
+    end
+  end
+
   def test_should_respect_cache_control_headers_with_no_cache_and_max_age
     url = "http://some.endpoint/no_cache_and_max_age.json"
     result = {"foo" => "bar"}

--- a/test/response_test.rb
+++ b/test/response_test.rb
@@ -22,6 +22,26 @@ describe GdsApi::Response do
     end
   end
 
+  describe ".cache_control_private?" do
+    it "returns true if the response contains a cache-control private header" do
+      headers = { :cache_control => 'max-age=5, private' }
+
+      mock_http_response = stub(:body => "{}", :code => 200, :headers => headers)
+      response = GdsApi::Response.new(mock_http_response)
+
+      assert response.cache_control_private?
+    end
+
+    it "returns false if the response does not contain a cache-control private header" do
+      headers = { :cache_control => 'max-age=5, public' }
+
+      mock_http_response = stub(:body => "{}", :code => 200, :headers => headers)
+      response = GdsApi::Response.new(mock_http_response)
+
+      refute response.cache_control_private?
+    end
+  end
+
   describe ".expires_at" do
     it "should be calculated from cache-control max-age" do
       Timecop.freeze(Time.parse("15:00")) do

--- a/test/response_test.rb
+++ b/test/response_test.rb
@@ -22,26 +22,6 @@ describe GdsApi::Response do
     end
   end
 
-  describe ".cache_control_private?" do
-    it "returns true if the response contains a cache-control private header" do
-      headers = { :cache_control => 'max-age=5, private' }
-
-      mock_http_response = stub(:body => "{}", :code => 200, :headers => headers)
-      response = GdsApi::Response.new(mock_http_response)
-
-      assert response.cache_control_private?
-    end
-
-    it "returns false if the response does not contain a cache-control private header" do
-      headers = { :cache_control => 'max-age=5, public' }
-
-      mock_http_response = stub(:body => "{}", :code => 200, :headers => headers)
-      response = GdsApi::Response.new(mock_http_response)
-
-      refute response.cache_control_private?
-    end
-  end
-
   describe ".expires_at" do
     it "should be calculated from cache-control max-age" do
       Timecop.freeze(Time.parse("15:00")) do


### PR DESCRIPTION
This updates gds-api-adapters to **not** cache responses that have cache-control "private" and "no-store" directives. It also updates `GdsApi::Response` with a `cache_control` method that exposes a `Rack::Cache::CacheControl` instance and, for further convenience, a  `cache_control_private?` method, making it easier for clients to know when a response is private and behave appropriately.

Trello: https://trello.com/c/oQvY66lk/239-better-cache-handling-in-gds-api-adapters