### PR TITLE
Fix `helpers.rb` after finder api removal

### DIFF
--- a/lib/gds_api/helpers.rb
+++ b/lib/gds_api/helpers.rb
@@ -10,7 +10,6 @@ require 'gds_api/need_api'
 require 'gds_api/panopticon'
 require 'gds_api/publisher'
 require 'gds_api/worldwide'
-require 'gds_api/finder_api'
 require 'gds_api/email_alert_api'
 
 module GdsApi

--- a/test/helpers_test.rb
+++ b/test/helpers_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+require 'gds_api/helpers'
+
+describe GdsApi::Helpers do
+  class TestDouble
+    include GdsApi::Helpers
+  end
+
+  it "should define helpers for the various apis" do
+    test_with_helpers = TestDouble.new
+
+    refute_nil test_with_helpers.asset_manager_api
+    refute_nil test_with_helpers.business_support_api
+    refute_nil test_with_helpers.content_api
+    refute_nil test_with_helpers.content_register
+    refute_nil test_with_helpers.content_store
+    refute_nil test_with_helpers.fact_cave_api
+    refute_nil test_with_helpers.publisher_api
+    refute_nil test_with_helpers.imminence_api
+    refute_nil test_with_helpers.licence_application_api
+    refute_nil test_with_helpers.need_api
+    refute_nil test_with_helpers.panopticon_api
+    refute_nil test_with_helpers.worldwide_api
+    refute_nil test_with_helpers.email_alert_api
+  end
+end


### PR DESCRIPTION
The removal of `finder_api` in 2715160c539 did not remove the `require`
line from `helpers.rb`, so the file raises an error when required.

There were no tests which load this file, so this error was not picked
up.

I've removed the offending require line and added a very simple test of
the `helpers.rb` so that such errors are picked up in the future.