### PR TITLE
Bump version to 26.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 26.3.0
+
+* Publishing API v2: add stub for 404 responses
+
 # 26.2.0
 
 * Support optional locale and previous version for discard_draft publishing API call

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '26.2.0'
+  VERSION = '26.3.0'
 end


### PR DESCRIPTION
This adds the Publishing API v2 stub for 404 responses (https://github.com/alphagov/gds-api-adapters/pull/399).

/cc @elliotcm @jamiecobbett 