### PR TITLE
Release 28.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-* Raise `HTTPUnauthorized` for 401 responses.
+# 28.0.0
+
+* Drop support for Ruby 1.9.3
+* Raise `HTTPUnauthorized` for 401 responses
 
 # 27.2.2
 

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '27.2.2'
+  VERSION = '28.0.0'
 end


### PR DESCRIPTION
This is a major bump because it removes support for ruby 1.9.3.