### PR TITLE
Publishing api switch to patch links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 29.0.0 (Unreleased)
+
+* Breaking change: rename `PublishingApiV2`'s `put_links` to `patch_links` to
+  better reflect the behaviour. Also rename related test_helper methods.
+
 # 28.3.1
 
 * Fixed `TestHelpers::Imminence` missing `end`.

--- a/lib/gds_api/base.rb
+++ b/lib/gds_api/base.rb
@@ -21,6 +21,7 @@ class GdsApi::Base
   def_delegators :client, :get_json, :get_json!,
                           :post_json, :post_json!,
                           :put_json, :put_json!,
+                          :patch_json, :patch_json!,
                           :delete_json, :delete_json!,
                           :get_raw, :get_raw!,
                           :put_multipart,

--- a/lib/gds_api/json_client.rb
+++ b/lib/gds_api/json_client.rb
@@ -78,7 +78,7 @@ module GdsApi
     # Each "bang method" tries to make a request, but raises an exception if
     # the response is not successful. These methods discard the HTTPNotFound
     # exceptions (and return nil), and pass through all other exceptions.
-    [:get, :post, :put, :delete].each do |http_method|
+    [:get, :post, :put, :patch, :delete].each do |http_method|
       method_name = "#{http_method}_json"
       define_method method_name do |url, *args, &block|
         ignoring_missing do
@@ -97,6 +97,10 @@ module GdsApi
 
     def put_json!(url, params, additional_headers = {})
       do_json_request(:put, url, params, additional_headers)
+    end
+
+    def patch_json!(url, params, additional_headers = {})
+      do_json_request(:patch, url, params, additional_headers)
     end
 
     def delete_json!(url, params = nil, additional_headers = {})

--- a/lib/gds_api/publishing_api/special_route_publisher.rb
+++ b/lib/gds_api/publishing_api/special_route_publisher.rb
@@ -27,7 +27,7 @@ module GdsApi
           rendering_app: options.fetch(:rendering_app),
           public_updated_at: time.now.iso8601,
         })
-        publishing_api.put_links(options.fetch(:content_id), links: options[:links]) if options[:links]
+        publishing_api.patch_links(options.fetch(:content_id), links: options[:links]) if options[:links]
         publishing_api.publish(options.fetch(:content_id), 'major')
         put_content_response
       end

--- a/lib/gds_api/publishing_api_v2.rb
+++ b/lib/gds_api/publishing_api_v2.rb
@@ -63,14 +63,14 @@ class GdsApi::PublishingApiV2 < GdsApi::Base
     get_json(links_url(content_id))
   end
 
-  def put_links(content_id, payload)
+  def patch_links(content_id, payload)
     params = {
       links: payload.fetch(:links)
     }
 
     params = merge_optional_keys(params, payload, [:previous_version])
 
-    put_json!(links_url(content_id), params)
+    patch_json!(links_url(content_id), params)
   end
 
   def get_content_items(params)

--- a/lib/gds_api/test_helpers/publishing_api_v2.rb
+++ b/lib/gds_api/test_helpers/publishing_api_v2.rb
@@ -26,7 +26,7 @@ module GdsApi
         stub_publishing_api_put(content_id, body, '/content', response_hash)
       end
 
-      def stub_publishing_api_put_links(content_id, body)
+      def stub_publishing_api_patch_links(content_id, body)
         stub_publishing_api_put(content_id, body, '/links')
       end
 
@@ -48,7 +48,7 @@ module GdsApi
         end
         stubs = []
         stubs << stub_publishing_api_put_content(content_id, body.except(:links))
-        stubs << stub_publishing_api_put_links(content_id, body.slice(:links)) unless body.slice(:links).empty?
+        stubs << stub_publishing_api_patch_links(content_id, body.slice(:links)) unless body.slice(:links).empty?
         stubs << stub_publishing_api_publish(content_id, publish_body)
         stubs
       end
@@ -57,7 +57,7 @@ module GdsApi
         stub_request(:put, %r{\A#{PUBLISHING_API_V2_ENDPOINT}/content/})
       end
 
-      def stub_any_publishing_api_put_links
+      def stub_any_publishing_api_patch_links
         stub_request(:put, %r{\A#{PUBLISHING_API_V2_ENDPOINT}/links/})
       end
 
@@ -81,7 +81,7 @@ module GdsApi
           publish_body[:locale] = body[:locale] if body[:locale]
         end
         assert_publishing_api_put_content(content_id, body.except(:links))
-        assert_publishing_api_put_links(content_id, body.slice(:links)) unless body.slice(:links).empty?
+        assert_publishing_api_patch_links(content_id, body.slice(:links)) unless body.slice(:links).empty?
         assert_publishing_api_publish(content_id, publish_body)
       end
 
@@ -95,7 +95,7 @@ module GdsApi
         assert_publishing_api(:post, url, attributes_or_matcher, times)
       end
 
-      def assert_publishing_api_put_links(content_id, attributes_or_matcher = nil, times = 1)
+      def assert_publishing_api_patch_links(content_id, attributes_or_matcher = nil, times = 1)
         url = PUBLISHING_API_V2_ENDPOINT + "/links/" + content_id
         assert_publishing_api(:put, url, attributes_or_matcher, times)
       end

--- a/test/publishing_api/special_route_publisher_test.rb
+++ b/test/publishing_api/special_route_publisher_test.rb
@@ -60,7 +60,7 @@ describe GdsApi::PublishingApi::SpecialRoutePublisher do
 
       publisher.publish(special_route.merge(links))
 
-      assert_requested(:put, "#{endpoint}/v2/links/#{content_id}", body: links)
+      assert_requested(:patch, "#{endpoint}/v2/links/#{content_id}", body: links)
     end
 
     describe 'Timezone handling' do

--- a/test/publishing_api_v2_test.rb
+++ b/test/publishing_api_v2_test.rb
@@ -615,14 +615,14 @@ describe GdsApi::PublishingApiV2 do
     end
   end
 
-  describe "#put_links" do
+  describe "#patch_links" do
     describe "when setting links of the same type" do
       before do
         publishing_api
           .given("organisation links exist for content_id #{@content_id}")
-          .upon_receiving("a put organisation links request")
+          .upon_receiving("a patch organisation links request")
           .with(
-            method: :put,
+            method: :patch,
             path: "/v2/links/#{@content_id}",
             body: {
               links: {
@@ -644,7 +644,7 @@ describe GdsApi::PublishingApiV2 do
       end
 
       it "replaces the links and responds with the new links" do
-        response = @api_client.put_links(@content_id, links: {
+        response = @api_client.patch_links(@content_id, links: {
           organisations: ["591436ab-c2ae-416f-a3c5-1901d633fbfb"],
         })
         assert_equal 200, response.code
@@ -656,9 +656,9 @@ describe GdsApi::PublishingApiV2 do
       before do
         publishing_api
           .given("organisation links exist for content_id #{@content_id}")
-          .upon_receiving("a put topic links request")
+          .upon_receiving("a patch topic links request")
           .with(
-            method: :put,
+            method: :patch,
             path: "/v2/links/#{@content_id}",
             body: {
               links: {
@@ -681,7 +681,7 @@ describe GdsApi::PublishingApiV2 do
       end
 
       it "adds the new type of links and responds with the whole link set" do
-        response = @api_client.put_links(@content_id, links: {
+        response = @api_client.patch_links(@content_id, links: {
           topics: ["225df4a8-2945-4e9b-8799-df7424a90b69"],
         })
 
@@ -697,9 +697,9 @@ describe GdsApi::PublishingApiV2 do
       before do
         publishing_api
           .given("organisation links exist for content_id #{@content_id}")
-          .upon_receiving("a put blank organisation links request")
+          .upon_receiving("a patch blank organisation links request")
           .with(
-            method: :put,
+            method: :patch,
             path: "/v2/links/#{@content_id}",
             body: {
               links: {
@@ -719,7 +719,7 @@ describe GdsApi::PublishingApiV2 do
       end
 
       it "responds with the links" do
-        response = @api_client.put_links(@content_id, links: {
+        response = @api_client.patch_links(@content_id, links: {
           organisations: [],
         })
 
@@ -732,9 +732,9 @@ describe GdsApi::PublishingApiV2 do
       before do
         publishing_api
           .given("no links exist for content_id #{@content_id}")
-          .upon_receiving("a put organisation links request")
+          .upon_receiving("a patch organisation links request")
           .with(
-            method: :put,
+            method: :patch,
             path: "/v2/links/#{@content_id}",
             body: {
               links: {
@@ -756,7 +756,7 @@ describe GdsApi::PublishingApiV2 do
       end
 
       it "responds with the links" do
-        response = @api_client.put_links(@content_id, links: {
+        response = @api_client.patch_links(@content_id, links: {
           organisations: ["591436ab-c2ae-416f-a3c5-1901d633fbfb"],
         })
 
@@ -774,7 +774,7 @@ describe GdsApi::PublishingApiV2 do
             .given("the linkset for #{@content_id} is at version 3")
             .upon_receiving("a request to update the linkset at version 3")
             .with(
-              method: :put,
+              method: :patch,
               path: "/v2/links/#{@content_id}",
               body: {
                 links: {
@@ -792,7 +792,7 @@ describe GdsApi::PublishingApiV2 do
         end
 
         it "responds with 200 OK" do
-          response = @api_client.put_links(@content_id,
+          response = @api_client.patch_links(@content_id,
             links: {
               organisations: ["591436ab-c2ae-416f-a3c5-1901d633fbfb"],
             },
@@ -809,7 +809,7 @@ describe GdsApi::PublishingApiV2 do
             .given("the linkset for #{@content_id} is at version 3")
             .upon_receiving("a request to update the linkset at version 2")
             .with(
-              method: :put,
+              method: :patch,
               path: "/v2/links/#{@content_id}",
               body: {
                 links: {
@@ -840,7 +840,7 @@ describe GdsApi::PublishingApiV2 do
 
         it "responds with 409 Conflict" do
           error = assert_raises GdsApi::HTTPClientError do
-            @api_client.put_links(@content_id,
+            @api_client.patch_links(@content_id,
               links: {
                 organisations: ["591436ab-c2ae-416f-a3c5-1901d633fbfb"],
               },
@@ -1210,8 +1210,8 @@ describe GdsApi::PublishingApiV2 do
       proc { @api_client.put_content(nil, {}) }.must_raise ArgumentError
     end
 
-    it "happens on put_links" do
-      proc { @api_client.put_links(nil, links: {}) }.must_raise ArgumentError
+    it "happens on patch_links" do
+      proc { @api_client.patch_links(nil, links: {}) }.must_raise ArgumentError
     end
   end
 end


### PR DESCRIPTION
Currently the Pact tests are failing. I think this is because the master of publishing-api doesn't have the PATCH route yet. Once https://github.com/alphagov/publishing-api/pull/198 has been merged, I think those tests will pass.