### PR TITLE
Mapit raises error on 404

### DIFF
--- a/lib/gds_api/mapit.rb
+++ b/lib/gds_api/mapit.rb
@@ -4,11 +4,15 @@ require_relative 'exceptions'
 class GdsApi::Mapit < GdsApi::Base
 
   def location_for_postcode(postcode)
-    response = get_json("#{base_url}/postcode/#{CGI.escape postcode}.json")
-    return Location.new(response) unless response.nil?
+    response = get_json!("#{base_url}/postcode/#{CGI.escape postcode}.json")
+    Location.new(response)
+
+  rescue GdsApi::HTTPNotFound => e
+    # allow 404 errors, as these will be valid postcodes with no match in Mapit
+    e
   rescue GdsApi::HTTPErrorResponse => e
     # allow 400 errors, as they can be invalid postcodes people have entered
-    raise e unless e.code == 400
+    e
   end
 
   def areas_for_type(type)

--- a/test/mapit_test.rb
+++ b/test/mapit_test.rb
@@ -45,16 +45,18 @@ describe GdsApi::Mapit do
       assert_equal "30UN", response.areas.last.codes['ons']
     end
 
-    it "should return nil if a postcode doesn't exist" do
+    it "should return 404 if a postcode doesn't exist" do
       mapit_does_not_have_a_postcode("SW1A 1AA")
 
-      assert_nil @api.location_for_postcode("SW1A 1AA")
+      response = @api.location_for_postcode("SW1A 1AA")
+      assert_equal 404, response.code
     end
 
-    it "should return nil for an invalid postcode" do
+    it "should return 400 for an invalid postcode" do
       mapit_does_not_have_a_bad_postcode("B4DP05TC0D3")
 
-      assert_nil @api.location_for_postcode("B4DP05TC0D3")
+      response = @api.location_for_postcode("B4DP05TC0D3")
+      assert_equal 400, response.code
     end
   end
   describe "areas_for_type" do


### PR DESCRIPTION
Previously, the Mapit adapter was only raising the error when the API
return a 400. This commit updates it to also return on a 404, which
happens when a User enters a valid postcode but gets back no matches.
Most commonly, this happens with new build housing developments which
haven't been added to the MapIt DB.
[Ticket](https://trello.com/c/Db6csIA7/135-log-the-errors-users-see-when-entering-postcodes-on-local-transaction-pages).