### PR TITLE
Add publishing api contract tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ pkg/
 *.gem
 .bundle
 /spec/pacts
+/log

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ coverage/*
 pkg/
 *.gem
 .bundle
+/spec/pacts

--- a/gds-api-adapters.gemspec
+++ b/gds-api-adapters.gemspec
@@ -36,4 +36,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'gem_publisher', '~> 1.5.0'
   s.add_development_dependency 'timecop', '~> 0.5.1'
   s.add_development_dependency 'pry'
+  s.add_development_dependency 'pact'
+  s.add_development_dependency 'pact-consumer-minitest'
+
 end

--- a/gds-api-adapters.gemspec
+++ b/gds-api-adapters.gemspec
@@ -27,8 +27,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rdoc', '3.12'
   s.add_development_dependency 'rake', '~> 0.9.2.2'
   s.add_development_dependency 'webmock', '~> 1.19'
-  s.add_development_dependency 'mocha', '~> 0.12.4'
-  s.add_development_dependency "minitest", "~> 3.4.0"
+  s.add_development_dependency 'mocha'
+  s.add_development_dependency "minitest", "> 5.0.0"
   s.add_development_dependency 'rack'
   s.add_development_dependency 'rack-test'
   s.add_development_dependency 'simplecov', '~> 0.5.4'

--- a/lib/gds_api/publishing_api.rb
+++ b/lib/gds_api/publishing_api.rb
@@ -16,7 +16,9 @@ class GdsApi::PublishingApi < GdsApi::Base
   end
 
   def destroy_intent(base_path)
-    delete_json(intent_url(base_path))
+    delete_json!(intent_url(base_path))
+  rescue GdsApi::HTTPNotFound => e
+    e
   end
 
 

--- a/test/publishing_api_test.rb
+++ b/test/publishing_api_test.rb
@@ -105,7 +105,7 @@ describe GdsApi::PublishingApi do
       publish_intent = intent_for_base_path(base_path)
 
       publishing_api
-        .given("a publish intent exists in the live content store")
+        .given("a publish intent exists at /test-intent in the live content store")
         .upon_receiving("DELETE /publish-intent/:base_path")
         .with(
           method: :delete,

--- a/test/publishing_api_test.rb
+++ b/test/publishing_api_test.rb
@@ -18,7 +18,7 @@ describe GdsApi::PublishingApi do
 
       publishing_api
         .given("both content stores and url-arbiter empty")
-        .upon_receiving("PUT /content/:base_path")
+        .upon_receiving("a request to create a content item")
         .with(
           method: :put,
           path: "/content#{base_path}",
@@ -47,7 +47,7 @@ describe GdsApi::PublishingApi do
 
       publishing_api
         .given("both content stores and url-arbiter empty")
-        .upon_receiving("PUT /draft-content/:base_path")
+        .upon_receiving("a request to create a draft content item")
         .with(
           method: :put,
           path: "/draft-content#{base_path}",
@@ -76,7 +76,7 @@ describe GdsApi::PublishingApi do
 
       publishing_api
         .given("both content stores and url-arbiter empty")
-        .upon_receiving("PUT /publish-intent/:base_path")
+        .upon_receiving("a request to create a publish intent")
         .with(
           method: :put,
           path: "/publish-intent#{base_path}",
@@ -106,7 +106,7 @@ describe GdsApi::PublishingApi do
 
       publishing_api
         .given("a publish intent exists at /test-intent in the live content store")
-        .upon_receiving("DELETE /publish-intent/:base_path")
+        .upon_receiving("a request to delete a publish intent")
         .with(
           method: :delete,
           path: "/publish-intent#{base_path}",
@@ -130,7 +130,7 @@ describe GdsApi::PublishingApi do
 
       publishing_api
         .given("both content stores and url-arbiter empty")
-        .upon_receiving("DELETE /publish-intent/:base_path")
+        .upon_receiving("a request to delete a publish intent")
         .with(
           method: :delete,
           path: "/publish-intent#{base_path}",

--- a/test/publishing_api_test.rb
+++ b/test/publishing_api_test.rb
@@ -24,14 +24,14 @@ describe GdsApi::PublishingApi do
           path: "/content#{base_path}",
           body: content_item,
           headers: {
-            "Content-type" => "application/json"
+            "Content-Type" => "application/json"
           },
         )
         .will_respond_with(
           status: 200,
           body: content_item,
           headers: {
-            "Content-type" => "application/json"
+            "Content-Type" => "application/json; charset=utf-8"
           },
         )
 
@@ -53,14 +53,14 @@ describe GdsApi::PublishingApi do
           path: "/draft-content#{base_path}",
           body: content_item,
           headers: {
-            "Content-type" => "application/json"
+            "Content-Type" => "application/json"
           },
         )
         .will_respond_with(
           status: 200,
           body: content_item,
           headers: {
-            "Content-type" => "application/json"
+            "Content-Type" => "application/json; charset=utf-8"
           },
         )
 
@@ -82,14 +82,14 @@ describe GdsApi::PublishingApi do
           path: "/publish-intent#{base_path}",
           body: publish_intent,
           headers: {
-            "Content-type" => "application/json"
+            "Content-Type" => "application/json"
           },
         )
         .will_respond_with(
           status: 200,
           body: publish_intent,
           headers: {
-            "Content-type" => "application/json"
+            "Content-Type" => "application/json; charset=utf-8"
           },
         )
 
@@ -115,7 +115,7 @@ describe GdsApi::PublishingApi do
           status: 200,
           body: "{}",
           headers: {
-            "Content-type" => "application/json"
+            "Content-Type" => "application/json; charset=utf-8"
           }
         )
 
@@ -139,7 +139,7 @@ describe GdsApi::PublishingApi do
           status: 404,
           body: "{}",
           headers: {
-            "Content-type" => "application/json"
+            "Content-Type" => "application/json; charset=utf-8"
           }
         )
 

--- a/test/publishing_api_test.rb
+++ b/test/publishing_api_test.rb
@@ -14,7 +14,7 @@ describe GdsApi::PublishingApi do
   describe "#put_content_item" do
     it "responds with 200 OK if the entry is valid" do
       base_path = "/test-content-item"
-      content_item = content_item_for_base_path(base_path)
+      content_item = content_item_for_base_path(base_path).merge("update_type" => "major")
 
       publishing_api
         .given("both content stores and url-arbiter empty")
@@ -43,7 +43,7 @@ describe GdsApi::PublishingApi do
   describe "#put_draft_content_item" do
     it "responds with 200 OK if the entry is valid" do
       base_path = "/test-draft-content-item"
-      content_item = content_item_for_base_path(base_path)
+      content_item = content_item_for_base_path(base_path).merge("update_type" => "major")
 
       publishing_api
         .given("both content stores and url-arbiter empty")
@@ -64,7 +64,7 @@ describe GdsApi::PublishingApi do
           },
         )
 
-      response = @api_client.put_draft_content_item(base_path, content_item_for_base_path(base_path))
+      response = @api_client.put_draft_content_item(base_path, content_item)
       assert_equal 200, response.code
     end
   end

--- a/test/publishing_api_test.rb
+++ b/test/publishing_api_test.rb
@@ -87,7 +87,7 @@ describe GdsApi::PublishingApi do
         )
         .will_respond_with(
           status: 200,
-          body: publish_intent,
+          body: {},
           headers: {
             "Content-Type" => "application/json; charset=utf-8"
           },
@@ -113,7 +113,7 @@ describe GdsApi::PublishingApi do
         )
         .will_respond_with(
           status: 200,
-          body: "{}",
+          body: {},
           headers: {
             "Content-Type" => "application/json; charset=utf-8"
           }
@@ -137,7 +137,7 @@ describe GdsApi::PublishingApi do
         )
         .will_respond_with(
           status: 404,
-          body: "{}",
+          body: {},
           headers: {
             "Content-Type" => "application/json; charset=utf-8"
           }

--- a/test/publishing_api_test.rb
+++ b/test/publishing_api_test.rb
@@ -4,44 +4,123 @@ require 'gds_api/test_helpers/publishing_api'
 
 describe GdsApi::PublishingApi do
   include GdsApi::TestHelpers::PublishingApi
+  include PactTest
 
   before do
     @base_api_url = Plek.current.find("publishing-api")
-    @api = GdsApi::PublishingApi.new(@base_api_url)
+    @api_client = GdsApi::PublishingApi.new('http://localhost:3093')
   end
 
-  describe "item" do
-    it "should create the item" do
+  describe "#put_content_item" do
+    it "responds with 200 OK if the entry is valid" do
       base_path = "/test-content-item"
-      stub_publishing_api_put_item(base_path)
-      response = @api.put_content_item(base_path, content_item_for_base_path(base_path))
-      assert_equal 201, response.code
+      content_item = content_item_for_base_path(base_path)
+
+      publishing_api
+        .given("both content stores and url-arbiter empty")
+        .upon_receiving("PUT /content/:base_path")
+        .with(
+          method: :put,
+          path: "/content#{base_path}",
+          body: content_item,
+          headers: {
+            "Content-type" => "application/json"
+          },
+        )
+        .will_respond_with(
+          status: 200,
+          body: content_item,
+          headers: {
+            "Content-type" => "application/json"
+          },
+        )
+
+      response = @api_client.put_content_item(base_path, content_item)
+      assert_equal 200, response.code
     end
   end
 
-  describe "draft item" do
-    it "should create the draft item" do
+  describe "#put_draft_content_item" do
+    it "responds with 200 OK if the entry is valid" do
       base_path = "/test-draft-content-item"
-      stub_publishing_api_put_draft_item(base_path)
+      content_item = content_item_for_base_path(base_path)
 
-      response = @api.put_draft_content_item(base_path, content_item_for_base_path(base_path))
-      assert_equal 201, response.code
+      publishing_api
+        .given("both content stores and url-arbiter empty")
+        .upon_receiving("PUT /draft-content/:base_path")
+        .with(
+          method: :put,
+          path: "/draft-content#{base_path}",
+          body: content_item,
+          headers: {
+            "Content-type" => "application/json"
+          },
+        )
+        .will_respond_with(
+          status: 200,
+          body: content_item,
+          headers: {
+            "Content-type" => "application/json"
+          },
+        )
+
+      response = @api_client.put_draft_content_item(base_path, content_item_for_base_path(base_path))
+      assert_equal 200, response.code
     end
   end
 
-  describe "intent" do
-    it "should create the intent" do
+  describe "#put_intent" do
+    it "responds with 200 OK if publish intent is valid" do
       base_path = "/test-intent"
-      stub_publishing_api_put_intent(base_path)
-      response = @api.put_intent(base_path, intent_for_base_path(base_path))
-      assert_equal 201, response.code
-    end
+      publish_intent = intent_for_base_path(base_path)
 
-    it "should delete an intent" do
+      publishing_api
+        .given("both content stores and url-arbiter empty")
+        .upon_receiving("PUT /publish-intent/:base_path")
+        .with(
+          method: :put,
+          path: "/publish-intent#{base_path}",
+          body: publish_intent,
+          headers: {
+            "Content-type" => "application/json"
+          },
+        )
+        .will_respond_with(
+          status: 200,
+          body: publish_intent,
+          headers: {
+            "Content-type" => "application/json"
+          },
+        )
+
+      response = @api_client.put_intent(base_path, publish_intent)
+      assert_equal 200, response.code
+    end
+  end
+
+  describe "#delete_intent" do
+    it "returns 200 OK if intent existed and was deleted" do
       base_path = "/test-intent"
-      stub_publishing_api_destroy_intent(base_path)
-      response = @api.destroy_intent(base_path)
-      assert_equal 201, response.code
+
+      publish_intent = intent_for_base_path(base_path)
+
+      publishing_api
+        .given("a publish intent exists in the live content store")
+        .upon_receiving("DELETE /publish-intent/:base_path")
+        .with(
+          method: :delete,
+          path: "/publish-intent#{base_path}",
+        )
+        .will_respond_with(
+          status: 200,
+          body: "{}",
+          headers: {
+            "Content-type" => "application/json"
+          }
+        )
+
+      response = @api_client.destroy_intent(base_path)
+      assert_equal 200, response.code
     end
   end
 end

--- a/test/publishing_api_test.rb
+++ b/test/publishing_api_test.rb
@@ -122,5 +122,29 @@ describe GdsApi::PublishingApi do
       response = @api_client.destroy_intent(base_path)
       assert_equal 200, response.code
     end
+
+    it "returns 404 Not found if the intent does not exist" do
+      base_path = "/test-intent"
+
+      publish_intent = intent_for_base_path(base_path)
+
+      publishing_api
+        .given("both content stores and url-arbiter empty")
+        .upon_receiving("DELETE /publish-intent/:base_path")
+        .with(
+          method: :delete,
+          path: "/publish-intent#{base_path}",
+        )
+        .will_respond_with(
+          status: 404,
+          body: "{}",
+          headers: {
+            "Content-type" => "application/json"
+          }
+        )
+
+      response = @api_client.destroy_intent(base_path)
+      assert_equal 404, response.code
+    end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,7 +11,7 @@ require 'rack/utils'
 require 'rack/test'
 require 'simplecov'
 require 'simplecov-rcov'
-require 'mocha'
+require 'mocha/mini_test'
 require 'timecop'
 
 SimpleCov.start do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -26,6 +26,23 @@ class MiniTest::Unit::TestCase
   end
 end
 
+require 'pact/consumer/minitest'
+module PactTest
+  include Pact::Consumer::Minitest
+
+  def before_suite
+    # Pact does its own stubbing of network connections, so we want to
+    # prevent WebMock interfering when pact is being used.
+    ::WebMock.allow_net_connect!
+    super
+  end
+
+  def after_suite
+    super
+    ::WebMock.disable_net_connect!
+  end
+end
+
 def load_fixture_file(filename)
   File.open( File.join( File.dirname(__FILE__), "fixtures", filename ), :encoding => 'utf-8' )
 end
@@ -34,3 +51,4 @@ require 'webmock/minitest'
 WebMock.disable_net_connect!
 
 require 'gds_api/test_helpers/json_client_helper'
+require 'test_helpers/pact_helper'

--- a/test/test_helpers/pact_helper.rb
+++ b/test/test_helpers/pact_helper.rb
@@ -1,0 +1,7 @@
+Pact.service_consumer "GDS API Adapters" do
+  has_pact_with "Publishing API" do
+    mock_service :publishing_api do
+      port 3093
+    end
+  end
+end


### PR DESCRIPTION
We are setting up contract testing for the new publishing api:

https://trello.com/c/t3R37qPh/334-set-up-contract-testing

For more background about what contract testing is see this [write up of our spike](https://gov-uk.atlassian.net/wiki/pages/viewpage.action?spaceKey=PUB&title=Spike%3A+Contract+testing+using+Pact).

The main purpose of contract testing is to test the interaction between a client and a service without needing to run them both at the same time.

This PR adds the basic configuration of [pact](https://github.com/realestate-com-au/pact) and tests of the happy path of operations on the existing publishing api.

We intend to add further tests to cover error scenarios in a future PR.
