### PR TITLE
Autocorrect obvious typos in postcodes before sending to MapIt

### DIFF
--- a/gds-api-adapters.gemspec
+++ b/gds-api-adapters.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'lrucache', '~> 0.1.1'
   s.add_dependency 'rest-client', '~> 1.8.0'
   s.add_dependency 'rack-cache'
+  s.add_dependency 'uk_postcode', '2.1.0'
 
   s.add_development_dependency 'gem_publisher', '~> 1.5.0'
   s.add_development_dependency 'mocha', "> 1.0.0"

--- a/lib/gds_api/mapit.rb
+++ b/lib/gds_api/mapit.rb
@@ -1,9 +1,12 @@
 require_relative 'base'
 require_relative 'exceptions'
+require_relative 'postcode_sanitizer'
+
 
 class GdsApi::Mapit < GdsApi::Base
 
   def location_for_postcode(postcode)
+    postcode = GdsApi::PostcodeSanitizer.sanitize(postcode)
     response = get_json("#{base_url}/postcode/#{CGI.escape postcode}.json")
     Location.new(response) unless response.nil?
   end

--- a/lib/gds_api/postcode_sanitizer.rb
+++ b/lib/gds_api/postcode_sanitizer.rb
@@ -1,0 +1,11 @@
+require 'uk_postcode'
+
+module GdsApi
+  class PostcodeSanitizer
+    def self.sanitize(postcode)
+      # Strip trailing whitespace, non-alphanumerics, and use the
+      # uk_postcode gem to potentially transpose O/0 and I/1.
+      UKPostcode.parse(postcode.gsub(/[^a-z0-9 ]/i, '').strip).to_s
+    end
+  end
+end

--- a/test/mapit_test.rb
+++ b/test/mapit_test.rb
@@ -45,6 +45,14 @@ describe GdsApi::Mapit do
       assert_equal "30UN", response.areas.last.codes['ons']
     end
 
+    it "should strip non-alphanumeric characters apart from a single space from the postcode, and potentially transpose letters for numbers" do
+      mapit_has_a_postcode("SW1A 1AA", [ 51.5010096, -0.141870 ])
+
+      response = @api.location_for_postcode("SWIA-1AA] ")
+      assert_equal 51.5010096, response.lat
+      assert_equal -0.141870, response.lon
+    end
+
     it "should return nil if a postcode doesn't exist" do
       mapit_does_not_have_a_postcode("SW1A 1AA")
 

--- a/test/postcode_sanitizer_test.rb
+++ b/test/postcode_sanitizer_test.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+require 'gds_api/postcode_sanitizer'
+
+describe GdsApi::PostcodeSanitizer do
+
+  describe "postcodes come through" do
+
+    it "strips trailing spaces from entered postcodes" do
+      assert_equal "WC2B 6NH", GdsApi::PostcodeSanitizer.sanitize("WC2B 6NH ")
+    end
+
+    it "strips non-alphanumerics from entered postcodes" do
+      assert_equal "WC2B 6NH", GdsApi::PostcodeSanitizer.sanitize("WC2B   -6NH]")
+    end
+
+    it "transposes O/0 and I/1 if necessary" do
+      # Thanks to the uk_postcode gem.
+      assert_equal "W1A 0AA", GdsApi::PostcodeSanitizer.sanitize("WIA OAA")
+    end
+
+  end
+
+end


### PR DESCRIPTION
- We were seeing lots of errors for postcodes entered with obvious
  typos, eg. hyphens instead of spaces, 0 instead of O, I instead of 1,
  etc, so this is an attempt at fixing most common ones. Strip most
  non-alphanumerics and trailing whitespace. Also use the uk_postcode
  gem to fix transposition of I/1, O/0.
- This was originally done in Imminence (https://github.com/alphagov/imminence/pull/116), but then it turned
  out that it wasn't working in the way I thought it did, with multiple
  apps (frontend included - vital for postcode lookups on local
  transaction pages) going directly to MapIt via the MapIt GDS API
  Adapter, hence doing the munging in here instead. Even Imminence uses
  this API Adapter, so the behaviour will be the same without the PR on
  Imminence.

(Thanks to @h-lame and @davidbasalla for helping me make sense of what was going on!)