### PR TITLE
Version bump to 25.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 25.3.0
+
+* Add Test Helpers for Publishing API V2 `index` and `get`
+
 # 25.2.0
 
 * Add `PublishingApiV2#get_content_items`.

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '25.2.0'
+  VERSION = '25.3.0'
 end


### PR DESCRIPTION
This bump adds Test Helpers for Publishing API V2 `index` and `get`
added in #391.