### PR TITLE
Update version to 24.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 24.8.0
+
+* Add test helpers for Publishing-API path reservation endpoint
+
 # 24.7.0
 
 * Add put_path endpoint for Publishing-API
@@ -8,7 +12,7 @@
 
 # 24.5.0
 
-* Adds the helper methods and pact tests for the GET and PUT publishing API endpoints for managing links  
+* Adds the helper methods and pact tests for the GET and PUT publishing API endpoints for managing links
   independently of content items.
 
 # 24.4.0

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '24.7.0'
+  VERSION = '24.8.0'
 end


### PR DESCRIPTION
This version bump is for the introduction of Publishing API path reservation test helpers
https://github.com/alphagov/gds-api-adapters/pull/379