### PR TITLE
Publshing API v2: harden adapter against nil content_ids

### DIFF
--- a/lib/gds_api/publishing_api_v2.rb
+++ b/lib/gds_api/publishing_api_v2.rb
@@ -59,25 +59,30 @@ class GdsApi::PublishingApiV2 < GdsApi::Base
 
   def get_linked_items(content_id, params = {})
     query = query_string(params)
+    validate_content_id(content_id)
     get_json("#{endpoint}/v2/linked/#{content_id}#{query}")
   end
 
 private
 
   def content_url(content_id, params = {})
+    validate_content_id(content_id)
     query = query_string(params)
     "#{endpoint}/v2/content/#{content_id}#{query}"
   end
 
   def links_url(content_id)
+    validate_content_id(content_id)
     "#{endpoint}/v2/links/#{content_id}"
   end
 
   def publish_url(content_id)
+    validate_content_id(content_id)
     "#{endpoint}/v2/content/#{content_id}/publish"
   end
 
   def discard_url(content_id)
+    validate_content_id(content_id)
     "#{endpoint}/v2/content/#{content_id}/discard-draft"
   end
 
@@ -85,5 +90,9 @@ private
     optional_keys.each_with_object(params) do |optional_key, hash|
       hash.merge!(optional_key => options[optional_key]) if options[optional_key]
     end
+  end
+
+  def validate_content_id(content_id)
+    raise ArgumentError, "content_id cannot be nil" unless content_id
   end
 end

--- a/test/publishing_api_v2_test.rb
+++ b/test/publishing_api_v2_test.rb
@@ -1232,4 +1232,24 @@ describe GdsApi::PublishingApiV2 do
       end
     end
   end
+
+  describe "content ID validation" do
+    [:get_content, :get_links, :get_linked_items, :discard_draft].each do |method|
+      it "happens on #{method}" do
+        proc { @api_client.send(method, nil) }.must_raise ArgumentError
+      end
+    end
+
+    it "happens on publish" do
+      proc { @api_client.publish(nil, "major") }.must_raise ArgumentError
+    end
+
+    it "happens on put_content" do
+      proc { @api_client.put_content(nil, {}) }.must_raise ArgumentError
+    end
+
+    it "happens on put_links" do
+      proc { @api_client.put_links(nil, links: {}) }.must_raise ArgumentError
+    end
+  end
 end


### PR DESCRIPTION
This catches the case when the publisher is trying to misuse the adapter
without having the error fail downstream (eg [this error](https://errbit.integration.publishing.service.gov.uk/apps/53020c2d0da11590e70000a0/problems/56b8a65f65786326b45b0000)).

/cc @alphagov/team-gov-uk-core-formats-and-publishing 