### PR TITLE
Special route publisher puts links

### DIFF
--- a/lib/gds_api/publishing_api/special_route_publisher.rb
+++ b/lib/gds_api/publishing_api/special_route_publisher.rb
@@ -27,6 +27,7 @@ module GdsApi
           rendering_app: options.fetch(:rendering_app),
           public_updated_at: time.now.iso8601,
         })
+        publishing_api.put_links(options.fetch(:content_id), links: options[:links]) if options[:links]
         publishing_api.publish(options.fetch(:content_id), 'major')
         put_content_response
       end

--- a/test/publishing_api/special_route_publisher_test.rb
+++ b/test/publishing_api/special_route_publisher_test.rb
@@ -51,6 +51,18 @@ describe GdsApi::PublishingApi::SpecialRoutePublisher do
       end
     end
 
+    it "publishes links" do
+      links = {
+        links: {
+          organisations: ['org-content-id']
+        }
+      }
+
+      publisher.publish(special_route.merge(links))
+
+      assert_requested(:put, "#{endpoint}/v2/links/#{content_id}", body: links)
+    end
+
     describe 'Timezone handling' do
       let(:publishing_api) {
         stub(:publishing_api, put_content_item: nil)


### PR DESCRIPTION
This allows linking special routes to organisations (eg [here](https://github.com/alphagov/contacts-admin/blob/master/lib/tasks/publishing_api.rake#L17)).

/cc @elliotcm 