### PR TITLE
Pass publishing_app in get_content_items request

### DIFF
--- a/lib/gds_api/publishing_api_v2.rb
+++ b/lib/gds_api/publishing_api_v2.rb
@@ -53,6 +53,8 @@ class GdsApi::PublishingApiV2 < GdsApi::Base
   end
 
   def get_content_items(params)
+    params = { publishing_app: app_name }.merge(params)
+    params.delete(:publishing_app) if params[:publishing_app] == 'all'
     query = query_string(params)
     get_json("#{endpoint}/v2/content#{query}")
   end
@@ -80,5 +82,9 @@ private
     optional_keys.each_with_object(params) do |optional_key, hash|
       hash.merge!(optional_key => options[optional_key]) if options[optional_key]
     end
+  end
+
+  def app_name
+    ENV["GOVUK_APP_NAME"]
   end
 end


### PR DESCRIPTION
The value is sourced from the GOVUK_APP_NAME env var by default; it can be
overridden by passing in the publishing_app parameter explicitly to
get_content_items. Passing a value of "all" will return all items.