### PR TITLE
Pin `tins` dependency to ruby 1.9.3-compatible version

### DIFF
--- a/gds-api-adapters.gemspec
+++ b/gds-api-adapters.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'gem_publisher', '~> 1.5.0'
   s.add_development_dependency 'mocha', "> 1.0.0"
   s.add_development_dependency "minitest", "> 5.0.0"
+  s.add_development_dependency 'tins', '1.6.0'
   s.add_development_dependency 'pact'
   s.add_development_dependency 'pact-consumer-minitest'
   s.add_development_dependency 'pry'


### PR DESCRIPTION
`tins` is a dependency of `term-ansicolor`, which is a dependency of `pact`.

A recent change in `tins` (https://github.com/flori/tins/commit/9ebb625d8a987bd54526006441ff97bc14c30e53) made ruby 2.0.0 required for that gem.

Because we pull in the latest version and `term-ansicolor` allows upgrades to any `1.X`, our tests have started failing after `tins` published 1.7.

