### PR TITLE
Don't test for request body if the argument is not supplied

### DIFF
--- a/lib/gds_api/test_helpers/publishing_api_v2.rb
+++ b/lib/gds_api/test_helpers/publishing_api_v2.rb
@@ -85,22 +85,22 @@ module GdsApi
         assert_publishing_api_publish(content_id, publish_body)
       end
 
-      def assert_publishing_api_put_content(content_id, attributes_or_matcher = {}, times = 1)
+      def assert_publishing_api_put_content(content_id, attributes_or_matcher = nil, times = 1)
         url = PUBLISHING_API_V2_ENDPOINT + "/content/" + content_id
         assert_publishing_api(:put, url, attributes_or_matcher, times)
       end
 
-      def assert_publishing_api_publish(content_id, attributes_or_matcher = {}, times = 1)
+      def assert_publishing_api_publish(content_id, attributes_or_matcher = nil, times = 1)
         url = PUBLISHING_API_V2_ENDPOINT + "/content/#{content_id}/publish"
         assert_publishing_api(:post, url, attributes_or_matcher, times)
       end
 
-      def assert_publishing_api_put_links(content_id, attributes_or_matcher = {}, times = 1)
+      def assert_publishing_api_put_links(content_id, attributes_or_matcher = nil, times = 1)
         url = PUBLISHING_API_V2_ENDPOINT + "/links/" + content_id
         assert_publishing_api(:put, url, attributes_or_matcher, times)
       end
 
-      def assert_publishing_api_discard_draft(content_id, attributes_or_matcher = {}, times = 1)
+      def assert_publishing_api_discard_draft(content_id, attributes_or_matcher = nil, times = 1)
         url = PUBLISHING_API_V2_ENDPOINT + "/content/#{content_id}/discard-draft"
         assert_publishing_api(:post, url, attributes_or_matcher, times)
       end


### PR DESCRIPTION
The default empty hash argument for `attributes_or_matcher` means
that the assertion only passes when the client has sent an empty hash to
the publishing-api.

In most cases where the second argument is not supplied, we don't care
about the payload. Webmock will not test the request body if it is nil.

To summarise, after this change:

`assert_publishing_api_put_links(content_id)` will pass with any body
`assert_publishing_api_put_links(content_id, {})` will only pass if the
body is empty
