### PR TITLE
Release 24.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-* Raise `HTTPConflict` exception for HTTP 409 status codes. 
+# 24.3.0
+
+* Raise `HTTPConflict` exception for HTTP 409 status codes.
 
 # 24.2.0
 

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '24.2.0'
+  VERSION = '24.3.0'
 end


### PR DESCRIPTION
Adds "Raise `HTTPConflict` exception for HTTP 409 status codes."