### PR TITLE
Bump version to 27.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 27.2.1
+
+* `PublishingAPIV2`: prevent clients from using nil `content_id` values
+
 # 27.2.0
 
 * Add some useful test helpers for EmailAlertApi

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '27.2.0'
+  VERSION = '27.2.1'
 end


### PR DESCRIPTION
This includes argument validation in the `PublishingAPIV2` adapter.