### PR TITLE
Migrate SpecialRoutePublisher to use v2 of publishing-api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Changed SpecialRoutePublisher to use v2 of publishing-api
+
 # 26.4.0
 
 * Performance Platform: add test helper stub for non-existent datasets

--- a/lib/gds_api/publishing_api/special_route_publisher.rb
+++ b/lib/gds_api/publishing_api/special_route_publisher.rb
@@ -1,4 +1,4 @@
-require "gds_api/publishing_api"
+require "gds_api/publishing_api_v2"
 require "time"
 
 module GdsApi
@@ -6,14 +6,14 @@ module GdsApi
     class SpecialRoutePublisher
       def initialize(options = {})
         @logger = options[:logger] || GdsApi::Base.logger
-        @publishing_api = options[:publishing_api] || GdsApi::PublishingApi.new(Plek.find("publishing-api"))
+        @publishing_api = options[:publishing_api] || GdsApi::PublishingApiV2.new(Plek.find("publishing-api"))
       end
 
       def publish(options)
         logger.info("Publishing #{options.fetch(:type)} route #{options.fetch(:base_path)}, routing to #{options.fetch(:rendering_app)}")
 
-        publishing_api.put_content_item(options.fetch(:base_path), {
-          content_id: options.fetch(:content_id),
+        put_content_response = publishing_api.put_content(options.fetch(:content_id), {
+          base_path: options.fetch(:base_path),
           format: "special_route",
           title: options.fetch(:title),
           description: options[:description] || "",
@@ -25,9 +25,10 @@ module GdsApi
           ],
           publishing_app: options.fetch(:publishing_app),
           rendering_app: options.fetch(:rendering_app),
-          update_type: "major",
           public_updated_at: time.now.iso8601,
         })
+        publishing_api.publish(options.fetch(:content_id), 'major')
+        put_content_response
       end
 
     private

--- a/test/publishing_api/special_route_publisher_test.rb
+++ b/test/publishing_api/special_route_publisher_test.rb
@@ -1,18 +1,14 @@
 require 'test_helper'
 require "gds_api/publishing_api/special_route_publisher"
+require File.dirname(__FILE__) + '/../../lib/gds_api/test_helpers/publishing_api_v2'
 
 describe GdsApi::PublishingApi::SpecialRoutePublisher do
-  let(:publishing_api) {
-    stub(:publishing_api, put_content_item: nil)
-  }
+  include ::GdsApi::TestHelpers::PublishingApiV2
 
-  let(:publisher) {
-    GdsApi::PublishingApi::SpecialRoutePublisher.new(publishing_api: publishing_api)
-  }
-
+  let(:content_id) { 'a-content-id-of-sorts' }  
   let(:special_route) {
     {
-      content_id: "a-content-id-of-sorts",
+      content_id: content_id,
       title: "A title",
       description: "A description",
       base_path: "/favicon.ico",
@@ -24,55 +20,71 @@ describe GdsApi::PublishingApi::SpecialRoutePublisher do
 
   describe ".publish" do
     it "publishes the special routes" do
+      
       Timecop.freeze(Time.now) do
-        publishing_api.expects(:put_content_item).with(
-          special_route[:base_path],
-          {
-            content_id: special_route[:content_id],
-            format: "special_route",
-            title: special_route[:title],
-            description: special_route[:description],
-            routes: [
-              {
-                path: special_route[:base_path],
-                type: special_route[:type],
-              }
-            ],
-            publishing_app: special_route[:publishing_app],
-            rendering_app: special_route[:rendering_app],
-            update_type: "major",
-            public_updated_at: Time.now.iso8601,
-          }
-        )
+        publisher = GdsApi::PublishingApi::SpecialRoutePublisher.new
+        endpoint = Plek.current.find('publishing-api')
+        payload = {
+          base_path: special_route[:base_path],
+          format: "special_route",
+          title: special_route[:title],
+          description: special_route[:description],
+          routes: [
+            {
+              path: special_route[:base_path],
+              type: special_route[:type],
+            }
+          ],
+          publishing_app: special_route[:publishing_app],
+          rendering_app: special_route[:rendering_app],
+          public_updated_at: Time.now.iso8601,
+        }
 
+        stub_any_publishing_api_call
+        
         publisher.publish(special_route)
+
+        base_path = "#{endpoint}/v2/content/#{content_id}"
+        assert_requested(:put, base_path, body: payload)
+        assert_requested(:post, "#{base_path}/publish", body: { update_type: 'major' })
+
       end
     end
 
-    it "is robust to Time.zone returning nil" do
-      Timecop.freeze(Time.now) do
-        Time.stubs(:zone).returns(nil)
+    describe 'Timezone handling' do
+      let(:publishing_api) {
+        stub(:publishing_api, put_content_item: nil)
+      }
+      let(:publisher) {
+        GdsApi::PublishingApi::SpecialRoutePublisher.new(publishing_api: publishing_api)
+      }
 
-        publishing_api.expects(:put_content_item).with(
-          anything,
-          has_entries(public_updated_at: Time.now.iso8601)
-        )
+      it "is robust to Time.zone returning nil" do
+        Timecop.freeze(Time.now) do
+          Time.stubs(:zone).returns(nil)
+          publishing_api.expects(:put_content).with(
+            anything,
+            has_entries(public_updated_at: Time.now.iso8601)
+          )
+          publishing_api.expects(:publish)
 
-        publisher.publish(special_route)
+          publisher.publish(special_route)
+        end
       end
-    end
 
-    it "uses Time.zone if available" do
-      Timecop.freeze(Time.now) do
-        time_in_zone = stub("Time in zone", now: Time.parse("2010-01-01 10:10:10 +04:00"))
-        Time.stubs(:zone).returns(time_in_zone)
+      it "uses Time.zone if available" do
+        Timecop.freeze(Time.now) do
+          time_in_zone = stub("Time in zone", now: Time.parse("2010-01-01 10:10:10 +04:00"))
+          Time.stubs(:zone).returns(time_in_zone)
 
-        publishing_api.expects(:put_content_item).with(
-          anything,
-          has_entries(public_updated_at: time_in_zone.now.iso8601)
-        )
+          publishing_api.expects(:put_content).with(
+            anything,
+            has_entries(public_updated_at: time_in_zone.now.iso8601)
+          )
+          publishing_api.expects(:publish)
 
-        publisher.publish(special_route)
+          publisher.publish(special_route)
+        end
       end
     end
   end


### PR DESCRIPTION
All clients of publishing-api should use v2 of the API.  This library contains one class, SpecialRoutePublisher which talks to the publishing-api (rather than just provide convenience adapter methods to do so).  This change modifies that class to use v2 of the API.

Trello: https://trello.com/c/yaUJdIRH/456-migrate-gds-api-adapters-gdsapi-publishingapi-specialroutepublisher-to-use-v2-of-publishing-api