### PR TITLE
Publishing api publish endpoint

### DIFF
--- a/gds-api-adapters.gemspec
+++ b/gds-api-adapters.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rack-cache'
 
   s.add_development_dependency 'gem_publisher', '~> 1.5.0'
+  s.add_development_dependency 'mocha', "> 1.0.0"
   s.add_development_dependency "minitest", "> 5.0.0"
   s.add_development_dependency 'mocha'
   s.add_development_dependency 'pact'

--- a/lib/gds_api/publishing_api_v2.rb
+++ b/lib/gds_api/publishing_api_v2.rb
@@ -10,7 +10,7 @@ class GdsApi::PublishingApiV2 < GdsApi::Base
     get_json(content_url(content_id))
   end
 
-  def publish(content_id, update_type:)
+  def publish(content_id, update_type)
     post_json!(content_url(content_id) + "/publish", {
       update_type: update_type,
     })

--- a/lib/gds_api/publishing_api_v2.rb
+++ b/lib/gds_api/publishing_api_v2.rb
@@ -10,6 +10,12 @@ class GdsApi::PublishingApiV2 < GdsApi::Base
     get_json(content_url(content_id))
   end
 
+  def publish(content_id, update_type:)
+    post_json!(content_url(content_id) + "/publish", {
+      update_type: update_type,
+    })
+  end
+
   private
 
   def content_url(content_id)

--- a/test/publishing_api_v2_test.rb
+++ b/test/publishing_api_v2_test.rb
@@ -205,9 +205,7 @@ describe GdsApi::PublishingApiV2 do
           status: 200
         )
 
-      response = @api_client.publish(@content_id,
-        update_type: "major",
-      )
+      response = @api_client.publish(@content_id, "major")
       assert_equal 200, response.code
     end
 
@@ -230,9 +228,7 @@ describe GdsApi::PublishingApiV2 do
         )
 
       error = assert_raises GdsApi::HTTPClientError do
-        @api_client.publish(@content_id,
-          update_type: "major",
-        )
+        @api_client.publish(@content_id, "major")
       end
 
       assert_equal 404, error.code
@@ -265,9 +261,7 @@ describe GdsApi::PublishingApiV2 do
         )
 
       error = assert_raises GdsApi::HTTPClientError do
-        @api_client.publish(@content_id,
-          update_type: "major",
-        )
+        @api_client.publish(@content_id, "major")
       end
 
       assert_equal 422, error.code
@@ -302,7 +296,7 @@ describe GdsApi::PublishingApiV2 do
         )
 
       error = assert_raises GdsApi::HTTPClientError do
-        @api_client.publish(@content_id, update_type: "")
+        @api_client.publish(@content_id, "")
       end
 
       assert_equal 422, error.code
@@ -333,9 +327,7 @@ describe GdsApi::PublishingApiV2 do
         )
 
       error = assert_raises GdsApi::HTTPClientError do
-        @api_client.publish(@content_id,
-          update_type: "major",
-        )
+        @api_client.publish(@content_id, "major")
       end
 
       assert_equal 400, error.code


### PR DESCRIPTION
Adds code and tests for an endpoint to publish a draft content item.

https://trello.com/c/iWQQLxNX/328-modify-existing-endpoints-to-record-events-to-the-event-log