### PR TITLE
Add `PublishingApiV2#get_linked_items`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Add `PublishingApiV2#get_linked_items`.
+
 # 26.5.0
 
 * Changed SpecialRoutePublisher to use v2 of publishing-api

--- a/lib/gds_api/publishing_api_v2.rb
+++ b/lib/gds_api/publishing_api_v2.rb
@@ -57,6 +57,11 @@ class GdsApi::PublishingApiV2 < GdsApi::Base
     get_json("#{endpoint}/v2/content#{query}")
   end
 
+  def get_linked_items(content_id, params = {})
+    query = query_string(params)
+    get_json("#{endpoint}/v2/linked/#{content_id}#{query}")
+  end
+
 private
 
   def content_url(content_id, params = {})


### PR DESCRIPTION
This method is used to interact with the `/v2/linked` endpoint on the
publishing-api.

Endpoint PR:
https://github.com/alphagov/publishing-api/pull/157