### PR TITLE
Fix timezone handling

### DIFF
--- a/lib/gds_api/publishing_api/special_route_publisher.rb
+++ b/lib/gds_api/publishing_api/special_route_publisher.rb
@@ -1,4 +1,5 @@
 require "gds_api/publishing_api"
+require "time"
 
 module GdsApi
   class PublishingApi < GdsApi::Base
@@ -25,12 +26,16 @@ module GdsApi
           publishing_app: options.fetch(:publishing_app),
           rendering_app: options.fetch(:rendering_app),
           update_type: "major",
-          public_updated_at: (Time.respond_to?(:zone) ? Time.zone.try(:now) : Time.now).iso8601,
+          public_updated_at: time.now.iso8601,
         })
       end
 
     private
       attr_reader :logger, :publishing_api
+
+      def time
+        (Time.respond_to?(:zone) && Time.zone) || Time
+      end
     end
   end
 end

--- a/test/publishing_api/special_route_publisher_test.rb
+++ b/test/publishing_api/special_route_publisher_test.rb
@@ -3,44 +3,77 @@ require "gds_api/publishing_api/special_route_publisher"
 
 describe GdsApi::PublishingApi::SpecialRoutePublisher do
   let(:publishing_api) {
-    stub(:publishing_api)
+    stub(:publishing_api, put_content_item: nil)
   }
 
   let(:publisher) {
     GdsApi::PublishingApi::SpecialRoutePublisher.new(publishing_api: publishing_api)
   }
 
+  let(:special_route) {
+    {
+      content_id: "a-content-id-of-sorts",
+      title: "A title",
+      description: "A description",
+      base_path: "/favicon.ico",
+      type: "exact",
+      publishing_app: "static-publisher",
+      rendering_app: "static-frontend",
+    }
+  }
+
   describe ".publish" do
     it "publishes the special routes" do
-      publishing_api.expects(:put_content_item).with(
-        "/favicon.ico",
-        {
-          content_id: "a-content-id-of-sorts",
-          format: "special_route",
-          title: "A title",
-          description: "A description",
-          routes: [
-            {
-              path: "/favicon.ico",
-              type: "exact",
-            }
-          ],
-          publishing_app: "static-publisher",
-          rendering_app: "static-frontend",
-          update_type: "major",
-          public_updated_at: Time.now.iso8601,
-        }
-      )
+      Timecop.freeze(Time.now) do
+        publishing_api.expects(:put_content_item).with(
+          special_route[:base_path],
+          {
+            content_id: special_route[:content_id],
+            format: "special_route",
+            title: special_route[:title],
+            description: special_route[:description],
+            routes: [
+              {
+                path: special_route[:base_path],
+                type: special_route[:type],
+              }
+            ],
+            publishing_app: special_route[:publishing_app],
+            rendering_app: special_route[:rendering_app],
+            update_type: "major",
+            public_updated_at: Time.now.iso8601,
+          }
+        )
 
-      publisher.publish(
-        content_id: "a-content-id-of-sorts",
-        title: "A title",
-        description: "A description",
-        base_path: "/favicon.ico",
-        type: "exact",
-        publishing_app: "static-publisher",
-        rendering_app: "static-frontend",
-      )
+        publisher.publish(special_route)
+      end
+    end
+
+    it "is robust to Time.zone returning nil" do
+      Timecop.freeze(Time.now) do
+        Time.stubs(:zone).returns(nil)
+
+        publishing_api.expects(:put_content_item).with(
+          anything,
+          has_entries(public_updated_at: Time.now.iso8601)
+        )
+
+        publisher.publish(special_route)
+      end
+    end
+
+    it "uses Time.zone if available" do
+      Timecop.freeze(Time.now) do
+        time_in_zone = stub("Time in zone", now: Time.parse("2010-01-01 10:10:10 +04:00"))
+        Time.stubs(:zone).returns(time_in_zone)
+
+        publishing_api.expects(:put_content_item).with(
+          anything,
+          has_entries(public_updated_at: time_in_zone.now.iso8601)
+        )
+
+        publisher.publish(special_route)
+      end
     end
   end
 end


### PR DESCRIPTION
if `Time.zone` returned `nil`, which unexpectedly does happen in some
circumstances, then the registration would crash.

This makes explicit the expected behaviour.

I've also changed the tests to use `Timecop` to freeze the system clock to
avoid possible intermit false failures in the tests (due to the clock
happening to roll over the 1 second boundary between the setting of the
expectation and the publishing of the special route).