### PR TITLE
Release 24.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 24.2.0
 
 * Change the Panopticon Registerer adapter to support the `content_id` field.
 

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '24.1.0'
+  VERSION = '24.2.0'
 end


### PR DESCRIPTION
* Change the Panopticon Registerer adapter to support the `content_id` field.