### PR TITLE
Update publishing api pact

### DIFF
--- a/lib/gds_api/publishing_api.rb
+++ b/lib/gds_api/publishing_api.rb
@@ -21,6 +21,10 @@ class GdsApi::PublishingApi < GdsApi::Base
     e
   end
 
+  def put_path(base_path, payload)
+    put_json!(paths_url(base_path), payload)
+  end
+
 
   private
 
@@ -34,5 +38,9 @@ class GdsApi::PublishingApi < GdsApi::Base
 
   def intent_url(base_path)
     "#{endpoint}/publish-intent#{base_path}"
+  end
+
+  def paths_url(base_path)
+    "#{endpoint}/paths#{base_path}"
   end
 end

--- a/lib/gds_api/test_helpers/publishing_api.rb
+++ b/lib/gds_api/test_helpers/publishing_api.rb
@@ -11,16 +11,16 @@ module GdsApi
 
       PUBLISHING_API_ENDPOINT = Plek.current.find('publishing-api')
 
-      def stub_publishing_api_put_draft_item(base_path, body = content_item_for_base_path(base_path))
+      def stub_publishing_api_put_draft_item(base_path, body = content_item_for_publishing_api(base_path))
         stub_publishing_api_put_item(base_path, body, '/draft-content')
       end
 
-      def stub_publishing_api_put_item(base_path, body = content_item_for_base_path(base_path), resource_path = '/content')
+      def stub_publishing_api_put_item(base_path, body = content_item_for_publishing_api(base_path), resource_path = '/content')
         url = PUBLISHING_API_ENDPOINT + resource_path + base_path
         stub_request(:put, url).with(body: body).to_return(status: 200, body: '{}', headers: {"Content-Type" => "application/json; charset=utf-8"})
       end
 
-      def stub_publishing_api_put_intent(base_path, body = intent_for_base_path(base_path))
+      def stub_publishing_api_put_intent(base_path, body = intent_for_publishing_api(base_path))
         url = PUBLISHING_API_ENDPOINT + "/publish-intent" + base_path
         body = body.to_json unless body.is_a?(String)
         stub_request(:put, url).with(body: body).to_return(status: 200, body: '{}', headers: {"Content-Type" => "application/json; charset=utf-8"})
@@ -108,6 +108,14 @@ module GdsApi
         else
           expected_value == actual_value
         end
+      end
+
+      def content_item_for_publishing_api(base_path, publishing_app="publisher")
+        content_item_for_base_path(base_path).merge("publishing_app" => publishing_app)
+      end
+
+      def intent_for_publishing_api(base_path, publishing_app="publisher")
+        intent_for_base_path(base_path).merge("publishing_app" => publishing_app)
       end
     end
   end

--- a/test/publishing_api_test.rb
+++ b/test/publishing_api_test.rb
@@ -147,4 +147,72 @@ describe GdsApi::PublishingApi do
       assert_equal 404, response.code
     end
   end
+
+  describe "#put_path" do
+    it "returns 200 if the path was successfully reserved" do
+      base_path = "/test-intent"
+      payload = {
+        publishing_app: "publisher"
+      }
+
+      publishing_api
+        .given("both content stores and the url-arbiter are empty")
+        .upon_receiving("a request to put a path")
+        .with(
+          method: :put,
+          path: "/paths#{base_path}",
+          body: payload,
+          headers: {
+            "Content-Type" => "application/json"
+          },
+        )
+        .will_respond_with(
+          status: 200,
+          body: {},
+          headers: {
+            "Content-Type" => "application/json; charset=utf-8"
+          }
+        )
+
+      response = @api_client.put_path(base_path, payload)
+      assert_equal 200, response.code
+    end
+
+    it "returns 422 if the request is invalid" do
+      base_path = "/test-item"
+      payload = {
+        publishing_app: "whitehall"
+      }
+
+      publishing_api
+        .given("/test-item has been reserved in url-arbiter by the Publisher application")
+        .upon_receiving("a request to change publishing app")
+        .with(
+          method: :put,
+          path: "/paths#{base_path}",
+          body: payload,
+          headers: {
+            "Content-Type" => "application/json"
+          },
+
+        )
+        .will_respond_with(
+          status: 422,
+          body: {
+            "error" => {
+              "code" => 422,
+              "message" => Pact.term(generate: "Unprocessable", matcher:/\S+/),
+              "fields" => {
+                "base_path" => Pact.each_like("has been reserved", :min => 1),
+              },
+            },
+          },
+        )
+
+      error = assert_raises GdsApi::HTTPClientError do
+        @api_client.put_path(base_path, payload)
+      end
+      assert_equal "Unprocessable", error.error_details["error"]["message"]
+    end
+  end
 end

--- a/test/publishing_api_test.rb
+++ b/test/publishing_api_test.rb
@@ -14,7 +14,7 @@ describe GdsApi::PublishingApi do
   describe "#put_content_item" do
     it "responds with 200 OK if the entry is valid" do
       base_path = "/test-content-item"
-      content_item = content_item_for_base_path(base_path).merge("update_type" => "major")
+      content_item = content_item_for_publishing_api(base_path).merge("update_type" => "major")
 
       publishing_api
         .given("both content stores and the url-arbiter are empty")
@@ -43,7 +43,7 @@ describe GdsApi::PublishingApi do
   describe "#put_draft_content_item" do
     it "responds with 200 OK if the entry is valid" do
       base_path = "/test-draft-content-item"
-      content_item = content_item_for_base_path(base_path).merge("update_type" => "major")
+      content_item = content_item_for_publishing_api(base_path).merge("update_type" => "major")
 
       publishing_api
         .given("both content stores and the url-arbiter are empty")
@@ -72,7 +72,7 @@ describe GdsApi::PublishingApi do
   describe "#put_intent" do
     it "responds with 200 OK if publish intent is valid" do
       base_path = "/test-intent"
-      publish_intent = intent_for_base_path(base_path)
+      publish_intent = intent_for_publishing_api(base_path)
 
       publishing_api
         .given("both content stores and the url-arbiter are empty")
@@ -102,7 +102,7 @@ describe GdsApi::PublishingApi do
     it "returns 200 OK if intent existed and was deleted" do
       base_path = "/test-intent"
 
-      publish_intent = intent_for_base_path(base_path)
+      publish_intent = intent_for_publishing_api(base_path)
 
       publishing_api
         .given("a publish intent exists at /test-intent in the live content store")
@@ -126,7 +126,7 @@ describe GdsApi::PublishingApi do
     it "returns 404 Not found if the intent does not exist" do
       base_path = "/test-intent"
 
-      publish_intent = intent_for_base_path(base_path)
+      publish_intent = intent_for_publishing_api(base_path)
 
       publishing_api
         .given("both content stores and the url-arbiter are empty")

--- a/test/publishing_api_v2_test.rb
+++ b/test/publishing_api_v2_test.rb
@@ -75,10 +75,10 @@ describe GdsApi::PublishingApiV2 do
             }
           )
           .will_respond_with(
-            status: 409,
+            status: 422,
             body: {
               "error" => {
-                "code" => 409,
+                "code" => 422,
                 "message" => Pact.term(generate: "Conflict", matcher:/\S+/),
                 "fields" => {
                   "base_path" => Pact.each_like("is already in use by the 'publisher' app", :min => 1),
@@ -91,8 +91,8 @@ describe GdsApi::PublishingApiV2 do
           )
       end
 
-      it "responds with 409 Conflict" do
-        error = assert_raises GdsApi::HTTPConflict do
+      it "responds with 422 Unprocessable Entity" do
+        error = assert_raises GdsApi::HTTPClientError do
           @api_client.put_content(@content_id, @content_item)
         end
         assert_equal "Conflict", error.error_details["error"]["message"]
@@ -237,7 +237,7 @@ describe GdsApi::PublishingApiV2 do
     describe "if the content item does not exist" do
       before do
         publishing_api
-          .given("both content stores and url-arbiter empty")
+          .given("both content stores and the url-arbiter are empty")
           .upon_receiving("a publish request")
           .with(
             method: :post,


### PR DESCRIPTION
Please do not merge yet. Relies on this publishing API pull request: https://github.com/alphagov/publishing-api/pull/101
Provides a convenient way to create an upstream content item complete with publishing app attribute.
Also alters the status code returned given [these changes](https://github.com/alphagov/publishing-api/pull/101) in publishing API.
Also needed are endpoint adapters for putting paths in the publishing api.
