### PR TITLE
Set both kinds of timeout in RestClient

### DIFF
--- a/lib/gds_api/json_client.rb
+++ b/lib/gds_api/json_client.rb
@@ -171,7 +171,8 @@ module GdsApi
     # parameters with timeouts included
     def with_timeout(method_params)
       method_params.merge(
-        timeout: options[:timeout] || DEFAULT_TIMEOUT_IN_SECONDS
+        timeout: options[:timeout] || DEFAULT_TIMEOUT_IN_SECONDS,
+        open_timeout: options[:timeout] || DEFAULT_TIMEOUT_IN_SECONDS,
       )
     end
 

--- a/test/json_client_test.rb
+++ b/test/json_client_test.rb
@@ -33,6 +33,14 @@ class JsonClientTest < MiniTest::Spec
     end
   end
 
+  def test_long_connections_timeout
+    url = "http://www.example.com/timeout.json"
+    stub_request(:get, url).to_raise(Net::OpenTimeout)
+    assert_raises GdsApi::TimedOutException do
+      @client.get_json(url)
+    end
+  end
+
   def test_get_should_raise_endpoint_not_found_if_connection_refused
     url = "http://some.endpoint/some.json"
     stub_request(:get, url).to_raise(Errno::ECONNREFUSED)

--- a/test/json_client_test.rb
+++ b/test/json_client_test.rb
@@ -35,7 +35,8 @@ class JsonClientTest < MiniTest::Spec
 
   def test_long_connections_timeout
     url = "http://www.example.com/timeout.json"
-    stub_request(:get, url).to_raise(Net::OpenTimeout)
+    exception = defined?(Net::OpenTimeout) ? Net::OpenTimeout : TimeoutError
+    stub_request(:get, url).to_raise(exception)
     assert_raises GdsApi::TimedOutException do
       @client.get_json(url)
     end


### PR DESCRIPTION
Setting `timeout` only sets the read timeout, which is the period
between a request being issued and receiving the response. We’ve had
issues with licensify in staging and new production where connecting to
the remote host waits for over a minute before erroring, so setting the
connection timeout will allow the request to fail faster.

The default timeout is 4 seconds, which seems reasonable for the
initial SYN/ACK cycle for a remote host.

In version 2.0.0 of RestClient (currently unreleased), both of these
timeouts will be set via the `timeout` variable, but can also be
individually set with `read_timeout` and `open_timeout`. Therefore,
setting `timeout` and `open_timeout` here is forward-compatible. The
change can be reverted once we upgrade to RestClient 2.0.0.

/cc @mattbostock @jennyd 