### PR TITLE
Always cast content items to Array

### DIFF
--- a/lib/gds_api/test_helpers/publishing_api_v2.rb
+++ b/lib/gds_api/test_helpers/publishing_api_v2.rb
@@ -135,7 +135,7 @@ module GdsApi
       end
 
       def publishing_api_has_fields_for_format(format, items, fields)
-        body = items.map { |item|
+        body = Array(items).map { |item|
           item.with_indifferent_access.slice(*fields)
         }
 


### PR DESCRIPTION
When stubing fields to be returned from the `index` `GET` endpoint, we
may only pass in one item and as such that won't be an array. This
commit modifies the helper to use `Array(arg)` to always cast it to an
Array.