### PR TITLE
Remove Rummager#organisations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Remove support for the `/organisations` endpoint on Rummager.
+
 # 23.2.2
 
 * Bugfix: `SpecialRoutePublisher` handles case where `Time.zone` returns `nil`

--- a/lib/gds_api/rummager.rb
+++ b/lib/gds_api/rummager.rb
@@ -15,10 +15,6 @@ module GdsApi
       get_json!(request_path)
     end
 
-    def organisations
-      get_json!("#{base_url}/organisations")
-    end
-
     def add_document(type, id, document)
       post_json!(
         documents_url,

--- a/test/rummager_test.rb
+++ b/test/rummager_test.rb
@@ -7,15 +7,6 @@ describe GdsApi::Rummager do
     stub_request(:get, /example.com\/unified_search/).to_return(body: "[]")
   end
 
-  # tests for #organisations
-
-  it "should request the list of organisations" do
-    stub_request(:get, /example.com\/organisations/).to_return(body: "{}")
-    GdsApi::Rummager.new("http://example.com").organisations
-
-    assert_requested :get, /organisations/
-  end
-
   # tests for #advanced_search
 
   it "#advanced_search should raise an exception if the service at the search URI returns a 500" do


### PR DESCRIPTION
This removes the Rummager endpoint for organisations.

The `/organisations` endpoint was used by the frontend application to render the select box of organisations. It was added in https://github.com/alphagov/rummager/pull/103 (May 2013).

Frontend stopped using the endpoint since moving to "Unified Search", and the call to rummager was removed in PR https://github.com/alphagov/frontend/pull/601.

PR: https://github.com/alphagov/rummager/pull/494