### PR TITLE
Pass Govuk-Original-URL header on to sub requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# unreleased
+
+* Pass the Govuk-Original-Url header on to requests made by gds-api-adapters,
+  similarly to the existing Govuk-Request-Id header.  Rails applications will
+  get this support automatically when using this version of gds-api-adapters.
+  Other applications will need to add an explicit call to `use
+  GdsApi::GovukHeaderSniffer, 'HTTP_GOVUK_ORIGINAL_URL"`, as detailed in the
+  README.
+
 # 28.1.1
 
 * `TestHelpers::PublishingApiV2` now has a `publishing_api_does_not_have_item` test helper

--- a/README.md
+++ b/README.md
@@ -31,15 +31,19 @@ something that actually logs:
 
 ## Middleware for request tracing
 
-We set a unique header at the cache level called `Govuk-Request-Id`. In order
-to serve a user's request, if apps make API requests they should pass on this
-header, so that we can trace a request across the entire GOV.UK stack.
+We set a unique header at the cache level called `Govuk-Request-Id`, and also
+set a header called `Govuk-Original-Url` to identify the original URL
+requested.  If apps make API requests in order to server a user's request, they
+should pass on these headers, so that we can trace requests across the entire
+GOV.UK stack.
 
-`GdsApi::GovukHeaderSniffer` middleware takes care of this. This gem contains
-a railtie that configures this middleware for Rails apps without extra effort.
-Other Rack-based apps should opt-in by adding this line to your `config.ru`:
+The `GdsApi::GovukHeaderSniffer` middleware takes care of this. This gem
+contains a railtie that configures this middleware for Rails apps without extra
+effort.  Other Rack-based apps should opt-in by adding these lines to your
+`config.ru`:
 
     use GdsApi::GovukHeaderSniffer, 'HTTP_GOVUK_REQUEST_ID'
+    use GdsApi::GovukHeaderSniffer, 'HTTP_GOVUK_ORIGINAL_URL'
 
 ## Middleware for identifying authenticated users
 

--- a/lib/gds_api/railtie.rb
+++ b/lib/gds_api/railtie.rb
@@ -7,6 +7,11 @@ module GdsApi
       app.middleware.use GdsApi::GovukHeaderSniffer, 'HTTP_GOVUK_REQUEST_ID'
     end
 
+    initializer "gds_api.initialize_govuk_original_url_sniffer" do |app|
+      Rails.logger.info "Using middleware GdsApi::GovukHeaderSniffer to sniff for GOVUK-Original-Url header"
+      app.middleware.use GdsApi::GovukHeaderSniffer, 'HTTP_GOVUK_ORIGINAL_URL'
+    end
+
     initializer "gds_api.initialize_govuk_authenticated_user_sniffer" do |app|
       Rails.logger.info "Using middleware GdsApi::GovukHeaderSniffer to sniff for X-GOVUK-Authenticated-User header"
       app.middleware.use GdsApi::GovukHeaderSniffer, 'HTTP_X_GOVUK_AUTHENTICATED_USER'

--- a/test/json_client_test.rb
+++ b/test/json_client_test.rb
@@ -702,13 +702,17 @@ class JsonClientTest < MiniTest::Spec
   end
 
   def test_govuk_headers_are_included_in_requests_if_present
-    GdsApi::GovukHeaders.set_header(:govuk_request_id, "12345") # set by middleware GovukHeaderSniffer
+    # set headers which would be set by middleware GovukHeaderSniffer
+    GdsApi::GovukHeaders.set_header(:govuk_request_id, "12345")
+    GdsApi::GovukHeaders.set_header(:govuk_original_url, "http://example.com")
+
     stub_request(:get, "http://some.other.endpoint/some.json").to_return(:status => 200)
 
     GdsApi::JsonClient.new.get_json("http://some.other.endpoint/some.json")
 
     assert_requested(:get, %r{/some.json}) do |request|
-      request.headers['Govuk-Request-Id'] == '12345'
+      request.headers['Govuk-Request-Id'] == '12345' &&
+      request.headers['Govuk-Original-Url'] == 'http://example.com'
     end
   end
 


### PR DESCRIPTION
We're adding tracing of the original URL which triggered requests to our logging, so that we can identify which pages depend on which backend services.

This PR adds support for passing the Govuk-Original-Url header on to calls made by gds-api-adapters, and updates the railtie to set this up to happen automatically for Rails apps.  Other apps will need to add an explicit call, as detailed in the README.

This PR follows on from alphagov/govuk-puppet#4065, which sends the header from varnish and logs it from nginx.