### PR TITLE
Add additional publishing-api-v2 test helpers

### DIFF
--- a/lib/gds_api/test_helpers/publishing_api_v2.rb
+++ b/lib/gds_api/test_helpers/publishing_api_v2.rb
@@ -10,8 +10,20 @@ module GdsApi
 
       PUBLISHING_API_V2_ENDPOINT = Plek.current.find('publishing-api') + '/v2'
 
-      def stub_publishing_api_put_content(content_id, body)
-        stub_publishing_api_put(content_id, body, '/content')
+      # stubs a PUT /v2/content/:content_id request with the given content id and request body.
+      # if no response_hash is given, a default response as follows is created:
+      # {status: 200, body: '{}', headers: {"Content-Type" => "application/json; charset=utf-8"}}
+      #
+      # if a response is given, then it will be merged with the default response.
+      # if the given parameter for the response body is a Hash, it will be converted to JSON.
+      #
+      # e.g. The following two examples are equivalent: 
+      #
+      # * stub_publishing_api_put_content(my_content_id, my_request_body, { status: 201, body: {version: 33}.to_json })
+      # * stub_publishing_api_put_content(my_content_id, my_request_body, { status: 201, body: {version: 33} })
+      #
+      def stub_publishing_api_put_content(content_id, body, response_hash = {})
+        stub_publishing_api_put(content_id, body, '/content', response_hash)
       end
 
       def stub_publishing_api_put_links(content_id, body)
@@ -58,6 +70,10 @@ module GdsApi
           .to_return(status: 404, headers: {"Content-Type" => "application/json; charset=utf-8"})
       end
 
+      def publishing_api_isnt_available
+        stub_request(:any, /#{PUBLISHING_API_V2_ENDPOINT}\/.*/).to_return(status: 503)
+      end
+
       def assert_publishing_api_put_content(content_id, attributes_or_matcher = {}, times = 1)
         url = PUBLISHING_API_V2_ENDPOINT + "/content/" + content_id
         assert_publishing_api(:put, url, attributes_or_matcher, times)
@@ -66,6 +82,11 @@ module GdsApi
       def assert_publishing_api_publish(content_id, attributes_or_matcher = {}, times = 1)
         url = PUBLISHING_API_V2_ENDPOINT + "/content/#{content_id}/publish"
         assert_publishing_api(:post, url, attributes_or_matcher, times)
+      end
+
+      def assert_publishing_api_put_links(content_id, attributes_or_matcher = {}, times = 1)
+        url = PUBLISHING_API_V2_ENDPOINT + "/links/" + content_id
+        assert_publishing_api(:put, url, attributes_or_matcher, times)
       end
 
       def assert_publishing_api_discard_draft(content_id, attributes_or_matcher = {}, times = 1)
@@ -122,9 +143,12 @@ module GdsApi
       end
 
     private
-      def stub_publishing_api_put(content_id, body, resource_path)
+      def stub_publishing_api_put(content_id, body, resource_path, override_response_hash = {})
+        response_hash = {status: 200, body: '{}', headers: {"Content-Type" => "application/json; charset=utf-8"}}
+        response_hash.merge!(override_response_hash)
+        response_hash[:body] = response_hash[:body].to_json if response_hash[:body].is_a?(Hash)
         url = PUBLISHING_API_V2_ENDPOINT + resource_path + "/" + content_id
-        stub_request(:put, url).with(body: body).to_return(status: 200, body: '{}', headers: {"Content-Type" => "application/json; charset=utf-8"})
+        stub_request(:put, url).with(body: body).to_return(response_hash)
       end
     end
   end


### PR DESCRIPTION
Additional test helper methods for publishing-api-v2 to added so that all clients can make use of them:

- allow a response to be specified when stubbing put_content
- stub the publishing_api as not available
