### PR TITLE
Add `PublishingApiV2#get_content_items`

### DIFF
--- a/lib/gds_api/base.rb
+++ b/lib/gds_api/base.rb
@@ -65,7 +65,7 @@ private
       case value
       when Array
         value.map { |v|
-          "#{CGI.escape(key+'[]')}=#{CGI.escape(v.to_s)}"
+          "#{CGI.escape(key.to_s+'[]')}=#{CGI.escape(v.to_s)}"
         }
       else
         "#{CGI.escape(key.to_s)}=#{CGI.escape(value.to_s)}"

--- a/lib/gds_api/publishing_api_v2.rb
+++ b/lib/gds_api/publishing_api_v2.rb
@@ -42,6 +42,11 @@ class GdsApi::PublishingApiV2 < GdsApi::Base
     put_json!(links_url(content_id), params)
   end
 
+  def get_content_items(params)
+    query = query_string(params)
+    get_json("#{endpoint}/v2/content#{query}")
+  end
+
 private
 
   def content_url(content_id, params = {})

--- a/test/publishing_api_v2_test.rb
+++ b/test/publishing_api_v2_test.rb
@@ -892,4 +892,38 @@ describe GdsApi::PublishingApiV2 do
       end
     end
   end
+
+  describe "#get_content_items" do
+    it "returns the content items of a certain format" do
+      publishing_api
+        .given("there is content with format 'topic'")
+        .upon_receiving("a get entries request")
+        .with(
+          method: :get,
+          path: "/v2/content",
+          query: "content_format=topic&fields%5B%5D=title&fields%5B%5D=base_path",
+          headers: {
+            "Content-Type" => "application/json",
+          },
+        )
+        .will_respond_with(
+          status: 200,
+          body: [
+            { title: 'Content Item A', base_path: '/a-base-path' },
+            { title: 'Content Item B', base_path: '/another-base-path' },
+          ]
+        )
+
+      response = @api_client.get_content_items(
+        content_format: 'topic',
+        fields: [:title, :base_path],
+      )
+
+      assert_equal 200, response.code
+      assert_equal [
+        { 'title' => 'Content Item A', 'base_path' => '/a-base-path' },
+        { 'title' => 'Content Item B', 'base_path' => '/another-base-path' },
+      ], response.to_a
+    end
+  end
 end


### PR DESCRIPTION
This method is used to interact with the `/v2/content` endpoint on publishing-api.

Endpoint PR: alphagov/publishing-api#126
