### PR TITLE
Mapit API returns error on 400

### DIFF
--- a/lib/gds_api/mapit.rb
+++ b/lib/gds_api/mapit.rb
@@ -5,10 +5,7 @@ class GdsApi::Mapit < GdsApi::Base
 
   def location_for_postcode(postcode)
     response = get_json("#{base_url}/postcode/#{CGI.escape postcode}.json")
-    return Location.new(response) unless response.nil?
-  rescue GdsApi::HTTPErrorResponse => e
-    # allow 400 errors, as they can be invalid postcodes people have entered
-    raise e unless e.code == 400
+    Location.new(response) unless response.nil?
   end
 
   def areas_for_type(type)

--- a/test/mapit_test.rb
+++ b/test/mapit_test.rb
@@ -51,10 +51,12 @@ describe GdsApi::Mapit do
       assert_nil @api.location_for_postcode("SW1A 1AA")
     end
 
-    it "should return nil for an invalid postcode" do
+    it "should return 400 for an invalid postcode" do
       mapit_does_not_have_a_bad_postcode("B4DP05TC0D3")
 
-      assert_nil @api.location_for_postcode("B4DP05TC0D3")
+      assert_raises GdsApi::HTTPClientError do
+        @api.location_for_postcode("B4DP05TC0D3")
+      end
     end
   end
   describe "areas_for_type" do


### PR DESCRIPTION
This change allows the API adapter for Mapit to return an error when the
User enters in an invalid postcode. This will allow us to log in
Frontend when this happens.

[Ticket](https://trello.com/c/Db6csIA7/135-log-the-errors-users-see-when-entering-postcodes-on-local-transaction-pages).