### PR TITLE
Bump to version 20.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
-# Unreleased
+# 20.0.0
 
 * remove collections-api client and helpers.
   The application has been retired.
+
+* Update content_store_has_item test helper to support better overriding of
+  Cache-Control headers in responses.
 
 # 19.2.0
 

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '19.2.0'
+  VERSION = '20.0.0'
 end


### PR DESCRIPTION
Includes removal of colllections-api adapter and updated content-store test
helpers.