### PR TITLE
Add special route publisher under PublishingApi.

### DIFF
--- a/lib/gds_api/publishing_api/special_route_publisher.rb
+++ b/lib/gds_api/publishing_api/special_route_publisher.rb
@@ -1,0 +1,36 @@
+require "gds_api/publishing_api"
+
+module GdsApi
+  class PublishingApi < GdsApi::Base
+    class SpecialRoutePublisher
+      def initialize(options = {})
+        @logger = options[:logger] || GdsApi::Base.logger
+        @publishing_api = options[:publishing_api] || GdsApi::PublishingApi.new(Plek.find("publishing-api"))
+      end
+
+      def publish(options)
+        logger.info("Publishing #{options.fetch(:type)} route #{options.fetch(:base_path)}, routing to #{options.fetch(:rendering_app)}")
+
+        publishing_api.put_content_item(options.fetch(:base_path), {
+          content_id: options.fetch(:content_id),
+          format: "special_route",
+          title: options.fetch(:title),
+          description: options[:description] || "",
+          routes: [
+            {
+              path: options.fetch(:base_path),
+              type: options.fetch(:type),
+            }
+          ],
+          publishing_app: options.fetch(:publishing_app),
+          rendering_app: options.fetch(:rendering_app),
+          update_type: "major",
+          public_updated_at: (Time.respond_to?(:zone) ? Time.zone.try(:now) : Time.now).iso8601,
+        })
+      end
+
+    private
+      attr_reader :logger, :publishing_api
+    end
+  end
+end

--- a/test/publishing_api/special_route_publisher_test.rb
+++ b/test/publishing_api/special_route_publisher_test.rb
@@ -1,0 +1,46 @@
+require 'test_helper'
+require "gds_api/publishing_api/special_route_publisher"
+
+describe GdsApi::PublishingApi::SpecialRoutePublisher do
+  let(:publishing_api) {
+    stub(:publishing_api)
+  }
+
+  let(:publisher) {
+    GdsApi::PublishingApi::SpecialRoutePublisher.new(publishing_api: publishing_api)
+  }
+
+  describe ".publish" do
+    it "publishes the special routes" do
+      publishing_api.expects(:put_content_item).with(
+        "/favicon.ico",
+        {
+          content_id: "a-content-id-of-sorts",
+          format: "special_route",
+          title: "A title",
+          description: "A description",
+          routes: [
+            {
+              path: "/favicon.ico",
+              type: "exact",
+            }
+          ],
+          publishing_app: "static-publisher",
+          rendering_app: "static-frontend",
+          update_type: "major",
+          public_updated_at: Time.now.iso8601,
+        }
+      )
+
+      publisher.publish(
+        content_id: "a-content-id-of-sorts",
+        title: "A title",
+        description: "A description",
+        base_path: "/favicon.ico",
+        type: "exact",
+        publishing_app: "static-publisher",
+        rendering_app: "static-frontend",
+      )
+    end
+  end
+end


### PR DESCRIPTION
This will be used in several apps for registering
"special" routes like `/government` or `/robots.txt`

See https://trello.com/c/blLdEZN5/292-make-apps-register-special-routes-on-deploy