### PR TITLE
Add publishing api discard draft endpoint

### DIFF
--- a/lib/gds_api/publishing_api_v2.rb
+++ b/lib/gds_api/publishing_api_v2.rb
@@ -1,7 +1,6 @@
 require_relative 'base'
 
 class GdsApi::PublishingApiV2 < GdsApi::Base
-
   def put_content(content_id, payload)
     put_json!(content_url(content_id), payload)
   end

--- a/lib/gds_api/publishing_api_v2.rb
+++ b/lib/gds_api/publishing_api_v2.rb
@@ -46,6 +46,10 @@ class GdsApi::PublishingApiV2 < GdsApi::Base
     get_json("#{endpoint}/v2/content#{query}")
   end
 
+  def discard_draft(content_id)
+    post_json!(discard_url(content_id), {})
+  end
+
 private
 
   def content_url(content_id, params = {})
@@ -59,6 +63,10 @@ private
 
   def publish_url(content_id)
     "#{endpoint}/v2/content/#{content_id}/publish"
+  end
+
+  def discard_url(content_id)
+    "#{endpoint}/v2/content/#{content_id}/discard-draft"
   end
 
   def merge_optional_keys(params, options, optional_keys)

--- a/lib/gds_api/test_helpers/publishing_api_v2.rb
+++ b/lib/gds_api/test_helpers/publishing_api_v2.rb
@@ -23,6 +23,11 @@ module GdsApi
         stub_request(:post, url).with(body: body).to_return(status: 200, body: '{}', headers: {"Content-Type" => "application/json; charset=utf-8"})
       end
 
+      def stub_publishing_api_discard_draft(content_id)
+        url = PUBLISHING_API_V2_ENDPOINT + "/content/#{content_id}/discard-draft"
+        stub_request(:post, url).to_return(status: 200, headers: {"Content-Type" => "application/json; charset=utf-8"})
+      end
+
       def stub_publishing_api_put_content_links_and_publish(body, content_id = nil, publish_options = nil)
         content_id ||= body[:content_id]
         publish_options ||= { update_type: { update_type: body[:update_type], locale: body[:locale] } }

--- a/test/publishing_api_v2_test.rb
+++ b/test/publishing_api_v2_test.rb
@@ -926,4 +926,59 @@ describe GdsApi::PublishingApiV2 do
       ], response.to_a
     end
   end
+
+  describe "#discard_draft(content_id)" do
+    describe "when the content item exists" do
+      before do
+        @content_item = content_item_for_content_id(@content_id)
+
+        publishing_api
+          .given("a content item exists with content_id: #{@content_id}")
+          .upon_receiving("a request to discard draft content")
+          .with(
+            method: :post,
+            path: "/v2/content/#{@content_id}/discard-draft",
+            body: {},
+            headers: {
+              "Content-Type" => "application/json",
+            },
+          )
+          .will_respond_with(
+            status: 200,
+          )
+      end
+
+      it "responds with 200" do
+        response = @api_client.discard_draft(@content_id)
+        assert_equal 200, response.code
+      end
+    end
+
+    describe "when there is no content with that content_id" do
+      before do
+        publishing_api
+          .given("no content exists")
+          .upon_receiving("a request to discard draft content")
+          .with(
+            method: :post,
+            path: "/v2/content/#{@content_id}/discard-draft",
+            body: {},
+            headers: {
+              "Content-Type" => "application/json",
+            },
+          )
+          .will_respond_with(
+            status: 404,
+          )
+      end
+
+      it "responds with a 404" do
+        error = assert_raises GdsApi::HTTPClientError do
+          @api_client.discard_draft(@content_id)
+        end
+
+        assert_equal 404, error.code
+      end
+    end
+  end
 end


### PR DESCRIPTION
This allows the discarding of unpublished drafts
for documents which have or have not been published
before.