### PR TITLE
Switch linkables to document type

### DIFF
--- a/lib/gds_api/publishing_api_v2.rb
+++ b/lib/gds_api/publishing_api_v2.rb
@@ -78,8 +78,20 @@ class GdsApi::PublishingApiV2 < GdsApi::Base
     get_json("#{endpoint}/v2/content#{query}")
   end
 
-  def get_linkables(format:)
-    get_json("#{endpoint}/v2/linkables?format=#{format}")
+  def get_linkables(document_type: nil, format: nil)
+    if document_type.nil?
+      if format.nil?
+        raise ArgumentError.new("Please provide a `document_type`")
+      else
+        self.class.logger.warn(
+          "Providing `format` to the `get_linkables` method is deprecated and will be removed in a " +
+          "future release.  Please use `document_type` instead."
+        )
+        document_type = format
+      end
+    end
+
+    get_json("#{endpoint}/v2/linkables?document_type=#{document_type}")
   end
 
   def get_linked_items(content_id, params = {})

--- a/test/publishing_api_v2_test.rb
+++ b/test/publishing_api_v2_test.rb
@@ -875,14 +875,14 @@ describe GdsApi::PublishingApiV2 do
       ]
     }
 
-    it "returns the content items of a given format" do
+    it "returns the content items of a given document_type" do
       publishing_api
         .given("there is content with format 'topic'")
         .upon_receiving("a get linkables request")
         .with(
           method: :get,
           path: "/v2/linkables",
-          query: "format=topic",
+          query: "document_type=topic",
           headers: {
             "Content-Type" => "application/json",
           },
@@ -892,8 +892,12 @@ describe GdsApi::PublishingApiV2 do
           body: linkables,
         )
 
-      response = @api_client.get_linkables(format: "topic")
+      response = @api_client.get_linkables(document_type: "topic")
+      assert_equal 200, response.code
+      assert_equal linkables, response.to_a
 
+      # `format` is supported but deprecated for backwards compatibility
+      response = @api_client.get_linkables(format: "topic")
       assert_equal 200, response.code
       assert_equal linkables, response.to_a
     end

--- a/test/publishing_api_v2_test.rb
+++ b/test/publishing_api_v2_test.rb
@@ -1178,7 +1178,7 @@ describe GdsApi::PublishingApiV2 do
       end
     end
 
-    describe "there are two documents that link to the wantend document" do
+    describe "there are two documents that link to the wanted document" do
       before do
         content_id2 = "08dfd5c3-d935-4e81-88fd-cfe65b78893d"
         content_id3 = "e2961462-bc37-48e9-bb98-c981ef1a2d59"


### PR DESCRIPTION
This has been replaced by `document_type` (though
wasn't actually shipped in a client anywhere).