### PR TITLE
Add `incoming_links` to content store client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Add `ContentStore#incoming_links!`
+
 # 26.3.1
 
 * Fix the composite "put and publish" Publishing API v2 stub

--- a/lib/gds_api/content_store.rb
+++ b/lib/gds_api/content_store.rb
@@ -13,6 +13,12 @@ class GdsApi::ContentStore < GdsApi::Base
     get_json(content_item_url(base_path))
   end
 
+  def incoming_links!(base_path)
+    get_json!(incoming_links_url(base_path))
+  rescue GdsApi::HTTPNotFound => e
+    raise ItemNotFound.build_from(e)
+  end
+
   def content_item!(base_path)
     get_json!(content_item_url(base_path))
   rescue GdsApi::HTTPNotFound => e
@@ -23,5 +29,9 @@ class GdsApi::ContentStore < GdsApi::Base
 
   def content_item_url(base_path)
     "#{endpoint}/content#{base_path}"
+  end
+
+  def incoming_links_url(base_path)
+    "#{endpoint}/incoming-links#{base_path}"
   end
 end

--- a/lib/gds_api/test_helpers/content_store.rb
+++ b/lib/gds_api/test_helpers/content_store.rb
@@ -34,6 +34,9 @@ module GdsApi
       def content_store_does_not_have_item(base_path)
         url = CONTENT_STORE_ENDPOINT + "/content" + base_path
         stub_request(:get, url).to_return(status: 404, headers: {})
+
+        url = CONTENT_STORE_ENDPOINT + "/incoming-links" + base_path
+        stub_request(:get, url).to_return(status: 404, headers: {})
       end
 
       def content_store_isnt_available
@@ -42,6 +45,13 @@ module GdsApi
 
       def content_item_for_base_path(base_path)
         super.merge({ "base_path" => base_path })
+      end
+
+      def content_store_has_incoming_links(base_path, links)
+        url = CONTENT_STORE_ENDPOINT + "/incoming-links" + base_path
+        body = links.to_json
+
+        stub_request(:get, url).to_return(body: body)
       end
     end
   end

--- a/test/content_store_test.rb
+++ b/test/content_store_test.rb
@@ -48,4 +48,25 @@ describe GdsApi::ContentStore do
       assert_equal "url: #{@base_api_url}/content/non-existent", e.message.strip
     end
   end
+
+  describe "#incoming_links!" do
+    it "returns the item" do
+      base_path = "/test-from-content-store"
+      content_store_has_incoming_links(base_path, [ { title: "Yolo" }])
+
+      response = @api.incoming_links!(base_path)
+
+      assert_equal [ { "title" => "Yolo" } ], response.to_hash
+    end
+
+    it "raises if the item doesn't exist" do
+      content_store_does_not_have_item("/non-existent")
+
+      e = assert_raises GdsApi::ContentStore::ItemNotFound do
+        response = @api.incoming_links!("/non-existent")
+      end
+
+      assert_equal 404, e.code
+    end
+  end
 end

--- a/test/content_store_test.rb
+++ b/test/content_store_test.rb
@@ -10,33 +10,40 @@ describe GdsApi::ContentStore do
     @api = GdsApi::ContentStore.new(@base_api_url)
   end
 
-  describe "content_item" do
-    it "should return the item" do
+  describe "#content_item" do
+    it "returns the item" do
       base_path = "/test-from-content-store"
       content_store_has_item(base_path)
+
       response = @api.content_item(base_path)
+
       assert_equal base_path, response["base_path"]
     end
 
-    it "should return nil if the item doesn't exist" do
+    it "returns nil if the item doesn't exist" do
       content_store_does_not_have_item("/non-existent")
+
       assert_nil @api.content_item("/non-existent")
     end
   end
 
-  describe "content_item!" do
-    it "should return the item" do
+  describe "#content_item!" do
+    it "returns the item" do
       base_path = "/test-from-content-store"
       content_store_has_item(base_path)
+
       response = @api.content_item!(base_path)
+
       assert_equal base_path, response["base_path"]
     end
 
-    it "should raise if the item doesn't exist" do
+    it "raises if the item doesn't exist" do
       content_store_does_not_have_item("/non-existent")
+
       e = assert_raises GdsApi::ContentStore::ItemNotFound do
         @api.content_item!("/non-existent")
       end
+
       assert_equal 404, e.code
       assert_equal "url: #{@base_api_url}/content/non-existent", e.message.strip
     end


### PR DESCRIPTION
The `/incoming-links` endpoint was added in alphagov/content-store#174.

Trello: https://trello.com/c/bsZAwZ35