### PR TITLE
Bump to 28.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 28.2.1
+
+* `TestHelpers::PublishingApiV2` now has a `publishing_api_does_not_have_links` test helper
+  which stubs the Publishing API V2 to return the 404 payload for the `content_id` passed
+  as the arg.
+
 # 28.2.0
 
 * Pass the Govuk-Original-Url header on to requests made by gds-api-adapters,

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '28.2.0'
+  VERSION = '28.2.1'
 end


### PR DESCRIPTION
This includes the `publishing_api_does_not_have_links` test helper added
in bcf11b.