### PR TITLE
Remove special cases for 1.9.3 support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,3 @@ source "http://rubygems.org"
 
 # Specify your gem's dependencies in gds-api-adapters.gemspec
 gemspec
-gem 'rack-cache', '1.2' if RUBY_VERSION == "1.9.3"

--- a/gds-api-adapters.gemspec
+++ b/gds-api-adapters.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'gem_publisher', '~> 1.5.0'
   s.add_development_dependency 'mocha', "> 1.0.0"
   s.add_development_dependency "minitest", "> 5.0.0"
-  s.add_development_dependency 'tins', '1.6.0'
   s.add_development_dependency 'pact'
   s.add_development_dependency 'pact-consumer-minitest'
   s.add_development_dependency 'pry'


### PR DESCRIPTION
https://github.com/alphagov/gds-api-adapters/pull/430 drops support for 1.9.3 so we can remove some special cases. More info in individual commits.