### PR TITLE
Add panopticon support for `content_id`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Change the Panopticon Registerer adapter to support the `content_id` field.
+
 # 24.1.0
 
 * Add test helper `content_register_isnt_available`

--- a/lib/gds_api/panopticon/registerer.rb
+++ b/lib/gds_api/panopticon/registerer.rb
@@ -45,6 +45,8 @@ module GdsApi
           :indexable_content,
           :public_timestamp,
           :latest_change_note,
+
+          :content_id,
         ]
 
         deprecated_params = {

--- a/test/panopticon_registerer_test.rb
+++ b/test/panopticon_registerer_test.rb
@@ -69,6 +69,7 @@ describe GdsApi::Panopticon::Registerer do
       specialist_sectors: ["oil-and-gas/wells", "oil-and-gas/licensing"],
       public_timestamp: "2014-01-01T12:00:00+00:00",
       latest_change_note: 'Added more stubble',
+      content_id: 'f47b4fab-46fa-4020-97a2-3413a5d75402'
     )
 
     GdsApi::Panopticon::Registerer.new(
@@ -86,6 +87,7 @@ describe GdsApi::Panopticon::Registerer do
         specialist_sectors: ["oil-and-gas/wells", "oil-and-gas/licensing"],
         public_timestamp: DateTime.parse('2014-01-01 12:00:00 +00:00'),
         latest_change_note: 'Added more stubble',
+        content_id: 'f47b4fab-46fa-4020-97a2-3413a5d75402'
       )
     )
 


### PR DESCRIPTION
We want to use content IDs instead of slugs to represent items in curated
lists, so that things like slug changes don't break the linkage. In order to
do this, we need to allow Whitehall and other publishing apps to send items
with content IDs to Panopticon.

Part of:
https://trello.com/c/rmBoBPm9/290-ensure-that-all-content-in-publisher-has-a-content-id