### PR TITLE
Bump version to 28.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 28.3.0
+
+* `TestHelpers::Imminence` now has `imminence_has_places_for_postcode` and
+  `stub_imminence_places_request` helper methods. There was previously no helper
+  for the find places with post code tools. It is now possible to stub all requests
+  for places with any status code or payload as required.
+
 # 28.2.1
 
 * `TestHelpers::PublishingApiV2` now has a `publishing_api_does_not_have_links` test helper

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '28.2.1'
+  VERSION = '28.3.0'
 end


### PR DESCRIPTION
New version includes postcode test helper for imminence [here](https://github.com/alphagov/gds-api-adapters/commit/34be7baf9bc798149edec3c0687649885dd9830d)