### PR TITLE
Publish pacts to the pact broker.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,5 @@
 # -*- encoding: utf-8 -*-
 
-require "bundler/gem_tasks"
 require "rdoc/task"
 require 'rake/testtask'
 

--- a/Rakefile
+++ b/Rakefile
@@ -14,11 +14,35 @@ Rake::TestTask.new("test") do |t|
   t.test_files = FileList["test/**/*_test.rb"]
   t.verbose = true
 end
+task :default => :test
 
-require "gem_publisher"
-task :publish_gem do |t|
-  gem = GemPublisher.publish_if_updated("gds-api-adapters.gemspec", :rubygems)
-  puts "Published #{gem}" if gem
+require 'pact_broker/client/tasks'
+
+def configure_pact_broker_location(task)
+  task.pact_broker_base_url = ENV.fetch("PACT_BROKER_BASE_URL")
+  if ENV['PACT_BROKER_USERNAME']
+    task.pact_broker_basic_auth =  { username: ENV['PACT_BROKER_USERNAME'], password: ENV['PACT_BROKER_PASSWORD']}
+  end
 end
 
-task :default => :test
+PactBroker::Client::PublicationTask.new("branch") do | task |
+  task.consumer_version = ENV.fetch("PACT_TARGET_BRANCH")
+  configure_pact_broker_location(task)
+end
+
+PactBroker::Client::PublicationTask.new("released_version") do | task |
+  require 'gds_api/version'
+  task.consumer_version = GdsApi::VERSION
+  configure_pact_broker_location(task)
+end
+
+require "gem_publisher"
+desc "Publish gem to rubygems.org if necessary"
+task :publish_gem do |t|
+  gem = GemPublisher.publish_if_updated("gds-api-adapters.gemspec", :rubygems)
+  if gem
+    puts "Published #{gem}"
+
+    Rake::Task["pact:publish:released_version"].invoke
+  end
+end

--- a/gds-api-adapters.gemspec
+++ b/gds-api-adapters.gemspec
@@ -38,4 +38,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'simplecov-rcov'
   s.add_development_dependency 'timecop', '~> 0.5.1'
   s.add_development_dependency 'webmock', '~> 1.19'
+  s.add_development_dependency 'pact_broker-client', '~> 1.0.0'
 end

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -49,6 +49,10 @@ for version in 2.2 2.1 1.9.3; do
 done
 unset RBENV_VERSION
 
+if [ -n "$PACT_TARGET_BRANCH" ]; then
+  bundle exec rake pact:publish:branch
+fi
+
 if [[ -n "$PUBLISH_GEM" ]]; then
   bundle install --path "${HOME}/bundles/${JOB_NAME}"
   bundle exec rake publish_gem --trace


### PR DESCRIPTION
This adds hooks to publish the generated pacts to the pact-broker after
the test run.

If `PACT_TARGET_BRANCH` is specified, it'll push the pacts to that target.
This will be used to push to branch targets (master, or branch-foo) so
that this project can then trigger builds of other projects using these
pacts before marking the build as green.

This additionally adds a hook to publish the pacts corresponding to the
released version when the gem is published.

**Note:** This depends on https://github.com/alphagov/ci-puppet/pull/343, and also CI being configured with necessary env variables, so **DO NOT MERGE** until those are in place.