### PR TITLE
Mapit raises error on 404

### DIFF
--- a/lib/gds_api/mapit.rb
+++ b/lib/gds_api/mapit.rb
@@ -7,8 +7,9 @@ class GdsApi::Mapit < GdsApi::Base
     response = get_json("#{base_url}/postcode/#{CGI.escape postcode}.json")
     return Location.new(response) unless response.nil?
   rescue GdsApi::HTTPErrorResponse => e
-    # allow 400 errors, as they can be invalid postcodes people have entered
-    raise e unless e.code == 400
+    # allow 400 or 404 errors, as they can be invalid postcodes people have
+    # entered or genuine postcodes with no match in Mapit
+    raise e unless (e.code == 400 || e.code == 404)
   end
 
   def areas_for_type(type)


### PR DESCRIPTION
Previously, the Mapit adapter was only raising the error when the API
return a 400. This commit updates it to also return on a 404, which
happens when a User enters a valid postcode but gets back no matches.
Most commonly, this happens with new builds.
[Ticket](https://trello.com/c/Db6csIA7/135-log-the-errors-users-see-when-entering-postcodes-on-local-transaction-pages).