### PR TITLE
Return 200 not 201 from publishing api stubs

### DIFF
--- a/lib/gds_api/test_helpers/publishing_api.rb
+++ b/lib/gds_api/test_helpers/publishing_api.rb
@@ -17,18 +17,18 @@ module GdsApi
 
       def stub_publishing_api_put_item(base_path, body = content_item_for_base_path(base_path), resource_path = '/content')
         url = PUBLISHING_API_ENDPOINT + resource_path + base_path
-        stub_request(:put, url).with(body: body).to_return(status: 201, body: '{}', headers: {})
+        stub_request(:put, url).with(body: body).to_return(status: 200, body: '{}', headers: {"Content-Type" => "application/json; charset=utf-8"})
       end
 
       def stub_publishing_api_put_intent(base_path, body = intent_for_base_path(base_path))
         url = PUBLISHING_API_ENDPOINT + "/publish-intent" + base_path
         body = body.to_json unless body.is_a?(String)
-        stub_request(:put, url).with(body: body).to_return(status: 201, body: '{}', headers: {})
+        stub_request(:put, url).with(body: body).to_return(status: 200, body: '{}', headers: {"Content-Type" => "application/json; charset=utf-8"})
       end
 
       def stub_publishing_api_destroy_intent(base_path)
         url = PUBLISHING_API_ENDPOINT + "/publish-intent" + base_path
-        stub_request(:delete, url).to_return(status: 201, body: '{}')
+        stub_request(:delete, url).to_return(status: 200, body: '{}', headers: {"Content-Type" => "application/json; charset=utf-8"})
       end
 
       def stub_default_publishing_api_put()


### PR DESCRIPTION
The publishing API delete commands never returned a 201 status code,
they returned a 200 status code.

The PUT /content and PUT /draft-content calls used to return 201 for a
new item and 200 for an existing item, but that behaviour changed when
we switched to a rails implementation of publishing api. This feature
was not tested anywhere so it wasn't noticed at the time. We don't
believe any client applications relied upon this behaviour so we've
encoded this expectation in the new contract tests[1]. This commit
updates the stub helpers to reflect the actual behaviour.

[1]
https://github.com/alphagov/gds-api-adapters/commit/2f74464a838f51a0d4c182e18b5ebd6f88242826#diff-a8f8b79ce21998f08dbaa06c40cc4551R31