### PR TITLE
Add `HTTPConflict` exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Raise `HTTPConflict` exception for HTTP 409 status codes. 
+
 # 24.2.0
 
 * Change the Panopticon Registerer adapter to support the `content_id` field.

--- a/lib/gds_api/exceptions.rb
+++ b/lib/gds_api/exceptions.rb
@@ -36,6 +36,9 @@ module GdsApi
   class HTTPForbidden < HTTPClientError
   end
 
+  class HTTPConflict < HTTPClientError
+  end
+
   class NoBearerToken < BaseError; end
 
   module ExceptionHandling
@@ -60,6 +63,8 @@ module GdsApi
         GdsApi::HTTPNotFound.new(code, message, details)
       when 410
         GdsApi::HTTPGone.new(code, message, details)
+      when 409
+        GdsApi::HTTPConflict.new(code, message, details)
       when (400..499)
         GdsApi::HTTPClientError.new(code, message, details)
       when (500..599)

--- a/test/json_client_test.rb
+++ b/test/json_client_test.rb
@@ -392,6 +392,14 @@ class JsonClientTest < MiniTest::Spec
     end
   end
 
+  def test_get_should_raise_conflict_for_410
+    url = "http://some.endpoint/some.json"
+    stub_request(:delete, url).to_return(:body => "{}", :status => 409)
+    assert_raises GdsApi::HTTPConflict do
+      @client.delete_json!(url)
+    end
+  end
+
   def test_get_should_follow_permanent_redirect
     url = "http://some.endpoint/some.json"
     new_url = "http://some.endpoint/other.json"


### PR DESCRIPTION
HTTP 409 can be used by client to indicate that the issued request is conflicting with something else.

> The request could not be completed due to a conflict with the current state of the resource. This code is only allowed in situations where it is expected that the user might be able to resolve the conflict and resubmit the request.

To be used by panopticon (https://github.com/alphagov/panopticon/pull/292) and collections-publisher (https://github.com/alphagov/collections-publisher/pull/138) to tell the user that a tag can't be deleted because it still has documents tagged to it.

Trello: https://trello.com/c/ybdnGMhl