### PR TITLE
Pin Plek version to >= 1.9.0

### DIFF
--- a/gds-api-adapters.gemspec
+++ b/gds-api-adapters.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files        = Dir.glob("lib/**/*") + %w(README.md Rakefile)
   s.test_files   = Dir['test/**/*']
   s.require_path = 'lib'
-  s.add_dependency 'plek'
+  s.add_dependency 'plek', '>= 1.9.0'
   s.add_dependency 'null_logger'
   s.add_dependency 'link_header'
   s.add_dependency 'lrucache', '~> 0.1.1'


### PR DESCRIPTION
The Plek.find method was added in 1.9.0.

We should ensure we're using a version greater-equal to this
because some of our calls to Plek are Plek.find.