### PR TITLE
Update publishing API pact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+* Update Pulishing API Pact.
+* Removes mention of url-arbiter and updates response codes to reflect url validation in publishing API.
+* Deduplicates empty content store provider states. 
+
 # 24.5.0
 
 * Adds the helper methods and pact tests for the GET and PUT publishing API endpoints for managing links  

--- a/lib/gds_api/test_helpers/publishing_api.rb
+++ b/lib/gds_api/test_helpers/publishing_api.rb
@@ -11,16 +11,16 @@ module GdsApi
 
       PUBLISHING_API_ENDPOINT = Plek.current.find('publishing-api')
 
-      def stub_publishing_api_put_draft_item(base_path, body = content_item_for_base_path(base_path))
+      def stub_publishing_api_put_draft_item(base_path, body = content_item_for_publishing_api(base_path))
         stub_publishing_api_put_item(base_path, body, '/draft-content')
       end
 
-      def stub_publishing_api_put_item(base_path, body = content_item_for_base_path(base_path), resource_path = '/content')
+      def stub_publishing_api_put_item(base_path, body = content_item_for_publishing_api(base_path), resource_path = '/content')
         url = PUBLISHING_API_ENDPOINT + resource_path + base_path
         stub_request(:put, url).with(body: body).to_return(status: 200, body: '{}', headers: {"Content-Type" => "application/json; charset=utf-8"})
       end
 
-      def stub_publishing_api_put_intent(base_path, body = intent_for_base_path(base_path))
+      def stub_publishing_api_put_intent(base_path, body = intent_for_publishing_api(base_path))
         url = PUBLISHING_API_ENDPOINT + "/publish-intent" + base_path
         body = body.to_json unless body.is_a?(String)
         stub_request(:put, url).with(body: body).to_return(status: 200, body: '{}', headers: {"Content-Type" => "application/json; charset=utf-8"})
@@ -108,6 +108,14 @@ module GdsApi
         else
           expected_value == actual_value
         end
+      end
+
+      def content_item_for_publishing_api(base_path, publishing_app="publisher")
+        content_item_for_base_path(base_path).merge("publishing_app" => publishing_app)
+      end
+
+      def intent_for_publishing_api(base_path, publishing_app="publisher")
+        intent_for_base_path(base_path).merge("publishing_app" => publishing_app)
       end
     end
   end

--- a/test/publishing_api_test.rb
+++ b/test/publishing_api_test.rb
@@ -14,10 +14,10 @@ describe GdsApi::PublishingApi do
   describe "#put_content_item" do
     it "responds with 200 OK if the entry is valid" do
       base_path = "/test-content-item"
-      content_item = content_item_for_base_path(base_path).merge("update_type" => "major")
+      content_item = content_item_for_publishing_api(base_path).merge("update_type" => "major")
 
       publishing_api
-        .given("both content stores and the url-arbiter are empty")
+        .given("both content stores are empty")
         .upon_receiving("a request to create a content item")
         .with(
           method: :put,
@@ -43,10 +43,10 @@ describe GdsApi::PublishingApi do
   describe "#put_draft_content_item" do
     it "responds with 200 OK if the entry is valid" do
       base_path = "/test-draft-content-item"
-      content_item = content_item_for_base_path(base_path).merge("update_type" => "major")
+      content_item = content_item_for_publishing_api(base_path).merge("update_type" => "major")
 
       publishing_api
-        .given("both content stores and the url-arbiter are empty")
+        .given("both content stores are empty")
         .upon_receiving("a request to create a draft content item")
         .with(
           method: :put,
@@ -72,10 +72,10 @@ describe GdsApi::PublishingApi do
   describe "#put_intent" do
     it "responds with 200 OK if publish intent is valid" do
       base_path = "/test-intent"
-      publish_intent = intent_for_base_path(base_path)
+      publish_intent = intent_for_publishing_api(base_path)
 
       publishing_api
-        .given("both content stores and the url-arbiter are empty")
+        .given("both content stores are empty")
         .upon_receiving("a request to create a publish intent")
         .with(
           method: :put,
@@ -102,7 +102,7 @@ describe GdsApi::PublishingApi do
     it "returns 200 OK if intent existed and was deleted" do
       base_path = "/test-intent"
 
-      publish_intent = intent_for_base_path(base_path)
+      publish_intent = intent_for_publishing_api(base_path)
 
       publishing_api
         .given("a publish intent exists at /test-intent in the live content store")
@@ -126,10 +126,10 @@ describe GdsApi::PublishingApi do
     it "returns 404 Not found if the intent does not exist" do
       base_path = "/test-intent"
 
-      publish_intent = intent_for_base_path(base_path)
+      publish_intent = intent_for_publishing_api(base_path)
 
       publishing_api
-        .given("both content stores and the url-arbiter are empty")
+        .given("both content stores are empty")
         .upon_receiving("a request to delete a publish intent")
         .with(
           method: :delete,

--- a/test/publishing_api_v2_test.rb
+++ b/test/publishing_api_v2_test.rb
@@ -38,7 +38,7 @@ describe GdsApi::PublishingApiV2 do
         @content_item = content_item_for_content_id(@content_id)
 
         publishing_api
-          .given("both content stores and the url-arbiter are empty")
+          .given("both content stores are empty")
           .upon_receiving("a request to create a content item without links")
           .with(
             method: :put,
@@ -64,7 +64,7 @@ describe GdsApi::PublishingApiV2 do
         @content_item = content_item_for_content_id(@content_id, "base_path" => "/test-item", "publishing_app" => "whitehall")
 
         publishing_api
-          .given("/test-item has been reserved in url-arbiter by the Publisher application")
+          .given("the path /test-item has been reserved by the Publisher application")
           .upon_receiving("a request from the Whitehall application to create a content item at /test-item")
           .with(
             method: :put,
@@ -75,10 +75,10 @@ describe GdsApi::PublishingApiV2 do
             }
           )
           .will_respond_with(
-            status: 409,
+            status: 422,
             body: {
               "error" => {
-                "code" => 409,
+                "code" => 422,
                 "message" => Pact.term(generate: "Conflict", matcher:/\S+/),
                 "fields" => {
                   "base_path" => Pact.each_like("is already in use by the 'publisher' app", :min => 1),
@@ -92,7 +92,7 @@ describe GdsApi::PublishingApiV2 do
       end
 
       it "responds with 409 Conflict" do
-        error = assert_raises GdsApi::HTTPConflict do
+        error = assert_raises GdsApi::HTTPClientError do
           @api_client.put_content(@content_id, @content_item)
         end
         assert_equal "Conflict", error.error_details["error"]["message"]
@@ -104,7 +104,7 @@ describe GdsApi::PublishingApiV2 do
         @content_item = content_item_for_content_id(@content_id, "base_path" => "not a url path")
 
         publishing_api
-          .given("both content stores and the url-arbiter are empty")
+          .given("both content stores are empty")
           .upon_receiving("a request to create an invalid content-item")
           .with(
             method: :put,
@@ -181,7 +181,7 @@ describe GdsApi::PublishingApiV2 do
     describe "a non-existent item" do
       before do
         publishing_api
-          .given("both content stores and the url-arbiter are empty")
+          .given("both content stores are empty")
           .upon_receiving("a request for a non-existent content item")
           .with(
             method: :get,
@@ -237,7 +237,7 @@ describe GdsApi::PublishingApiV2 do
     describe "if the content item does not exist" do
       before do
         publishing_api
-          .given("both content stores and url-arbiter empty")
+          .given("both content stores are empty")
           .upon_receiving("a publish request")
           .with(
             method: :post,


### PR DESCRIPTION
- Update Publishing API Pact.
- Removes mention of url-arbiter
- Updates response codes to reflect path validation in publishing API.
- Removes duplicate empty content store provider states. 