### PR TITLE
Raise `HTTPUnauthorized` for 401 responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Raise `HTTPUnauthorized` for 401 responses.
+
 # 27.2.2
 
 * Fix `ContentStore#incoming_links`.

--- a/lib/gds_api/exceptions.rb
+++ b/lib/gds_api/exceptions.rb
@@ -56,22 +56,25 @@ module GdsApi
     def build_specific_http_error(error, url, details = nil, request_body = nil)
       message = "URL: #{url}\nResponse body:\n#{error.http_body}\n\nRequest body:\n#{request_body}"
       code = error.http_code
+      error_class_for_code(code).new(code, message, details)
+    end
 
+    def error_class_for_code(code)
       case code
       when 403
-        GdsApi::HTTPForbidden.new(code, message, details)
+        GdsApi::HTTPForbidden
       when 404
-        GdsApi::HTTPNotFound.new(code, message, details)
+        GdsApi::HTTPNotFound
       when 410
-        GdsApi::HTTPGone.new(code, message, details)
+        GdsApi::HTTPGone
       when 409
-        GdsApi::HTTPConflict.new(code, message, details)
+        GdsApi::HTTPConflict
       when (400..499)
-        GdsApi::HTTPClientError.new(code, message, details)
+        GdsApi::HTTPClientError
       when (500..599)
-        GdsApi::HTTPServerError.new(code, message, details)
+        GdsApi::HTTPServerError
       else
-        GdsApi::HTTPErrorResponse.new(code, message, details)
+        GdsApi::HTTPErrorResponse
       end
     end
   end

--- a/lib/gds_api/exceptions.rb
+++ b/lib/gds_api/exceptions.rb
@@ -34,6 +34,9 @@ module GdsApi
   class HTTPGone < HTTPClientError
   end
 
+  class HTTPUnauthorized < HTTPClientError
+  end
+
   class HTTPForbidden < HTTPClientError
   end
 
@@ -61,6 +64,8 @@ module GdsApi
 
     def error_class_for_code(code)
       case code
+      when 401
+        GdsApi::HTTPUnauthorized
       when 403
         GdsApi::HTTPForbidden
       when 404

--- a/lib/gds_api/exceptions.rb
+++ b/lib/gds_api/exceptions.rb
@@ -70,10 +70,10 @@ module GdsApi
         GdsApi::HTTPForbidden
       when 404
         GdsApi::HTTPNotFound
-      when 410
-        GdsApi::HTTPGone
       when 409
         GdsApi::HTTPConflict
+      when 410
+        GdsApi::HTTPGone
       when (400..499)
         GdsApi::HTTPClientError
       when (500..599)


### PR DESCRIPTION
Publishing API has started to return 401s for requests without a bearer token. Raising a specific exception for this will allow us to debug this more easily.

Includes some refactoring / cleanup.
