### PR TITLE
Bump to 22.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-# Unreleased
+# 22.0.0
+
+* Remove `FinderAPI` and `FinderSchema` classes.
+  Finder API has been retired and these are no longer used.
 
 * Raise specific error on 404 in content-store client.
 

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '21.0.0'
+  VERSION = '22.0.0'
 end


### PR DESCRIPTION
Summary of changes:

* Remove `FinderAPI` and `FinderSchema` classes.
  Finder API has been retired and these are no longer used.

* Raise specific error on 404 in content-store client.