### PR TITLE
Add support for redirect route segments_mode

### DIFF
--- a/lib/gds_api/router.rb
+++ b/lib/gds_api/router.rb
@@ -33,7 +33,7 @@ class GdsApi::Router < GdsApi::Base
 
   def add_redirect_route(path, type, destination, redirect_type = "permanent", options = {})
     response = put_json!("#{endpoint}/routes", :route => {:incoming_path => path, :route_type => type, :handler => "redirect",
-              :redirect_to => destination, :redirect_type => redirect_type})
+              :redirect_to => destination, :redirect_type => redirect_type, :segments_mode => options[:segments_mode]})
     commit_routes if options[:commit]
     response
   end

--- a/lib/gds_api/test_helpers/router.rb
+++ b/lib/gds_api/test_helpers/router.rb
@@ -31,13 +31,14 @@ module GdsApi
         [register_stub, commit_stub]
       end
 
-      def stub_redirect_registration(path, type, destination, redirect_type)
+      def stub_redirect_registration(path, type, destination, redirect_type, segments_mode = nil)
         redirect = { route: {
                       incoming_path: path,
                       route_type: type,
                       handler: 'redirect',
                       redirect_to: destination,
-                      redirect_type: redirect_type }
+                      redirect_type: redirect_type,
+                      segments_mode: segments_mode }
                   }
 
         register_stub = stub_route_put(redirect)

--- a/test/gds_api_base_test.rb
+++ b/test/gds_api_base_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 require 'gds_api/base'
 require 'uri'
 
-class GdsApiBaseTest < MiniTest::Unit::TestCase
+class GdsApiBaseTest < Minitest::Test
 
   class ConcreteApi < GdsApi::Base
     def base_url

--- a/test/imminence_api_test.rb
+++ b/test/imminence_api_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 require "gds_api/imminence"
 
-class ImminenceApiTest < MiniTest::Unit::TestCase
+class ImminenceApiTest < Minitest::Test
 
   ROOT = "https://imminence.test.alphagov.co.uk"
   LATITUDE = 52.1327584352089

--- a/test/licence_application_api_test.rb
+++ b/test/licence_application_api_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 require "gds_api/licence_application"
 require "gds_api/test_helpers/licence_application"
 
-class LicenceApplicationApiTest < MiniTest::Unit::TestCase
+class LicenceApplicationApiTest < Minitest::Test
   include GdsApi::TestHelpers::LicenceApplication
 
   def setup

--- a/test/router_test.rb
+++ b/test/router_test.rb
@@ -238,7 +238,8 @@ describe GdsApi::Router do
 
     describe "creating/updating a redirect route" do
       it "should allow creating/updating a redirect route" do
-        route_data = {"incoming_path" => "/foo", "route_type" => "exact", "handler" => "redirect", "redirect_to" => "/bar", "redirect_type" => "permanent"}
+        route_data = {"incoming_path" => "/foo", "route_type" => "exact", "handler" => "redirect",
+          "redirect_to" => "/bar", "redirect_type" => "permanent", "segments_mode" => nil}
         req = WebMock.stub_request(:put, "#{@base_api_url}/routes").
           with(:body => {"route" => route_data}.to_json).
           to_return(:status => 201, :body => route_data.to_json, :headers => {"Content-type" => "application/json"})
@@ -252,12 +253,28 @@ describe GdsApi::Router do
       end
 
       it "should allow creating/updating a temporary redirect route" do
-        route_data = {"incoming_path" => "/foo", "route_type" => "exact", "handler" => "redirect", "redirect_to" => "/bar", "redirect_type" => "temporary"}
+        route_data = {"incoming_path" => "/foo", "route_type" => "exact", "handler" => "redirect",
+          "redirect_to" => "/bar", "redirect_type" => "temporary", "segments_mode" => nil}
         req = WebMock.stub_request(:put, "#{@base_api_url}/routes").
           with(:body => {"route" => route_data}.to_json).
           to_return(:status => 201, :body => route_data.to_json, :headers => {"Content-type" => "application/json"})
 
         response = @api.add_redirect_route("/foo", "exact", "/bar", "temporary")
+        assert_equal 201, response.code
+        assert_equal "/bar", response.redirect_to
+
+        assert_requested(req)
+        assert_not_requested(@commit_req)
+      end
+
+      it "should allow creating/updating a redirect route which preserves segments" do
+        route_data = {"incoming_path" => "/foo", "route_type" => "exact", "handler" => "redirect",
+          "redirect_to" => "/bar", "redirect_type" => "temporary", "segments_mode" => "preserve"}
+        req = WebMock.stub_request(:put, "#{@base_api_url}/routes").
+          with(:body => {"route" => route_data}.to_json).
+          to_return(:status => 201, :body => route_data.to_json, :headers => {"Content-type" => "application/json"})
+
+        response = @api.add_redirect_route("/foo", "exact", "/bar", "temporary", :segments_mode => "preserve")
         assert_equal 201, response.code
         assert_equal "/bar", response.redirect_to
 
@@ -276,7 +293,8 @@ describe GdsApi::Router do
       end
 
       it "should raise an error if creating/updating the redirect route fails" do
-        route_data = {"incoming_path" => "/foo", "route_type" => "exact", "handler" => "redirect", "redirect_to" => "bar", "redirect_type" => "permanent"}
+        route_data = {"incoming_path" => "/foo", "route_type" => "exact", "handler" => "redirect",
+          "redirect_to" => "bar", "redirect_type" => "permanent", "segments_mode" => nil}
         response_data = route_data.merge("errors" => {"redirect_to" => "is not a valid URL path"})
 
         req = WebMock.stub_request(:put, "#{@base_api_url}/routes").

--- a/test/rummager_helpers_test.rb
+++ b/test/rummager_helpers_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 require 'gds_api/rummager'
 require 'gds_api/test_helpers/rummager'
 
-class RummagerHelpersTest < MiniTest::Unit::TestCase
+class RummagerHelpersTest < Minitest::Test
   include GdsApi::TestHelpers::Rummager
 
   def test_services_and_info_data_returns_an_adequate_response_object

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -20,7 +20,7 @@ SimpleCov.start do
   formatter SimpleCov::Formatter::RcovFormatter
 end
 
-class MiniTest::Unit::TestCase
+class Minitest::Test
   def teardown
     Timecop.return
   end


### PR DESCRIPTION
Supports new functionality in router-api where an app can specify the
behaviour of a redirect when handling path segments or query strings.

See alphagov/router#102