### PR TITLE
Update jenkins.sh to use the newer combined variant.

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,19 +1,57 @@
-#!/bin/bash -x
-set -e
+#!/bin/bash
 
+REPO_NAME=${REPO_NAME:-"alphagov/gds-api-adapters"}
+CONTEXT_MESSAGE=${CONTEXT_MESSAGE:-"default"}
+GH_STATUS_GIT_COMMIT=${SCHEMA_GIT_COMMIT:-${GIT_COMMIT}}
+
+function github_status {
+  REPO_NAME="$1"
+  STATUS="$2"
+  MESSAGE="$3"
+  gh-status "$REPO_NAME" "$GH_STATUS_GIT_COMMIT" "$STATUS" -d "Build #${BUILD_NUMBER} ${MESSAGE}" -u "$BUILD_URL" -c "$CONTEXT_MESSAGE" >/dev/null
+}
+
+function error_handler {
+  trap - ERR # disable error trap to avoid recursion
+  local parent_lineno="$1"
+  local message="$2"
+  local code="${3:-1}"
+  if [[ -n "$message" ]] ; then
+    echo "Error on or near line ${parent_lineno}: ${message}; exiting with status ${code}"
+  else
+    echo "Error on or near line ${parent_lineno}; exiting with status ${code}"
+  fi
+  github_status "$REPO_NAME" error "errored on Jenkins"
+  exit "${code}"
+}
+
+trap 'error_handler ${LINENO}' ERR
+github_status "$REPO_NAME" pending "is running on Jenkins"
+
+# Cleanup anything left from previous test runs
 git clean -fdx
 
+# Try to merge master into the current branch, and abort if it doesn't exit
+# cleanly (ie there are conflicts). This will be a noop if the current branch
+# is master.
+git merge --no-commit origin/master || git merge --abort
+
+# Bundle and run tests against multiple ruby versions
 for version in 2.2 2.1 1.9.3; do
   rm -f Gemfile.lock
   export RBENV_VERSION=$version
   echo "Running tests under ruby $version"
   bundle install --path "${HOME}/bundles/${JOB_NAME}"
-  bundle exec rake
+  if ! bundle exec rake ${TEST_TASK:-"default"}; then
+    github_status "$REPO_NAME" failure "failed on Jenkins"
+    exit 1
+  fi
 done
-
 unset RBENV_VERSION
 
 if [[ -n "$PUBLISH_GEM" ]]; then
   bundle install --path "${HOME}/bundles/${JOB_NAME}"
   bundle exec rake publish_gem --trace
 fi
+
+github_status "$REPO_NAME" success "succeeded on Jenkins"

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -3,8 +3,6 @@ set -e
 
 git clean -fdx
 
-export GOVUK_APP_DOMAIN=dev.gov.uk
-
 for version in 2.2 2.1 1.9.3; do
   rm -f Gemfile.lock
   export RBENV_VERSION=$version

--- a/jenkins_branches.sh
+++ b/jenkins_branches.sh
@@ -1,20 +1,5 @@
 #!/bin/bash
-set -e
 
-VENV_PATH="${HOME}/venv/${JOB_NAME}"
+# FIXME: Remove this file when CI is no longer referencing it.
 
-[ -x ${VENV_PATH}/bin/pip ] || virtualenv ${VENV_PATH}
-. ${VENV_PATH}/bin/activate
-
-pip install -q ghtools
-
-REPO="alphagov/gds-api-adapters"
-gh-status "$REPO" "$GIT_COMMIT" pending -d "\"Build #${BUILD_NUMBER} is running on Jenkins\"" -u "$BUILD_URL" >/dev/null
-
-if ./jenkins.sh; then
-  gh-status "$REPO" "$GIT_COMMIT" success -d "\"Build #${BUILD_NUMBER} succeeded on Jenkins\"" -u "$BUILD_URL" >/dev/null
-  exit 0
-else
-  gh-status "$REPO" "$GIT_COMMIT" failure -d "\"Build #${BUILD_NUMBER} failed on Jenkins\"" -u "$BUILD_URL" >/dev/null
-  exit 1
-fi
+exec ./jenkins.sh

--- a/test/asset_manager_test.rb
+++ b/test/asset_manager_test.rb
@@ -52,7 +52,7 @@ describe GdsApi::AssetManager do
     let(:asset_id) { "test-id" }
 
     it "updates an asset with a file" do
-      req = stub_request(:put, "http://asset-manager.dev.gov.uk/assets/test-id").
+      req = stub_request(:put, "#{base_api_url}/assets/test-id").
         to_return(:body => JSON.dump(asset_manager_response), :status => 200)
 
       response = api.update_asset(asset_id, :file => file_fixture)


### PR DESCRIPTION
This leaves a placeholder `jenkins_branches.sh` in place to ease the transition.

This PR includes a fix for the asset-manager tests that relied on the value of `GOVUK_APP_DOMAIN`.