### PR TITLE
Release 25.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 25.2.0
+
+* Add `PublishingApiV2#get_content_items`.
+
 # 25.1.0
 
 * Add support for optimistic locking to the v2 publishing API endpoints.

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '25.1.0'
+  VERSION = '25.2.0'
 end


### PR DESCRIPTION
Adds `PublishingApiV2#get_content_items` (https://github.com/alphagov/gds-api-adapters/pull/386).