### PR TITLE
Release 24.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 24.0.0
+
 * Remove support for the `/organisations` endpoint on Rummager.
 
 # 23.2.2

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '23.2.2'
+  VERSION = '24.0.0'
 end


### PR DESCRIPTION
Major version because of removal of `Rummager#organisations` method.