### PR TITLE
Fix hash key in content-store helper.

### DIFF
--- a/lib/gds_api/test_helpers/content_store.rb
+++ b/lib/gds_api/test_helpers/content_store.rb
@@ -41,7 +41,7 @@ module GdsApi
       end
 
       def content_item_for_base_path(base_path)
-        super.merge({ base_path: base_path })
+        super.merge({ "base_path" => base_path })
       end
     end
   end


### PR DESCRIPTION
Hashes returned from the content-store client have keys that are
strings. This test helper was adding the base_path with a symbol key.
Updating this makes it consistent with what's returned from the API
client.