### PR TITLE
Bump to 28.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 28.0.2
+
+* `TestHelpers::PublishingApiV2` now has a `publishing_api_has_links` test helper
+  which stubs the Publishing API V2 to return the links payload which is supplied
+  as the arg.
+
 # 28.0.1
 
 * In `TestHelpers::PublishingApiV2` - for methods that accept an optional arg

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '28.0.1'
+  VERSION = '28.0.2'
 end


### PR DESCRIPTION
This includes the new test helper added in 96acb5