### PR TITLE
Remove support for deprecated contentapi path

### DIFF
--- a/lib/gds_api/content_api.rb
+++ b/lib/gds_api/content_api.rb
@@ -52,13 +52,12 @@ class GdsApi::ContentApi < GdsApi::Base
   end
 
   def tag(tag, tag_type=nil)
-    url = "#{base_url}/tags"
-
-    if tag_type
-      url << "/#{CGI.escape(tag_type)}"
+    if tag_type.nil?
+      raise "Requests for tags without a tag_type are no longer supported. You probably want a tag_type of 'section'. See https://github.com/alphagov/govuk_content_api/blob/f4c0102a1ae4970be6a440707b89798442f768b9/govuk_content_api.rb#L241-L250"
     end
 
-    get_json("#{url}/#{CGI.escape(tag)}.json")
+    url = [base_url, "tags", CGI.escape(tag_type), CGI.escape(tag)].join("/") + ".json"
+    get_json(url)
   end
 
   def with_tag(tag, tag_type=nil, options={})

--- a/lib/gds_api/test_helpers/content_api.rb
+++ b/lib/gds_api/test_helpers/content_api.rb
@@ -62,10 +62,6 @@ module GdsApi
 
         urls = ["#{CONTENT_API_ENDPOINT}/tags/#{CGI.escape(tag_type)}/#{CGI.escape(tag[:slug])}.json"]
 
-        if tag_type == "section"
-          urls << "#{CONTENT_API_ENDPOINT}/tags/#{CGI.escape(tag[:slug])}.json"
-        end
-
         urls.each do |url|
           stub_request(:get, url).to_return(status: 200, body: body.to_json, headers: {})
         end
@@ -79,10 +75,6 @@ module GdsApi
         }
 
         urls = ["#{CONTENT_API_ENDPOINT}/tags/#{CGI.escape(tag_type)}/#{CGI.escape(slug)}.json"]
-
-        if tag_type == "section"
-          urls << "#{CONTENT_API_ENDPOINT}/tags/#{CGI.escape(slug)}.json"
-        end
 
         urls.each do |url|
           stub_request(:get, url).to_return(status: 404, body: body.to_json, headers: {})

--- a/test/content_api_test.rb
+++ b/test/content_api_test.rb
@@ -364,7 +364,7 @@ describe GdsApi::ContentApi do
 
     it "returns tag information for a section" do
       content_api_has_section("crime-and-justice")
-      response = @api.tag("crime-and-justice")
+      response = @api.tag("crime-and-justice", "section")
 
       assert_equal "Crime and justice", response["title"]
     end


### PR DESCRIPTION
This has been deprecated since:
https://github.com/alphagov/govuk_content_api/commit/5361729cd9adb4fe8ba4d94d6e428b6fc8fc8465

Using grep and looking at the user agent in the logs for contentapi in
production, the only place I was able to find this being used was in Whitehall
in the code for building breadcrumbs. We should be able to switch this to
specify the tag_type as it will always be looking for tags of type "section".