### PR TITLE
Remove stray collections-api require.

### DIFF
--- a/lib/gds_api/helpers.rb
+++ b/lib/gds_api/helpers.rb
@@ -1,6 +1,5 @@
 require 'gds_api/asset_manager'
 require 'gds_api/business_support_api'
-require 'gds_api/collections_api'
 require 'gds_api/content_api'
 require 'gds_api/content_register'
 require 'gds_api/content_store'


### PR DESCRIPTION
This was missed in #322.  The referenced file no longer exists, so this
currently breaks things.