### PR TITLE
Drop support for 1.9.3

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -37,7 +37,7 @@ git clean -fdx
 git merge --no-commit origin/master || git merge --abort
 
 # Bundle and run tests against multiple ruby versions
-for version in 2.2 2.1 1.9.3; do
+for version in 2.2 2.1; do
   rm -f Gemfile.lock
   export RBENV_VERSION=$version
   echo "Running tests under ruby $version"

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -37,7 +37,7 @@ git clean -fdx
 git merge --no-commit origin/master || git merge --abort
 
 # Bundle and run tests against multiple ruby versions
-for version in 2.2 2.1; do
+for version in 2.3 2.2 2.1; do
   rm -f Gemfile.lock
   export RBENV_VERSION=$version
   echo "Running tests under ruby $version"


### PR DESCRIPTION
[This discussion](https://github.com/alphagov/gds-api-adapters/pull/429/files#r52297113) reminded me that we still have to support 1.9.3 in this repo.

I propose we drop that, because:

- Support for this ruby version ended [almost a year ago](https://www.ruby-lang.org/en/news/2014/01/10/ruby-1-9-3-will-end-on-2015).
- No apps on GOV.UK are [currently on 1.9.3](https://docs.google.com/spreadsheets/d/1FJmr39c9eXgpA-qHUU6GAbbJrnenc0P7JcyY2NB9PgU).
- Our dependencies start to drop support for 1.9.3 (https://github.com/alphagov/gds-api-adapters/pull/363 & https://github.com/alphagov/gds-api-adapters/pull/387).
- 2.X has cool new features which we use often in other projects (keyword args, `%i[]`).
