### PR TITLE
Update User-Agent header

### DIFF
--- a/lib/gds_api/json_client.rb
+++ b/lib/gds_api/json_client.rb
@@ -54,7 +54,8 @@ module GdsApi
       {
         'Accept' => 'application/json',
         'Content-Type' => 'application/json',
-        'User-Agent' => "GDS Api Client v. #{GdsApi::VERSION}"
+        # GOVUK_APP_NAME is set for all apps by Puppet
+        'User-Agent' => "gds-api-adapters/#{GdsApi::VERSION} (#{ENV["GOVUK_APP_NAME"]})"
       }
     end
 

--- a/lib/gds_api/json_client.rb
+++ b/lib/gds_api/json_client.rb
@@ -50,11 +50,14 @@ module GdsApi
       @options = options
     end
 
-    DEFAULT_REQUEST_HEADERS = {
+    def self.default_request_headers
+      {
         'Accept' => 'application/json',
         'Content-Type' => 'application/json',
         'User-Agent' => "GDS Api Client v. #{GdsApi::VERSION}"
-    }
+      }
+    end
+
     DEFAULT_TIMEOUT_IN_SECONDS = 4
     DEFAULT_CACHE_SIZE = 100
     DEFAULT_CACHE_TTL = 15 * 60 # 15 minutes
@@ -232,7 +235,7 @@ module GdsApi
       method_params = {
         method: method,
         url: url,
-        headers: DEFAULT_REQUEST_HEADERS
+        headers: self.class.default_request_headers
       }
       method_params[:payload] = params
       method_params = with_auth_options(method_params)

--- a/lib/gds_api/test_helpers/licence_application.rb
+++ b/lib/gds_api/test_helpers/licence_application.rb
@@ -10,14 +10,14 @@ module GdsApi
       def licence_exists(identifier, licence)
         licence = licence.to_json unless licence.is_a?(String)
         stub_request(:get, "#{LICENCE_APPLICATION_ENDPOINT}/api/licence/#{identifier}").
-          with(headers: GdsApi::JsonClient::DEFAULT_REQUEST_HEADERS).
+          with(headers: GdsApi::JsonClient.default_request_headers).
           to_return(status: 200,
             body: licence)
       end
 
       def licence_does_not_exist(identifier)
         stub_request(:get, "#{LICENCE_APPLICATION_ENDPOINT}/api/licence/#{identifier}").
-          with(headers: GdsApi::JsonClient::DEFAULT_REQUEST_HEADERS).
+          with(headers: GdsApi::JsonClient.default_request_headers).
           to_return(status: 404,
             body: "{\"error\": [\"Unrecognised Licence Id: #{identifier}\"]}")
       end

--- a/lib/gds_api/test_helpers/publisher.rb
+++ b/lib/gds_api/test_helpers/publisher.rb
@@ -47,7 +47,7 @@ module GdsApi
         slug = input_details.delete('slug')
         uri = "#{PUBLISHER_ENDPOINT}/local_transactions/#{slug}/verify_snac.json"
         stub_request(:post, uri).with(:body => JSON.dump(input_details),
-          :headers => GdsApi::JsonClient::DEFAULT_REQUEST_HEADERS).
+          :headers => GdsApi::JsonClient.default_request_headers).
           to_return(:body => json, :status => 200)
       end
 

--- a/test/content_api_test.rb
+++ b/test/content_api_test.rb
@@ -484,7 +484,7 @@ describe GdsApi::ContentApi do
   describe "local authorities" do
     it "should return nil if no local authority found" do
       stub_request(:get, "#{@base_api_url}/local_authorities/does-not-exist.json").
-        with(:headers => GdsApi::JsonClient::DEFAULT_REQUEST_HEADERS).
+        with(:headers => GdsApi::JsonClient.default_request_headers).
         to_return(:status => 404,
                   :body => {"_response_info" => {"status" => "ok"}}.to_json,
                   :headers => {})
@@ -501,7 +501,7 @@ describe GdsApi::ContentApi do
       }
 
       stub_request(:get, "#{@base_api_url}/local_authorities/00CT.json").
-        with(:headers => GdsApi::JsonClient::DEFAULT_REQUEST_HEADERS).
+        with(:headers => GdsApi::JsonClient.default_request_headers).
         to_return(:status => 200,
                   :body => body_response.to_json,
                   :headers => {})
@@ -520,7 +520,7 @@ describe GdsApi::ContentApi do
       }.to_json
 
       stub_request(:get, "#{@base_api_url}/local_authorities.json?name=Swansalona").
-        with(:headers => GdsApi::JsonClient::DEFAULT_REQUEST_HEADERS).
+        with(:headers => GdsApi::JsonClient.default_request_headers).
         to_return(:status => 200,
                   :body => body_response,
                   :headers => {})
@@ -540,7 +540,7 @@ describe GdsApi::ContentApi do
       }.to_json
 
       stub_request(:get, "#{@base_api_url}/local_authorities.json?snac_code=SNACKS").
-        with(:headers => GdsApi::JsonClient::DEFAULT_REQUEST_HEADERS).
+        with(:headers => GdsApi::JsonClient.default_request_headers).
         to_return(:status => 200,
                   :body => body_response,
                   :headers => {})
@@ -569,7 +569,7 @@ describe GdsApi::ContentApi do
       }.to_json
 
       stub_request(:get, "#{@base_api_url}/local_authorities.json?name=Swans").
-        with(:headers => GdsApi::JsonClient::DEFAULT_REQUEST_HEADERS).
+        with(:headers => GdsApi::JsonClient.default_request_headers).
         to_return(:status => 200,
                   :body => body_response,
                   :headers => {})

--- a/test/imminence_api_test.rb
+++ b/test/imminence_api_test.rb
@@ -157,7 +157,7 @@ class ImminenceApiTest < MiniTest::Unit::TestCase
 EOS
 
     stub_request(:get, "#{ROOT}/places/test.kml").
-      with(headers: GdsApi::JsonClient::DEFAULT_REQUEST_HEADERS).
+      with(headers: GdsApi::JsonClient.default_request_headers).
       to_return(status: 200, body: kml_body )
 
     response_body = api_client.places_kml("test")
@@ -176,7 +176,7 @@ EOS
     }
 
     stub_request(:get, "#{ROOT}/areas/WC2B%206SE.json").
-      with(headers: GdsApi::JsonClient::DEFAULT_REQUEST_HEADERS).
+      with(headers: GdsApi::JsonClient.default_request_headers).
       to_return(status: 200, body: results.to_json )
 
     response = api_client.areas_for_postcode("WC2B 6SE")
@@ -200,7 +200,7 @@ EOS
     }
 
     stub_request(:get, "#{ROOT}/areas/EUR.json").
-      with(headers: GdsApi::JsonClient::DEFAULT_REQUEST_HEADERS).
+      with(headers: GdsApi::JsonClient.default_request_headers).
       to_return(status: 200, body: results.to_json )
 
     response = api_client.areas_for_type("EUR")

--- a/test/json_client_test.rb
+++ b/test/json_client_test.rb
@@ -625,7 +625,7 @@ class JsonClientTest < MiniTest::Spec
 
   def test_client_can_use_bearer_token
     client = GdsApi::JsonClient.new(bearer_token: 'SOME_BEARER_TOKEN')
-    expected_headers = GdsApi::JsonClient::DEFAULT_REQUEST_HEADERS.
+    expected_headers = GdsApi::JsonClient.default_request_headers.
       merge('Authorization' => 'Bearer SOME_BEARER_TOKEN')
 
     stub_request(:put, "http://some.other.endpoint/some.json").

--- a/test/json_client_test.rb
+++ b/test/json_client_test.rb
@@ -789,4 +789,20 @@ class JsonClientTest < MiniTest::Spec
       GdsApi::JsonClient.new(:timeout => -1)
     end
   end
+
+  def test_should_add_user_agent_using_env
+    previous_govuk_app_name = ENV['GOVUK_APP_NAME']
+    ENV['GOVUK_APP_NAME'] = "api-tests"
+
+    url = "http://some.other.endpoint/some.json"
+    stub_request(:get, url).to_return(:status => 200)
+
+    GdsApi::JsonClient.new.get_json(url)
+
+    assert_requested(:get, %r{/some.json}) do |request|
+      request.headers["User-Agent"] == "gds-api-adapters/#{GdsApi::VERSION} (api-tests)"
+    end
+  ensure
+    ENV['GOVUK_APP_NAME'] = previous_govuk_app_name
+  end
 end

--- a/test/licence_application_api_test.rb
+++ b/test/licence_application_api_test.rb
@@ -19,7 +19,7 @@ class LicenceApplicationApiTest < MiniTest::Unit::TestCase
 
   def test_should_return_list_of_licences
     stub_request(:get, "#{@core_url}/api/licences").
-      with(headers: GdsApi::JsonClient::DEFAULT_REQUEST_HEADERS).
+      with(headers: GdsApi::JsonClient.default_request_headers).
       to_return(:status => 200,
                 :body => <<-EOS
 [
@@ -59,7 +59,7 @@ EOS
 
   def test_should_return_error_message_if_licences_collection_not_found
     stub_request(:get, "#{@core_url}/api/licences").
-      with(headers: GdsApi::JsonClient::DEFAULT_REQUEST_HEADERS).
+      with(headers: GdsApi::JsonClient.default_request_headers).
       to_return(status: 404,
         body: "{\"error\": \"Error\"}")
 
@@ -104,7 +104,7 @@ EOS
 
   def test_should_return_error_message_to_pick_a_relevant_snac_code_for_the_provided_licence_id
     stub_request(:get, "#{@core_url}/api/licence/590001/sw10").
-      with(headers: GdsApi::JsonClient::DEFAULT_REQUEST_HEADERS).
+      with(headers: GdsApi::JsonClient.default_request_headers).
       to_return(status: 404,
                 body: "{\"error\": \"No authorities found for the licence 590001 and for the snacCode sw10\"}")
 

--- a/test/publisher_api_test.rb
+++ b/test/publisher_api_test.rb
@@ -102,7 +102,7 @@ describe GdsApi::Publisher do
 
   it "should be able to retrieve local transaction details" do
     stub_request(:post, "#{PUBLISHER_ENDPOINT}/local_transactions/fake-transaction/verify_snac.json").
-      with(:body => "{\"snac_codes\":[12345]}", :headers => GdsApi::JsonClient::DEFAULT_REQUEST_HEADERS).
+      with(:body => "{\"snac_codes\":[12345]}", :headers => GdsApi::JsonClient.default_request_headers).
       to_return(:status => 200, :body => '{"snac": "12345"}', :headers => {})
     assert_equal '12345', api.council_for_slug('fake-transaction', [12345])
   end


### PR DESCRIPTION
Previously included the version, now includes the
version and the originating app name.

The app name ENV var is set by Puppet for all
applications.

https://trello.com/c/zVGpH4oP/246-add-user-agent-tracking-to-gds-api-adapters