### PR TITLE
[FOR DISCUSSION:] Log API call times to Statsd

### DIFF
--- a/gds-api-adapters.gemspec
+++ b/gds-api-adapters.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'plek'
   s.add_dependency 'rack-cache'
   s.add_dependency 'rest-client', '~> 1.8.0'
+  s.add_dependency 'statsd-ruby', '1.2.1'
 
   s.add_development_dependency "minitest", "~> 3.4.0"
   s.add_development_dependency 'gem_publisher', '~> 1.5.0'

--- a/gds-api-adapters.gemspec
+++ b/gds-api-adapters.gemspec
@@ -17,23 +17,23 @@ Gem::Specification.new do |s|
   s.files        = Dir.glob("lib/**/*") + %w(README.md Rakefile)
   s.test_files   = Dir['test/**/*']
   s.require_path = 'lib'
-  s.add_dependency 'plek'
-  s.add_dependency 'null_logger'
   s.add_dependency 'link_header'
   s.add_dependency 'lrucache', '~> 0.1.1'
-  s.add_dependency 'rest-client', '~> 1.8.0'
+  s.add_dependency 'null_logger'
+  s.add_dependency 'plek'
   s.add_dependency 'rack-cache'
+  s.add_dependency 'rest-client', '~> 1.8.0'
 
-  s.add_development_dependency 'rdoc', '3.12'
-  s.add_development_dependency 'rake', '~> 0.9.2.2'
-  s.add_development_dependency 'webmock', '~> 1.19'
-  s.add_development_dependency 'mocha', '~> 0.12.4'
   s.add_development_dependency "minitest", "~> 3.4.0"
+  s.add_development_dependency 'gem_publisher', '~> 1.5.0'
+  s.add_development_dependency 'mocha', '~> 0.12.4'
+  s.add_development_dependency 'pry'
   s.add_development_dependency 'rack'
   s.add_development_dependency 'rack-test'
+  s.add_development_dependency 'rake', '~> 0.9.2.2'
+  s.add_development_dependency 'rdoc', '3.12'
   s.add_development_dependency 'simplecov', '~> 0.5.4'
   s.add_development_dependency 'simplecov-rcov'
-  s.add_development_dependency 'gem_publisher', '~> 1.5.0'
   s.add_development_dependency 'timecop', '~> 0.5.1'
-  s.add_development_dependency 'pry'
+  s.add_development_dependency 'webmock', '~> 1.19'
 end


### PR DESCRIPTION
Log the duration of API calls to statsd for each application, using
their hostname to distinguish between each application.

Although we already track request times in Nginx, it's hard to see where
those API calls originated from.

By logging call times in this way, we'll be able to see:

- call times by machine they originated from
- call times by application they originated from
- call times by application the API call is targetting

By combining these three dimensions, we should be able to build a useful
picture for troubleshooting misbehaving APIs, networking partitions and
back-pressure.

__Note: I haven't tested this yet as I'd like feedback on the implementation and as to how useful this is__.