### PR TITLE
Bump version to 26.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 26.3.1
+
+* Fix the composite "put and publish" Publishing API v2 stub
+
 # 26.3.0
 
 * Publishing API v2: add stub for 404 responses

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '26.3.0'
+  VERSION = '26.3.1'
 end


### PR DESCRIPTION
This picks up https://github.com/alphagov/gds-api-adapters/pull/401.

/cc @jamiecobbett 