### PR TITLE
Remove business_support_schemes from Imminence API

### DIFF
--- a/lib/gds_api/imminence.rb
+++ b/lib/gds_api/imminence.rb
@@ -31,12 +31,6 @@ class GdsApi::Imminence < GdsApi::Base
     get_raw("#{@endpoint}/places/#{type}.kml").body
   end
 
-  def business_support_schemes(facets_hash)
-    query = facets_hash.keys.sort.map { |k| "#{k.to_s}=#{facets_hash[k]}" }.join("&")
-    query = "?#{query}" unless query.empty?
-    get_json!("#{@endpoint}/business_support_schemes.json#{query}")
-  end
-
   def areas_for_postcode(postcode)
     url = "#{@endpoint}/areas/#{URI.encode(postcode)}.json"
     get_json(url)
@@ -69,6 +63,5 @@ private
     ].reject { |a| a.nil? or a == "" }
     {"address" => address_fields.map(&:strip).join(", ")}
   end
-
 
 end

--- a/lib/gds_api/test_helpers/imminence.rb
+++ b/lib/gds_api/test_helpers/imminence.rb
@@ -15,33 +15,6 @@ module GdsApi
         to_return(:status => 200, :body => response, :headers => {})
       end
 
-      def imminence_has_business_support_schemes(facets_hash, schemes)
-        results = {
-          "_response_info" => {"status" => "ok"},
-          "description" => "Business Support Schemes!",
-          "total" => schemes.size, "startIndex" => 1, "pageSize" => schemes.size, "currentPage" => 1, "pages" => 1,
-          "results" => schemes
-        }
-
-        stub_request(:get, "#{IMMINENCE_API_ENDPOINT}/business_support_schemes.json").
-          with(query: facets_hash).
-          to_return(status: 200, body: results.to_json, headers: {})
-      end
-
-      # Stubs out all bussiness_support_schemes requests to return an ampty set of results.
-      # Requests stubbed with the above method will take precedence over this.
-      def stub_imminence_default_business_support_schemes
-        empty_results = {
-          "_response_info" => {"status" => "ok"},
-          "description" => "Business Support Schemes!",
-          "total" => 0, "startIndex" => 1, "pageSize" => 0, "currentPage" => 1, "pages" => 1,
-          "results" => []
-        }
-
-        stub_request(:get, %r{\A#{IMMINENCE_API_ENDPOINT}/business_support_schemes\.json}).
-          to_return(:body => empty_results.to_json)
-      end
-
       def imminence_has_areas_for_postcode(postcode, areas)
         results = {
           "_response_info" => {"status" => "ok"},

--- a/test/imminence_api_test.rb
+++ b/test/imminence_api_test.rb
@@ -118,25 +118,6 @@ class ImminenceApiTest < MiniTest::Unit::TestCase
     end
   end
 
-  def test_business_support_schemes
-    dummy_schemes = [
-      { "business_support_identifier" => "bar-business-award", "title" => "Bar business award." },
-      { "business_support_identifier" => "bar-small-business-loan", "title" => "Bar small business loan." },
-      { "business_support_identifier" => "foo-small-business-loan", "title" => "Foo small business loan." }
-    ]
-    c = api_client
-    url = "#{ROOT}/business_support_schemes.json?business_types=private-company&" +
-      "sectors=agriculture,healthcare,manufacturing&stages=grow-and-sustain&types=award,loan"
-    c.expects(:get_json!).with(url).returns(dummy_schemes)
-
-    schemes = c.business_support_schemes(sectors: "agriculture,healthcare,manufacturing",
-      business_types: "private-company", stages: "grow-and-sustain", types: "award,loan")
-
-    assert_equal 3, schemes.size
-    assert_equal "bar-business-award", schemes.first["business_support_identifier"]
-    assert_equal "Foo small business loan.", schemes.last["title"]
-  end
-
   def test_places_kml
     kml_body = <<-EOS
 <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
Imminence hasn't supported this API since https://github.com/alphagov/imminence/pull/88
so it makes sense to finally remove this API from the adapters.