### PR TITLE
`content_register_isnt_available` test helper

### DIFF
--- a/lib/gds_api/test_helpers/content_register.rb
+++ b/lib/gds_api/test_helpers/content_register.rb
@@ -19,6 +19,11 @@ module GdsApi
           to_return(body: entries.to_json, status: 200)
       end
 
+      def content_register_isnt_available
+        stub_request(:any, /#{CONTENT_REGISTER_ENDPOINT}\/.*/).
+          to_return(status: 503)
+      end
+
     private
 
       def content_register_entry_url_for(content_id)


### PR DESCRIPTION
Stubs requests to Content Register, returning 503.

Entirely copied from the `publishing_api_isnt_available` test helper (https://github.com/alphagov/gds-api-adapters/blob/master/lib/gds_api/test_helpers/publishing_api.rb#L89-L91).