### PR TITLE
GET/PUT links endpoints

### DIFF
--- a/gds-api-adapters.gemspec
+++ b/gds-api-adapters.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'gem_publisher', '~> 1.5.0'
   s.add_development_dependency 'mocha', "> 1.0.0"
   s.add_development_dependency "minitest", "> 5.0.0"
-  s.add_development_dependency 'mocha'
   s.add_development_dependency 'pact'
   s.add_development_dependency 'pact-consumer-minitest'
   s.add_development_dependency 'pry'

--- a/lib/gds_api/publishing_api_v2.rb
+++ b/lib/gds_api/publishing_api_v2.rb
@@ -20,6 +20,11 @@ class GdsApi::PublishingApiV2 < GdsApi::Base
     get_json(links_url(content_id))
   end
 
+  def put_links(content_id, payload)
+    links = payload.fetch(:links)
+    put_json!(links_url(content_id), links: links)
+  end
+
 private
 
   def content_url(content_id)

--- a/lib/gds_api/publishing_api_v2.rb
+++ b/lib/gds_api/publishing_api_v2.rb
@@ -16,9 +16,17 @@ class GdsApi::PublishingApiV2 < GdsApi::Base
     })
   end
 
-  private
+  def get_links(content_id)
+    get_json(links_url(content_id))
+  end
+
+private
 
   def content_url(content_id)
     "#{endpoint}/v2/content/#{content_id}"
+  end
+
+  def links_url(content_id)
+    "#{endpoint}/v2/links/#{content_id}"
   end
 end

--- a/test/publishing_api_v2_test.rb
+++ b/test/publishing_api_v2_test.rb
@@ -407,4 +407,157 @@ describe GdsApi::PublishingApiV2 do
       end
     end
   end
+
+  describe "#put_links" do
+    describe "when setting links of the same type" do
+      before do
+        publishing_api
+          .given("organisation links exist for content_id #{@content_id}")
+          .upon_receiving("a put organisation links request")
+          .with(
+            method: :put,
+            path: "/v2/links/#{@content_id}",
+            body: {
+              links: {
+                organisations: ["591436ab-c2ae-416f-a3c5-1901d633fbfb"],
+              }
+            },
+            headers: {
+              "Content-Type" => "application/json",
+            },
+          )
+          .will_respond_with(
+            status: 200,
+            body: {
+              links: {
+                organisations: ["591436ab-c2ae-416f-a3c5-1901d633fbfb"],
+              }
+            }
+          )
+      end
+
+      it "replaces the links and responds with the new links" do
+        response = @api_client.put_links(@content_id, links: {
+          organisations: ["591436ab-c2ae-416f-a3c5-1901d633fbfb"],
+        })
+        assert_equal 200, response.code
+        assert_equal ["591436ab-c2ae-416f-a3c5-1901d633fbfb"], response.links[:organisations]
+      end
+    end
+
+    describe "when setting links of a different type" do
+      before do
+        publishing_api
+          .given("organisation links exist for content_id #{@content_id}")
+          .upon_receiving("a put topic links request")
+          .with(
+            method: :put,
+            path: "/v2/links/#{@content_id}",
+            body: {
+              links: {
+                topics: ["225df4a8-2945-4e9b-8799-df7424a90b69"],
+              }
+            },
+            headers: {
+              "Content-Type" => "application/json",
+            },
+          )
+          .will_respond_with(
+            status: 200,
+            body: {
+              links: {
+                topics: ["225df4a8-2945-4e9b-8799-df7424a90b69"],
+                organisations: ["20583132-1619-4c68-af24-77583172c070"]
+              }
+            }
+          )
+      end
+
+      it "adds the new type of links and responds with the whole link set" do
+        response = @api_client.put_links(@content_id, links: {
+          topics: ["225df4a8-2945-4e9b-8799-df7424a90b69"],
+        })
+
+        assert_equal 200, response.code
+        assert_equal(OpenStruct.new(
+          topics: ["225df4a8-2945-4e9b-8799-df7424a90b69"],
+          organisations: ["20583132-1619-4c68-af24-77583172c070"],
+        ), response.links)
+      end
+    end
+
+    describe "when deleting links of a specific type" do
+      before do
+        publishing_api
+          .given("organisation links exist for content_id #{@content_id}")
+          .upon_receiving("a put blank organisation links request")
+          .with(
+            method: :put,
+            path: "/v2/links/#{@content_id}",
+            body: {
+              links: {
+                organisations: [],
+              }
+            },
+            headers: {
+              "Content-Type" => "application/json",
+            },
+          )
+          .will_respond_with(
+            status: 200,
+            body: {
+              links: {}
+            }
+          )
+      end
+
+      it "responds with the links" do
+        response = @api_client.put_links(@content_id, links: {
+          organisations: [],
+        })
+
+        assert_equal 200, response.code
+        assert_equal OpenStruct.new({}), response.links
+      end
+    end
+
+    describe "when there's no links entry" do
+      before do
+        publishing_api
+          .given("no links exist for content_id #{@content_id}")
+          .upon_receiving("a put organisation links request")
+          .with(
+            method: :put,
+            path: "/v2/links/#{@content_id}",
+            body: {
+              links: {
+                organisations: ["591436ab-c2ae-416f-a3c5-1901d633fbfb"],
+              }
+            },
+            headers: {
+              "Content-Type" => "application/json",
+            },
+          )
+          .will_respond_with(
+            status: 200,
+            body: {
+              links: {
+                organisations: ["591436ab-c2ae-416f-a3c5-1901d633fbfb"],
+              }
+            },
+          )
+      end
+
+      it "responds with the links" do
+        response = @api_client.put_links(@content_id, links: {
+          organisations: ["591436ab-c2ae-416f-a3c5-1901d633fbfb"],
+        })
+
+        assert_equal 200, response.code
+        assert_equal(OpenStruct.new(
+          organisations: ["591436ab-c2ae-416f-a3c5-1901d633fbfb"],
+        ), response.links)
+      end
+    end
+  end
 end

--- a/test/publishing_api_v2_test.rb
+++ b/test/publishing_api_v2_test.rb
@@ -399,7 +399,7 @@ describe GdsApi::PublishingApiV2 do
       it "responds with the links" do
         response = @api_client.get_links(@content_id)
         assert_equal 200, response.code
-        assert_equal ["20583132-1619-4c68-af24-77583172c070"], response.links[:organisations]
+        assert_equal ["20583132-1619-4c68-af24-77583172c070"], response.links.organisations
       end
     end
 
@@ -482,7 +482,7 @@ describe GdsApi::PublishingApiV2 do
           organisations: ["591436ab-c2ae-416f-a3c5-1901d633fbfb"],
         })
         assert_equal 200, response.code
-        assert_equal ["591436ab-c2ae-416f-a3c5-1901d633fbfb"], response.links[:organisations]
+        assert_equal ["591436ab-c2ae-416f-a3c5-1901d633fbfb"], response.links.organisations
       end
     end
 

--- a/test/publishing_api_v2_test.rb
+++ b/test/publishing_api_v2_test.rb
@@ -33,305 +33,346 @@ describe GdsApi::PublishingApiV2 do
   end
 
   describe "#put_content" do
-    it "responds with 200 OK if the entry is valid" do
-      content_item = content_item_for_content_id(@content_id)
+    describe "if the entry is valid" do
+      before do
+        @content_item = content_item_for_content_id(@content_id)
 
-      publishing_api
-        .given("both content stores and the url-arbiter are empty")
-        .upon_receiving("a request to create a content item without links")
-        .with(
-          method: :put,
-          path: "/v2/content/#{@content_id}",
-          body: content_item,
-          headers: {
-            "Content-Type" => "application/json",
-          },
-        )
-        .will_respond_with(
-          status: 200,
-        )
+        publishing_api
+          .given("both content stores and the url-arbiter are empty")
+          .upon_receiving("a request to create a content item without links")
+          .with(
+            method: :put,
+            path: "/v2/content/#{@content_id}",
+            body: @content_item,
+            headers: {
+              "Content-Type" => "application/json",
+            },
+          )
+          .will_respond_with(
+            status: 200,
+          )
+      end
 
-      response = @api_client.put_content(@content_id, content_item)
-      assert_equal 200, response.code
+      it "responds with 200 OK" do
+        response = @api_client.put_content(@content_id, @content_item)
+        assert_equal 200, response.code
+      end
     end
 
-    it "responds with 409 Conflict if the path is reserved by a different app" do
-      content_item = content_item_for_content_id(@content_id, "base_path" => "/test-item", "publishing_app" => "whitehall")
+    describe "if the path is reserved by a different app" do
+      before do
+        @content_item = content_item_for_content_id(@content_id, "base_path" => "/test-item", "publishing_app" => "whitehall")
 
-      publishing_api
-        .given("/test-item has been reserved in url-arbiter by the Publisher application")
-        .upon_receiving("a request from the Whitehall application to create a content item at /test-item")
-        .with(
-          method: :put,
-          path: "/v2/content/#{@content_id}",
-          body: content_item,
-          headers: {
-            "Content-Type" => "application/json",
-          }
-        )
-        .will_respond_with(
-          status: 409,
-          body: {
-            "error" => {
-              "code" => 409,
-              "message" => Pact.term(generate: "Conflict", matcher:/\S+/),
-              "fields" => {
-                "base_path" => Pact.each_like("is already in use by the 'publisher' app", :min => 1),
+        publishing_api
+          .given("/test-item has been reserved in url-arbiter by the Publisher application")
+          .upon_receiving("a request from the Whitehall application to create a content item at /test-item")
+          .with(
+            method: :put,
+            path: "/v2/content/#{@content_id}",
+            body: @content_item,
+            headers: {
+              "Content-Type" => "application/json",
+            }
+          )
+          .will_respond_with(
+            status: 409,
+            body: {
+              "error" => {
+                "code" => 409,
+                "message" => Pact.term(generate: "Conflict", matcher:/\S+/),
+                "fields" => {
+                  "base_path" => Pact.each_like("is already in use by the 'publisher' app", :min => 1),
+                },
               },
             },
-          },
-          headers: {
-            "Content-Type" => "application/json; charset=utf-8"
-          }
-        )
-
-      error = assert_raises GdsApi::HTTPConflict do
-        @api_client.put_content(@content_id, content_item)
+            headers: {
+              "Content-Type" => "application/json; charset=utf-8"
+            }
+          )
       end
-      assert_equal "Conflict", error.error_details["error"]["message"]
+
+      it "responds with 409 Conflict" do
+        error = assert_raises GdsApi::HTTPConflict do
+          @api_client.put_content(@content_id, @content_item)
+        end
+        assert_equal "Conflict", error.error_details["error"]["message"]
+      end
     end
 
-    it "responds with 422 Unprocessable Entity with an invalid item" do
-      content_item = content_item_for_content_id(@content_id, "base_path" => "not a url path")
+    describe "with an invalid item" do
+      before do
+        @content_item = content_item_for_content_id(@content_id, "base_path" => "not a url path")
 
-      publishing_api
-        .given("both content stores and the url-arbiter are empty")
-        .upon_receiving("a request to create an invalid content-item")
-        .with(
-          method: :put,
-          path: "/v2/content/#{@content_id}",
-          body: content_item,
-          headers: {
-            "Content-Type" => "application/json",
-          },
-        )
-        .will_respond_with(
-          status: 422,
-          body: {
-            "error" => {
-              "code" => 422,
-              "message" => Pact.term(generate: "Unprocessable entity", matcher:/\S+/),
-              "fields" => {
-                "base_path" => Pact.each_like("is invalid", :min => 1),
+        publishing_api
+          .given("both content stores and the url-arbiter are empty")
+          .upon_receiving("a request to create an invalid content-item")
+          .with(
+            method: :put,
+            path: "/v2/content/#{@content_id}",
+            body: @content_item,
+            headers: {
+              "Content-Type" => "application/json",
+            },
+          )
+          .will_respond_with(
+            status: 422,
+            body: {
+              "error" => {
+                "code" => 422,
+                "message" => Pact.term(generate: "Unprocessable entity", matcher:/\S+/),
+                "fields" => {
+                  "base_path" => Pact.each_like("is invalid", :min => 1),
+                },
               },
             },
-          },
-          headers: {
-            "Content-Type" => "application/json; charset=utf-8"
-          }
-        )
-
-      error = assert_raises GdsApi::HTTPClientError do
-        @api_client.put_content(@content_id, content_item)
+            headers: {
+              "Content-Type" => "application/json; charset=utf-8"
+            }
+          )
       end
-      assert_equal 422, error.code
-      assert_equal "Unprocessable entity", error.error_details["error"]["message"]
+
+      it "responds with 422 Unprocessable Entity" do
+        error = assert_raises GdsApi::HTTPClientError do
+          @api_client.put_content(@content_id, @content_item)
+        end
+        assert_equal 422, error.code
+        assert_equal "Unprocessable entity", error.error_details["error"]["message"]
+      end
     end
   end
 
   describe "#get_content" do
-    it "responds with 200 and the content item when it exists" do
-      content_item = content_item_for_content_id(@content_id)
-      publishing_api
-        .given("a content item exists with content_id: #{@content_id}")
-        .upon_receiving("a request to return the content item")
-        .with(
-          method: :get,
-          path: "/v2/content/#{@content_id}",
-        )
-        .will_respond_with(
-          status: 200,
-          body: {
-            "content_id" => @content_id,
-            "format" => Pact.like("special_route"),
-            "publishing_app" => Pact.like("publisher"),
-            "rendering_app" => Pact.like("frontend"),
-            "locale" => Pact.like("en"),
-            "routes" => Pact.like([{}]),
-            "public_updated_at" => Pact.like("2015-07-30T13:58:11.000Z"),
-            "details" => Pact.like({})
-          },
-          headers: {
-            "Content-Type" => "application/json; charset=utf-8",
-          },
-        )
+    describe "when the content item exists" do
+      before do
+        @content_item = content_item_for_content_id(@content_id)
 
-      response = @api_client.get_content(@content_id)
-      assert_equal 200, response.code
-      assert_equal content_item["format"], response["format"]
+        publishing_api
+          .given("a content item exists with content_id: #{@content_id}")
+          .upon_receiving("a request to return the content item")
+          .with(
+            method: :get,
+            path: "/v2/content/#{@content_id}",
+          )
+          .will_respond_with(
+            status: 200,
+            body: {
+              "content_id" => @content_id,
+              "format" => Pact.like("special_route"),
+              "publishing_app" => Pact.like("publisher"),
+              "rendering_app" => Pact.like("frontend"),
+              "locale" => Pact.like("en"),
+              "routes" => Pact.like([{}]),
+              "public_updated_at" => Pact.like("2015-07-30T13:58:11.000Z"),
+              "details" => Pact.like({})
+            },
+            headers: {
+              "Content-Type" => "application/json; charset=utf-8",
+            },
+          )
+      end
+
+      it "responds with 200 and the content item" do
+        response = @api_client.get_content(@content_id)
+        assert_equal 200, response.code
+        assert_equal @content_item["format"], response["format"]
+      end
     end
 
-    it "responds with 404 for a non-existent item" do
-      publishing_api
-        .given("both content stores and the url-arbiter are empty")
-        .upon_receiving("a request for a non-existent content item")
-        .with(
-          method: :get,
-          path: "/v2/content/#{@content_id}",
-        )
-        .will_respond_with(
-          status: 404,
-          body: {
-            "error" => {
-              "code" => 404,
-              "message" => Pact.term(generate: "not found", matcher:/\S+/)
+    describe "a non-existent item" do
+      before do
+        publishing_api
+          .given("both content stores and the url-arbiter are empty")
+          .upon_receiving("a request for a non-existent content item")
+          .with(
+            method: :get,
+            path: "/v2/content/#{@content_id}",
+          )
+          .will_respond_with(
+            status: 404,
+            body: {
+              "error" => {
+                "code" => 404,
+                "message" => Pact.term(generate: "not found", matcher:/\S+/)
+              },
             },
-          },
-          headers: {
-            "Content-Type" => "application/json; charset=utf-8",
-          },
-        )
+            headers: {
+              "Content-Type" => "application/json; charset=utf-8",
+            },
+          )
+      end
 
-      assert_nil @api_client.get_content(@content_id)
+      it "responds with 404" do
+        assert_nil @api_client.get_content(@content_id)
+      end
     end
   end
 
   describe "#publish" do
-    it "responds with 200 if the publish command succeeds" do
-      publishing_api
-        .given("a draft content item exists with content_id: #{@content_id}")
-        .upon_receiving("a publish request")
-        .with(
-          method: :post,
-          path: "/v2/content/#{@content_id}/publish",
-          body: {
-            update_type: "major",
-          },
-          headers: {
-            "Content-Type" => "application/json",
-          },
-        )
-        .will_respond_with(
-          status: 200
-        )
-
-      response = @api_client.publish(@content_id, "major")
-      assert_equal 200, response.code
-    end
-
-    it "responds with 404 if the content item does not exist" do
-      publishing_api
-        .given("both content stores and url-arbiter empty")
-        .upon_receiving("a publish request")
-        .with(
-          method: :post,
-          path: "/v2/content/#{@content_id}/publish",
-          body: {
-            update_type: "major",
-          },
-          headers: {
-            "Content-Type" => "application/json",
-          },
-        )
-        .will_respond_with(
-          status: 404
-        )
-
-      error = assert_raises GdsApi::HTTPClientError do
-        @api_client.publish(@content_id, "major")
+    describe "if the publish command succeeds" do
+      before do
+        publishing_api
+          .given("a draft content item exists with content_id: #{@content_id}")
+          .upon_receiving("a publish request")
+          .with(
+            method: :post,
+            path: "/v2/content/#{@content_id}/publish",
+            body: {
+              update_type: "major",
+            },
+            headers: {
+              "Content-Type" => "application/json",
+            },
+          )
+          .will_respond_with(
+            status: 200
+          )
       end
 
-      assert_equal 404, error.code
+      it "responds with 200 if the publish command succeeds" do
+        response = @api_client.publish(@content_id, "major")
+        assert_equal 200, response.code
+      end
     end
 
-    it "responds with 422 if the content item is not publishable" do
-      publishing_api
-        .given("a draft content item exists with content_id: #{@content_id} which does not have a publishing_app")
-        .upon_receiving("a publish request")
-        .with(
-          method: :post,
-          path: "/v2/content/#{@content_id}/publish",
-          body: {
-            update_type: "major",
-          },
-          headers: {
-            "Content-Type" => "application/json",
-          },
-        )
-        .will_respond_with(
-          status: 422,
-          body: {
-            "error" => {
-              "code" => 422,
-              "fields" => {
-                "publishing_app"=>["can't be blank"],
+    describe "if the content item does not exist" do
+      before do
+        publishing_api
+          .given("both content stores and url-arbiter empty")
+          .upon_receiving("a publish request")
+          .with(
+            method: :post,
+            path: "/v2/content/#{@content_id}/publish",
+            body: {
+              update_type: "major",
+            },
+            headers: {
+              "Content-Type" => "application/json",
+            },
+          )
+          .will_respond_with(
+            status: 404
+          )
+      end
+
+      it "responds with 404" do
+        error = assert_raises GdsApi::HTTPClientError do
+          @api_client.publish(@content_id, "major")
+        end
+
+        assert_equal 404, error.code
+      end
+    end
+
+    describe "if the content item is not publishable" do
+      before do
+        publishing_api
+          .given("a draft content item exists with content_id: #{@content_id} which does not have a publishing_app")
+          .upon_receiving("a publish request")
+          .with(
+            method: :post,
+            path: "/v2/content/#{@content_id}/publish",
+            body: {
+              update_type: "major",
+            },
+            headers: {
+              "Content-Type" => "application/json",
+            },
+          )
+          .will_respond_with(
+            status: 422,
+            body: {
+              "error" => {
+                "code" => 422,
+                "fields" => {
+                  "publishing_app"=>["can't be blank"],
+                },
               },
-            },
-          }
-        )
-
-      error = assert_raises GdsApi::HTTPClientError do
-        @api_client.publish(@content_id, "major")
+            }
+          )
       end
 
-      assert_equal 422, error.code
-      assert_equal ["can't be blank"], error.error_details["error"]["fields"]["publishing_app"]
+      it "responds with 422" do
+        error = assert_raises GdsApi::HTTPClientError do
+          @api_client.publish(@content_id, "major")
+        end
+
+        assert_equal 422, error.code
+        assert_equal ["can't be blank"], error.error_details["error"]["fields"]["publishing_app"]
+      end
     end
 
-    it "responds with 422 if the update information is invalid" do
-      publishing_api
-        .given("a draft content item exists with content_id: #{@content_id}")
-        .upon_receiving("an invalid publish request")
-        .with(
-          method: :post,
-          path: "/v2/content/#{@content_id}/publish",
-          body: {
-            "update_type" => ""
-          },
-          headers: {
-            "Content-Type" => "application/json",
-          },
-        )
-        .will_respond_with(
-          status: 422,
-          body: {
-            "error" => {
-              "code" => 422,
-              "message" => Pact.term(generate: "Unprocessable entity", matcher:/\S+/),
-              "fields" => {
-                "update_type" => Pact.each_like("is required", :min => 1),
+    describe "if the update information is invalid" do
+      before do
+        publishing_api
+          .given("a draft content item exists with content_id: #{@content_id}")
+          .upon_receiving("an invalid publish request")
+          .with(
+            method: :post,
+            path: "/v2/content/#{@content_id}/publish",
+            body: {
+              "update_type" => ""
+            },
+            headers: {
+              "Content-Type" => "application/json",
+            },
+          )
+          .will_respond_with(
+            status: 422,
+            body: {
+              "error" => {
+                "code" => 422,
+                "message" => Pact.term(generate: "Unprocessable entity", matcher:/\S+/),
+                "fields" => {
+                  "update_type" => Pact.each_like("is required", :min => 1),
+                },
               },
-            },
-          }
-        )
-
-      error = assert_raises GdsApi::HTTPClientError do
-        @api_client.publish(@content_id, "")
+            }
+          )
       end
 
-      assert_equal 422, error.code
-      assert_equal "Unprocessable entity", error.error_details["error"]["message"]
+      it "responds with 422" do
+        error = assert_raises GdsApi::HTTPClientError do
+          @api_client.publish(@content_id, "")
+        end
+
+        assert_equal 422, error.code
+        assert_equal "Unprocessable entity", error.error_details["error"]["message"]
+      end
     end
 
-    it "responds with 400 if the content item is already published" do
-      publishing_api
-        .given("a published content item exists with content_id: #{@content_id}")
-        .upon_receiving("a publish request")
-        .with(
-          method: :post,
-          path: "/v2/content/#{@content_id}/publish",
-          body: {
-            update_type: "major",
-          },
-          headers: {
-            "Content-Type" => "application/json",
-          },
-        )
-        .will_respond_with(
-          status: 400,
-          body: {
-            "error" => {
-              "code" => 400, "message" => Pact.term(generate: "Cannot publish an already published content item", matcher:/\S+/),
+    describe "if the content item is already published" do
+      before do
+        publishing_api
+          .given("a published content item exists with content_id: #{@content_id}")
+          .upon_receiving("a publish request")
+          .with(
+            method: :post,
+            path: "/v2/content/#{@content_id}/publish",
+            body: {
+              update_type: "major",
             },
-          }
-        )
-
-      error = assert_raises GdsApi::HTTPClientError do
-        @api_client.publish(@content_id, "major")
+            headers: {
+              "Content-Type" => "application/json",
+            },
+          )
+          .will_respond_with(
+            status: 400,
+            body: {
+              "error" => {
+                "code" => 400, "message" => Pact.term(generate: "Cannot publish an already published content item", matcher:/\S+/),
+              },
+            }
+          )
       end
 
-      assert_equal 400, error.code
-      assert_equal "Cannot publish an already published content item", error.error_details["error"]["message"]
+      it "responds with 400" do
+        error = assert_raises GdsApi::HTTPClientError do
+          @api_client.publish(@content_id, "major")
+        end
+
+        assert_equal 400, error.code
+        assert_equal "Cannot publish an already published content item", error.error_details["error"]["message"]
+      end
     end
   end
 

--- a/test/publishing_api_v2_test.rb
+++ b/test/publishing_api_v2_test.rb
@@ -334,4 +334,77 @@ describe GdsApi::PublishingApiV2 do
       assert_equal "Cannot publish an already published content item", error.error_details["error"]["message"]
     end
   end
+
+  describe "#get_links" do
+    describe "when there's a links entry with links" do
+      before do
+        publishing_api
+          .given("organisation links exist for content_id #{@content_id}")
+          .upon_receiving("a get-links request")
+          .with(
+            method: :get,
+            path: "/v2/links/#{@content_id}",
+          )
+          .will_respond_with(
+            status: 200,
+            body: {
+              links: {
+                organisations: ["20583132-1619-4c68-af24-77583172c070"]
+              }
+            }
+          )
+      end
+
+      it "responds with the links" do
+        response = @api_client.get_links(@content_id)
+        assert_equal 200, response.code
+        assert_equal ["20583132-1619-4c68-af24-77583172c070"], response.links[:organisations]
+      end
+    end
+
+    describe "when there's an empty links entry" do
+      before do
+        publishing_api
+          .given("empty links exist for content_id #{@content_id}")
+          .upon_receiving("a get-links request")
+          .with(
+            method: :get,
+            path: "/v2/links/#{@content_id}",
+          )
+          .will_respond_with(
+            status: 200,
+            body: {
+              links: {
+              }
+            }
+          )
+      end
+
+      it "responds with the empty link set" do
+        response = @api_client.get_links(@content_id)
+        assert_equal 200, response.code
+        assert_equal OpenStruct.new({}), response.links
+      end
+    end
+
+    describe "when there's no links entry" do
+      before do
+        publishing_api
+          .given("no links exist for content_id #{@content_id}")
+          .upon_receiving("a get-links request")
+          .with(
+            method: :get,
+            path: "/v2/links/#{@content_id}",
+          )
+          .will_respond_with(
+            status: 404
+          )
+      end
+
+      it "responds with 404" do
+        response = @api_client.get_links(@content_id)
+        assert_nil response
+      end
+    end
+  end
 end


### PR DESCRIPTION
Adds the helper methods and pact tests for the GET and PUT publishing API endpoints for managing links independently of content items.

Part of https://trello.com/c/SPLM0ANz/318-support-links-endpoints-in-publishing-api and related to https://github.com/alphagov/publishing-api/pull/86