### PR TITLE
Version bump to 25.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 25.0.0
+
+* Allow `Mapit#location_for_postcode` to raise if it receives something which doesn't look like a postcode.
+
 # 24.8.0
 
 * Add test helpers for Publishing-API path reservation endpoint

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '24.8.0'
+  VERSION = '25.0.0'
 end


### PR DESCRIPTION
This includes the changes to the `Mapit` API added in #381.