### PR TITLE
Add helpers to stub Pub API v2 show and index

### DIFF
--- a/lib/gds_api/test_helpers/publishing_api_v2.rb
+++ b/lib/gds_api/test_helpers/publishing_api_v2.rb
@@ -70,6 +70,26 @@ module GdsApi
         end
       end
 
+      def publishing_api_has_fields_for_format(format, items, fields)
+        body = items.map { |item|
+          item.with_indifferent_access.slice(*fields)
+        }
+
+        query_params = fields.map { |f|
+          "&fields%5B%5D=#{f}"
+        }
+
+        url = PUBLISHING_API_V2_ENDPOINT + "/content?content_format=#{format}#{query_params.join('')}"
+
+        stub_request(:get, url).to_return(:status => 200, :body => body.to_json, :headers => {})
+      end
+
+      def publishing_api_has_item(item)
+        item = item.with_indifferent_access
+        url = PUBLISHING_API_V2_ENDPOINT + "/content/" + item[:content_id]
+        stub_request(:get, url).to_return(status: 200, body: item.to_json, headers: {})
+      end
+
     private
       def stub_publishing_api_put(content_id, body, resource_path)
         url = PUBLISHING_API_V2_ENDPOINT + resource_path + "/" + content_id


### PR DESCRIPTION
These helpers can be used to stub out the `show` and `index` endpoints
for the Publishing API V2.