### PR TITLE
Fix `ContentStore#incoming_links`

### DIFF
--- a/lib/gds_api/content_store.rb
+++ b/lib/gds_api/content_store.rb
@@ -13,8 +13,9 @@ class GdsApi::ContentStore < GdsApi::Base
     get_json(content_item_url(base_path))
   end
 
-  def incoming_links!(base_path)
-    get_json!(incoming_links_url(base_path))
+  def incoming_links!(base_path, params = {})
+    query = query_string(params)
+    get_json!("#{endpoint}/incoming-links#{base_path}#{query}")
   rescue GdsApi::HTTPNotFound => e
     raise ItemNotFound.build_from(e)
   end
@@ -29,9 +30,5 @@ class GdsApi::ContentStore < GdsApi::Base
 
   def content_item_url(base_path)
     "#{endpoint}/content#{base_path}"
-  end
-
-  def incoming_links_url(base_path)
-    "#{endpoint}/incoming-links#{base_path}"
   end
 end

--- a/test/content_store_test.rb
+++ b/test/content_store_test.rb
@@ -51,10 +51,10 @@ describe GdsApi::ContentStore do
 
   describe "#incoming_links!" do
     it "returns the item" do
-      base_path = "/test-from-content-store"
+      base_path = "/test-from-content-store?types%5B%5D=a&types%5B%5D=b"
       content_store_has_incoming_links(base_path, [ { title: "Yolo" }])
 
-      response = @api.incoming_links!(base_path)
+      response = @api.incoming_links!('/test-from-content-store', types: [:a, :b])
 
       assert_equal [ { "title" => "Yolo" } ], response.to_hash
     end


### PR DESCRIPTION
The /incoming-links endpoint needs a `types` parameter, or it will return 500. This commit adds support for this parameter.