### PR TITLE
Add support for optimistic locking to the v2 publishing API endpoints.

### DIFF
--- a/lib/gds_api/publishing_api_v2.rb
+++ b/lib/gds_api/publishing_api_v2.rb
@@ -14,8 +14,16 @@ class GdsApi::PublishingApiV2 < GdsApi::Base
   end
 
   def publish(content_id, update_type, options = {})
-    params = { update_type: update_type }
-    params = params.merge(locale: options[:locale]) if options[:locale]
+    params = {
+      update_type: update_type
+    }
+
+    optional_keys = [
+      :locale,
+      :previous_version,
+    ]
+
+    params = merge_optional_keys(params, options, optional_keys)
 
     post_json!(publish_url(content_id), params)
   end
@@ -25,8 +33,13 @@ class GdsApi::PublishingApiV2 < GdsApi::Base
   end
 
   def put_links(content_id, payload)
-    links = payload.fetch(:links)
-    put_json!(links_url(content_id), links: links)
+    params = {
+      links: payload.fetch(:links)
+    }
+
+    params = merge_optional_keys(params, payload, [:previous_version])
+
+    put_json!(links_url(content_id), params)
   end
 
 private
@@ -42,5 +55,11 @@ private
 
   def publish_url(content_id)
     "#{endpoint}/v2/content/#{content_id}/publish"
+  end
+
+  def merge_optional_keys(params, options, optional_keys)
+    optional_keys.each_with_object(params) do |optional_key, hash|
+      hash.merge!(optional_key => options[optional_key]) if options[optional_key]
+    end
   end
 end


### PR DESCRIPTION
This allows publisher applications to detect conflicts
when (for example) a user has left their edit page
open for a long time and someone else has updated
the item in the meantime.

If the version the app thinks it's updating does
not match the version in the Publishing API, a 409
Conflict is returned.

If the `previous_version` key is not provided, no
checking is performed.  This makes this locking
opt-in on the part of the publisher application.

https://trello.com/c/s3dN4eDP/336-optimistic-locking