### PR TITLE
Add documentation for PublishingApiV2::get_content_items

### DIFF
--- a/lib/gds_api/publishing_api_v2.rb
+++ b/lib/gds_api/publishing_api_v2.rb
@@ -42,6 +42,30 @@ class GdsApi::PublishingApiV2 < GdsApi::Base
     put_json!(links_url(content_id), params)
   end
 
+
+  # Returns content items by format.
+  #
+  # This includes draft content items. A special field +publication_state+ will
+  # be returned indicating wheter the content item is live or draft.
+  #
+  # @param params [Hash]
+  # @option params [String] content_format A GOV.UK content format, like +topic+
+  #   or +mainstream_browse_page+.
+  # @option params [Array] fields Attributes of the content item, like +title+,
+  #   +description+ or +content_id+. You can request any valid content_item
+  #   attribute (including +details+, which contains page data).
+  #
+  # @return [GdsApi::Response] a list of content items of the format.
+  #
+  # @example
+  #  publishing_api.get_content_items(content_format: 'topic', fields: [:title, :base_path])
+  #
+  #  # will return a GdsApi::Response with the data:
+  #
+  #  [
+  #    {"title" => "A", "base_path" => "/a-live-item", "publication_state" => "live"},
+  #    {"title" => "B", "base_path" => "/a-draft-item", "publication_state" => "draft"}
+  #  ]
   def get_content_items(params)
     query = query_string(params)
     get_json("#{endpoint}/v2/content#{query}")


### PR DESCRIPTION
This commit adds some documentation for the `/v2/content` endpoint. When merged, it can be automatically accessed on rubydoc.info:

http://www.rubydoc.info/gems/gds-api-adapters/25.1.0/GdsApi/PublishingApiV2
 
This is how it looks:

![screen shot 2015-11-16 at 17 24 10](https://cloud.githubusercontent.com/assets/233676/11189218/e23ac276-8c86-11e5-9f04-aa6ee5e48810.png)

As far as I can see, we're not using this for this gem, so open for discussion.