### PR TITLE
Raise specific error on 404 in content-store client.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Raise specific error on 404 in content-store client.
+
 # 21.0.0
 
 * Using GdsApi::ContentApi#tag without the second parameter for tag type will

--- a/lib/gds_api/content_store.rb
+++ b/lib/gds_api/content_store.rb
@@ -3,12 +3,20 @@ require_relative 'exceptions'
 
 class GdsApi::ContentStore < GdsApi::Base
 
+  class ItemNotFound < GdsApi::HTTPNotFound
+    def self.build_from(http_error)
+      new(http_error.code, http_error.message, http_error.error_details)
+    end
+  end
+
   def content_item(base_path)
     get_json(content_item_url(base_path))
   end
 
   def content_item!(base_path)
     get_json!(content_item_url(base_path))
+  rescue GdsApi::HTTPNotFound => e
+    raise ItemNotFound.build_from(e)
   end
 
   private

--- a/test/content_store_test.rb
+++ b/test/content_store_test.rb
@@ -10,12 +10,35 @@ describe GdsApi::ContentStore do
     @api = GdsApi::ContentStore.new(@base_api_url)
   end
 
-  describe "item" do
+  describe "content_item" do
     it "should return the item" do
       base_path = "/test-from-content-store"
       content_store_has_item(base_path)
       response = @api.content_item(base_path)
       assert_equal base_path, response["base_path"]
+    end
+
+    it "should return nil if the item doesn't exist" do
+      content_store_does_not_have_item("/non-existent")
+      assert_nil @api.content_item("/non-existent")
+    end
+  end
+
+  describe "content_item!" do
+    it "should return the item" do
+      base_path = "/test-from-content-store"
+      content_store_has_item(base_path)
+      response = @api.content_item!(base_path)
+      assert_equal base_path, response["base_path"]
+    end
+
+    it "should raise if the item doesn't exist" do
+      content_store_does_not_have_item("/non-existent")
+      e = assert_raises GdsApi::ContentStore::ItemNotFound do
+        @api.content_item!("/non-existent")
+      end
+      assert_equal 404, e.code
+      assert_equal "url: #{@base_api_url}/content/non-existent", e.message.strip
     end
   end
 end


### PR DESCRIPTION
In order to allow this to be rescued in controllers without also
rescuing 404s from other API clients. Because content-store is the
primary source of information about what is available at a given path,
it makes sense to pass on 404s from content-store, whereas it may not
for other API clients.

Trello: https://trello.com/c/0KVM0tDC