### PR TITLE
Bump gem version to 26.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 26.6.0
 
 * Add `PublishingApiV2#get_linked_items`.
 

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '26.5.0'
+  VERSION = '26.6.0'
 end


### PR DESCRIPTION
Add `PublishingApiV2#get_linked_items`. (https://github.com/alphagov/gds-api-adapters/pull/408)
