### PR TITLE
Issue 23.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+# 23.0.0
 
 * Remove `GdsApi::Rummager#search`. The `/search` endpoint was removed
   from rummager in favor of `/unified_search`.

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '22.0.0'
+  VERSION = '23.0.0'
 end


### PR DESCRIPTION
removal of the rummager `#search` method is a backward-incompatible
api change.