### PR TITLE
Bump version to 27.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 27.0.0
+
+* Fix issue within PublishingApiV2 test helpers where
+  `request_json_matching` and `request_json_including` where incorrectly
+  named and had the opposite behaviour.
+* The default behaviour of assert_publishing_api (and the more specific
+  helpers that use it) is not to match the entire supplied attributes.
+  To do partial matching use `request_json_includes`
+* Add support for symbol keys to the PubishingApiV2 test helpers.
+
 # 26.7.0
 
 * Add support for Rummager's `delete_content` & `get_content`.

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '26.7.0'
+  VERSION = '27.0.0'
 end


### PR DESCRIPTION
Changes to PublishingApiV2 test helpers to fix incorrect behaviour of
json matching.