### PR TITLE
Remove mention of url-arbiter

### DIFF
--- a/test/publishing_api_test.rb
+++ b/test/publishing_api_test.rb
@@ -17,7 +17,7 @@ describe GdsApi::PublishingApi do
       content_item = content_item_for_publishing_api(base_path).merge("update_type" => "major")
 
       publishing_api
-        .given("both content stores are empty")
+        .given("no content exists")
         .upon_receiving("a request to create a content item")
         .with(
           method: :put,
@@ -46,7 +46,7 @@ describe GdsApi::PublishingApi do
       content_item = content_item_for_publishing_api(base_path).merge("update_type" => "major")
 
       publishing_api
-        .given("both content stores are empty")
+        .given("no content exists")
         .upon_receiving("a request to create a draft content item")
         .with(
           method: :put,
@@ -75,7 +75,7 @@ describe GdsApi::PublishingApi do
       publish_intent = intent_for_publishing_api(base_path)
 
       publishing_api
-        .given("both content stores are empty")
+        .given("no content exists")
         .upon_receiving("a request to create a publish intent")
         .with(
           method: :put,
@@ -105,7 +105,7 @@ describe GdsApi::PublishingApi do
       publish_intent = intent_for_publishing_api(base_path)
 
       publishing_api
-        .given("a publish intent exists at /test-intent in the live content store")
+        .given("a publish intent exists at /test-intent")
         .upon_receiving("a request to delete a publish intent")
         .with(
           method: :delete,
@@ -129,7 +129,7 @@ describe GdsApi::PublishingApi do
       publish_intent = intent_for_publishing_api(base_path)
 
       publishing_api
-        .given("both content stores are empty")
+        .given("no content exists")
         .upon_receiving("a request to delete a publish intent")
         .with(
           method: :delete,
@@ -156,7 +156,7 @@ describe GdsApi::PublishingApi do
       }
 
       publishing_api
-        .given("both content stores are empty")
+        .given("no content exists")
         .upon_receiving("a request to put a path")
         .with(
           method: :put,

--- a/test/publishing_api_test.rb
+++ b/test/publishing_api_test.rb
@@ -17,7 +17,7 @@ describe GdsApi::PublishingApi do
       content_item = content_item_for_publishing_api(base_path).merge("update_type" => "major")
 
       publishing_api
-        .given("both content stores and the url-arbiter are empty")
+        .given("both content stores are empty")
         .upon_receiving("a request to create a content item")
         .with(
           method: :put,
@@ -46,7 +46,7 @@ describe GdsApi::PublishingApi do
       content_item = content_item_for_publishing_api(base_path).merge("update_type" => "major")
 
       publishing_api
-        .given("both content stores and the url-arbiter are empty")
+        .given("both content stores are empty")
         .upon_receiving("a request to create a draft content item")
         .with(
           method: :put,
@@ -75,7 +75,7 @@ describe GdsApi::PublishingApi do
       publish_intent = intent_for_publishing_api(base_path)
 
       publishing_api
-        .given("both content stores and the url-arbiter are empty")
+        .given("both content stores are empty")
         .upon_receiving("a request to create a publish intent")
         .with(
           method: :put,
@@ -129,7 +129,7 @@ describe GdsApi::PublishingApi do
       publish_intent = intent_for_publishing_api(base_path)
 
       publishing_api
-        .given("both content stores and the url-arbiter are empty")
+        .given("both content stores are empty")
         .upon_receiving("a request to delete a publish intent")
         .with(
           method: :delete,
@@ -156,7 +156,7 @@ describe GdsApi::PublishingApi do
       }
 
       publishing_api
-        .given("both content stores and the url-arbiter are empty")
+        .given("both content stores are empty")
         .upon_receiving("a request to put a path")
         .with(
           method: :put,
@@ -185,7 +185,7 @@ describe GdsApi::PublishingApi do
       }
 
       publishing_api
-        .given("/test-item has been reserved in url-arbiter by the Publisher application")
+        .given("/test-item has been reserved by the Publisher application")
         .upon_receiving("a request to change publishing app")
         .with(
           method: :put,

--- a/test/publishing_api_v2_test.rb
+++ b/test/publishing_api_v2_test.rb
@@ -38,7 +38,7 @@ describe GdsApi::PublishingApiV2 do
         @content_item = content_item_for_content_id(@content_id)
 
         publishing_api
-          .given("both content stores and the url-arbiter are empty")
+          .given("both content stores are empty")
           .upon_receiving("a request to create a content item without links")
           .with(
             method: :put,
@@ -64,7 +64,7 @@ describe GdsApi::PublishingApiV2 do
         @content_item = content_item_for_content_id(@content_id, "base_path" => "/test-item", "publishing_app" => "whitehall")
 
         publishing_api
-          .given("/test-item has been reserved in url-arbiter by the Publisher application")
+          .given("/test-item has been reserved by the Publisher application")
           .upon_receiving("a request from the Whitehall application to create a content item at /test-item")
           .with(
             method: :put,
@@ -104,7 +104,7 @@ describe GdsApi::PublishingApiV2 do
         @content_item = content_item_for_content_id(@content_id, "base_path" => "not a url path")
 
         publishing_api
-          .given("both content stores and the url-arbiter are empty")
+          .given("both content stores are empty")
           .upon_receiving("a request to create an invalid content-item")
           .with(
             method: :put,
@@ -218,7 +218,7 @@ describe GdsApi::PublishingApiV2 do
     describe "a non-existent item" do
       before do
         publishing_api
-          .given("both content stores and the url-arbiter are empty")
+          .given("both content stores are empty")
           .upon_receiving("a request for a non-existent content item")
           .with(
             method: :get,
@@ -274,7 +274,7 @@ describe GdsApi::PublishingApiV2 do
     describe "if the content item does not exist" do
       before do
         publishing_api
-          .given("both content stores and the url-arbiter are empty")
+          .given("both content stores are empty")
           .upon_receiving("a publish request")
           .with(
             method: :post,

--- a/test/publishing_api_v2_test.rb
+++ b/test/publishing_api_v2_test.rb
@@ -38,7 +38,7 @@ describe GdsApi::PublishingApiV2 do
         @content_item = content_item_for_content_id(@content_id)
 
         publishing_api
-          .given("both content stores are empty")
+          .given("no content exists")
           .upon_receiving("a request to create a content item without links")
           .with(
             method: :put,
@@ -104,7 +104,7 @@ describe GdsApi::PublishingApiV2 do
         @content_item = content_item_for_content_id(@content_id, "base_path" => "not a url path")
 
         publishing_api
-          .given("both content stores are empty")
+          .given("no content exists")
           .upon_receiving("a request to create an invalid content-item")
           .with(
             method: :put,
@@ -218,7 +218,7 @@ describe GdsApi::PublishingApiV2 do
     describe "a non-existent item" do
       before do
         publishing_api
-          .given("both content stores are empty")
+          .given("no content exists")
           .upon_receiving("a request for a non-existent content item")
           .with(
             method: :get,
@@ -274,7 +274,7 @@ describe GdsApi::PublishingApiV2 do
     describe "if the content item does not exist" do
       before do
         publishing_api
-          .given("both content stores are empty")
+          .given("no content exists")
           .upon_receiving("a publish request")
           .with(
             method: :post,


### PR DESCRIPTION
Url arbiter has been removed from publishing API, update provider state
titles accordingly.