### PR TITLE
Add a special route unpublisher

### DIFF
--- a/lib/gds_api/publishing_api/special_route_unpublisher.rb
+++ b/lib/gds_api/publishing_api/special_route_unpublisher.rb
@@ -1,0 +1,33 @@
+require "gds_api/publishing_api"
+
+module GdsApi
+  class PublishingApi < GdsApi::Base
+    class SpecialRouteUnpublisher
+      def initialize(options = {})
+        @logger = options[:logger] || GdsApi::Base.logger
+        @publishing_api = options[:publishing_api] || GdsApi::PublishingApi.new(Plek.find("publishing-api"))
+      end
+
+      def unpublish(options)
+        logger.info("Unpublishing #{options.fetch(:type)} route #{options.fetch(:base_path)}")
+
+        publishing_api.put_content_item(options.fetch(:base_path), {
+          content_id: options.fetch(:content_id),
+          format: "gone",
+          update_type: "major",
+          publishing_app: options.fetch(:publishing_app),
+          routes: [
+            {
+              path: options.fetch(:base_path),
+              type: options.fetch(:type),
+            }
+          ],
+        })
+      end
+
+    private
+      attr_reader :logger, :publishing_api
+
+    end
+  end
+end

--- a/test/publishing_api/special_route_unpublisher_test.rb
+++ b/test/publishing_api/special_route_unpublisher_test.rb
@@ -1,0 +1,48 @@
+require 'test_helper'
+require "gds_api/publishing_api/special_route_unpublisher"
+
+describe GdsApi::PublishingApi::SpecialRouteUnpublisher do
+  let(:publishing_api) {
+    stub(:publishing_api, put_content_item: nil)
+  }
+
+  let(:unpublisher) {
+    GdsApi::PublishingApi::SpecialRouteUnpublisher.new(publishing_api: publishing_api)
+  }
+
+  let(:special_route) {
+    {
+      content_id: "a-content-id-of-sorts",
+      base_path: "/favicon.ico",
+      type: "prefix",
+      publishing_app: "static-publisher",
+      routes: [
+        {path: "/favicon.ico", type: "exact"},
+      ],
+    }
+  }
+
+  describe ".publish" do
+    it "unpublishes the special routes" do
+
+      publishing_api.expects(:put_content_item).with(
+        special_route[:base_path],
+        {
+          content_id: special_route[:content_id],
+          format: "gone",
+          routes: [
+            {
+              path: special_route[:base_path],
+              type: special_route[:type],
+            }
+          ],
+          publishing_app: special_route[:publishing_app],
+          update_type: "major",
+        }
+      )
+
+      unpublisher.unpublish(special_route)
+
+    end
+  end
+end


### PR DESCRIPTION
As we have special routes on GOV.UK published with the
`SpecialRoutePublisher`, we may also want to unpublish those special
routes.

This commit adds a `SpecialRouteUnpublisher` which publishes a `gone`
route for a `base_path`. This follows the same logic as the
`SpecialRoutePublisher`.