### PR TITLE
Bump version to 26.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 26.4.0
+
+* Performance Platform: add test helper stub for non-existent datasets
 * Add `ContentStore#incoming_links!`
 
 # 26.3.1

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '26.3.1'
+  VERSION = '26.4.0'
 end


### PR DESCRIPTION
* Performance Platform: add test helper stub for non-existent datasets
* Add `ContentStore#incoming_links!`