### PR TITLE
Fix publishing api v2 publish stub

### DIFF
--- a/lib/gds_api/test_helpers/publishing_api_v2.rb
+++ b/lib/gds_api/test_helpers/publishing_api_v2.rb
@@ -28,13 +28,13 @@ module GdsApi
         stub_request(:post, url).to_return(status: 200, headers: {"Content-Type" => "application/json; charset=utf-8"})
       end
 
-      def stub_publishing_api_put_content_links_and_publish(body, content_id = nil, publish_options = nil)
+      def stub_publishing_api_put_content_links_and_publish(body, content_id = nil, publish_body = nil)
         content_id ||= body[:content_id]
-        publish_options ||= { update_type: body[:update_type], locale: body[:locale] }
+        publish_body ||= { update_type: body[:update_type], locale: body[:locale] }
         stubs = []
         stubs << stub_publishing_api_put_content(content_id, body.except(:links))
         stubs << stub_publishing_api_put_links(content_id, body.slice(:links)) unless body.slice(:links).empty?
-        stubs << stub_publishing_api_publish(content_id, publish_options)
+        stubs << stub_publishing_api_publish(content_id, publish_body)
         stubs
       end
 

--- a/lib/gds_api/test_helpers/publishing_api_v2.rb
+++ b/lib/gds_api/test_helpers/publishing_api_v2.rb
@@ -30,7 +30,10 @@ module GdsApi
 
       def stub_publishing_api_put_content_links_and_publish(body, content_id = nil, publish_body = nil)
         content_id ||= body[:content_id]
-        publish_body ||= { update_type: body[:update_type], locale: body[:locale] }
+        if publish_body.nil?
+          publish_body = { update_type: body.fetch(:update_type) }
+          publish_body[:locale] = body[:locale] if body[:locale]
+        end
         stubs = []
         stubs << stub_publishing_api_put_content(content_id, body.except(:links))
         stubs << stub_publishing_api_put_links(content_id, body.slice(:links)) unless body.slice(:links).empty?

--- a/lib/gds_api/test_helpers/publishing_api_v2.rb
+++ b/lib/gds_api/test_helpers/publishing_api_v2.rb
@@ -30,7 +30,7 @@ module GdsApi
 
       def stub_publishing_api_put_content_links_and_publish(body, content_id = nil, publish_options = nil)
         content_id ||= body[:content_id]
-        publish_options ||= { update_type: { update_type: body[:update_type], locale: body[:locale] } }
+        publish_options ||= { update_type: body[:update_type], locale: body[:locale] }
         stubs = []
         stubs << stub_publishing_api_put_content(content_id, body.except(:links))
         stubs << stub_publishing_api_put_links(content_id, body.slice(:links)) unless body.slice(:links).empty?


### PR DESCRIPTION
It was nesting the keys inside an update_type key, but shouldn't have been.

Code tested with this helper will be sending the update_type and locale keys in a way that will be ignored by publishing-api. This is currently true of Whitehall.

I think this would be a PATCH release.

/cc @elliotcm @benilovj 