### PR TITLE
Include the request in the error message

### DIFF
--- a/lib/gds_api/exceptions.rb
+++ b/lib/gds_api/exceptions.rb
@@ -14,10 +14,11 @@ module GdsApi
   class HTTPErrorResponse < BaseError
     attr_accessor :code, :error_details
 
-    def initialize(code, message = nil, error_details = nil)
+    def initialize(code, message = nil, error_details = nil, request_body = nil)
       super(message)
       @code = code
       @error_details = error_details
+      @request_body = request_body
     end
   end
 
@@ -52,8 +53,8 @@ module GdsApi
       ignoring([HTTPNotFound, HTTPGone], &block)
     end
 
-    def build_specific_http_error(error, url, details = nil)
-      message = "url: #{url}\n#{error.http_body}"
+    def build_specific_http_error(error, url, details = nil, request_body = nil)
+      message = "URL: #{url}\nResponse body:\n#{error.http_body}\n\nRequest body:\n#{request_body}"
       code = error.http_code
 
       case code

--- a/lib/gds_api/json_client.rb
+++ b/lib/gds_api/json_client.rb
@@ -121,7 +121,7 @@ module GdsApi
     def do_raw_request(method, url, params = nil)
       response = do_request(method, url, params)
     rescue RestClient::Exception => e
-      raise build_specific_http_error(e, url)
+      raise build_specific_http_error(e, url, nil, params)
     end
 
     # method: the symbolic name of the method to use, e.g. :get, :post
@@ -141,7 +141,7 @@ module GdsApi
         rescue JSON::ParserError
           nil
         end
-        raise build_specific_http_error(e, url, error_details)
+        raise build_specific_http_error(e, url, error_details, params)
       end
 
       # If no custom response is given, just instantiate Response

--- a/test/content_store_test.rb
+++ b/test/content_store_test.rb
@@ -45,7 +45,7 @@ describe GdsApi::ContentStore do
       end
 
       assert_equal 404, e.code
-      assert_equal "url: #{@base_api_url}/content/non-existent", e.message.strip
+      assert_equal "URL: #{@base_api_url}/content/non-existent\nResponse body:\n\n\nRequest body:", e.message.strip
     end
   end
 

--- a/test/router_test.rb
+++ b/test/router_test.rb
@@ -447,7 +447,7 @@ describe GdsApi::Router do
 
         refute_nil e
         assert_equal 500, e.code
-        assert_equal "url: #{@base_api_url}/routes/commit\nFailed to update all routers", e.message
+        assert_equal "URL: #{@base_api_url}/routes/commit\nResponse body:\nFailed to update all routers\n\nRequest body:\n{}", e.message
       end
     end
   end


### PR DESCRIPTION
This should make the default error reporting much more useful. At the moment,
it can be very difficult to figure out what the request was that triggered the
error. Whilst clients could explicitly capture and record the problem request
body, that requires lots of manual work in every place a gds-api-adapter is
used.

The downside is that the error message suddenly becomes much longer. I can't
really see how that is a problem.