### PR TITLE
Support searching by a document_type in email-alert-api

### DIFF
--- a/lib/gds_api/email_alert_api.rb
+++ b/lib/gds_api/email_alert_api.rb
@@ -4,7 +4,21 @@ require_relative 'exceptions'
 class GdsApi::EmailAlertApi < GdsApi::Base
 
   def find_or_create_subscriber_list(attributes)
-    search_subscriber_list_by_tags(attributes.fetch("tags"))
+    tags = attributes["tags"]
+    links = attributes["links"]
+    document_type = attributes["document_type"]
+
+    if tags && links
+      message = "please provide either tags or links (or neither), but not both"
+      raise ArgumentError, message
+    end
+
+    params = {}
+    params[:tags] = tags if tags
+    params[:links] = links if links
+    params[:document_type] = document_type if document_type
+
+    search_subscriber_list(params)
   rescue GdsApi::HTTPNotFound
     create_subscriber_list(attributes)
   end
@@ -15,8 +29,9 @@ class GdsApi::EmailAlertApi < GdsApi::Base
 
 private
 
-  def search_subscriber_list_by_tags(tags)
-    get_json!("#{endpoint}/subscriber-lists?" + nested_query_string(tags: tags))
+  def search_subscriber_list(params)
+    query_string = nested_query_string(params)
+    get_json!("#{endpoint}/subscriber-lists?" + query_string)
   end
 
   def create_subscriber_list(attributes)

--- a/lib/gds_api/test_helpers/email_alert_api.rb
+++ b/lib/gds_api/test_helpers/email_alert_api.rb
@@ -7,12 +7,7 @@ module GdsApi
       EMAIL_ALERT_API_ENDPOINT = Plek.find("email-alert-api")
 
       def email_alert_api_has_subscriber_list(attributes)
-        title = attributes.fetch("title")
-        tags = attributes.fetch("tags")
-
-        query = Rack::Utils.build_nested_query(tags: tags)
-
-        stub_request(:get, subscriber_lists_url(query))
+        stub_request(:get, subscriber_lists_url(attributes))
           .to_return(
             :status => 200,
             :body => get_subscriber_list_response(attributes).to_json,
@@ -20,9 +15,7 @@ module GdsApi
       end
 
       def email_alert_api_does_not_have_subscriber_list(attributes)
-        query = Rack::Utils.build_nested_query(tags: attributes.fetch("tags"))
-
-        stub_request(:get, subscriber_lists_url(query))
+        stub_request(:get, subscriber_lists_url(attributes))
           .to_return(status: 404)
       end
 
@@ -48,9 +41,6 @@ module GdsApi
             "subscription_url" => "https://stage-public.govdelivery.com/accounts/UKGOVUK/subscriber/new?topic_id=UKGOVUK_1234",
             "gov_delivery_id" => "UKGOVUK_1234",
             "title" => "Some title",
-            "tags" => {
-              "format" => ["some-format"],
-            }
           }.merge(attributes)
         }
       end
@@ -86,7 +76,20 @@ module GdsApi
 
     private
 
-      def subscriber_lists_url(query = nil)
+      def subscriber_lists_url(attributes = nil)
+        if attributes
+          tags = attributes["tags"]
+          links = attributes["links"]
+          document_type = attributes["document_type"]
+
+          params = {}
+          params[:tags] = tags if tags
+          params[:links] = links if links
+          params[:document_type] = document_type if document_type
+
+          query = Rack::Utils.build_nested_query(params)
+        end
+
         url = EMAIL_ALERT_API_ENDPOINT + "/subscriber-lists"
         query ? "#{url}?#{query}" : url
       end

--- a/test/email_alert_api_test.rb
+++ b/test/email_alert_api_test.rb
@@ -96,6 +96,67 @@ describe GdsApi::EmailAlertApi do
           )
         end
       end
+
+      describe "when the optional 'document_type' is provided" do
+        let(:params) {
+          {
+            "title" => title,
+            "tags" => tags,
+            "document_type" => "travel_advice",
+          }
+        }
+
+        before do
+          email_alert_api_has_subscriber_list(
+            "title" => "Some Title",
+            "tags" => tags,
+            "document_type" => "travel_advice",
+            "subscription_url" => expected_subscription_url,
+          )
+        end
+
+        it "returns the subscriber list attributes" do
+          subscriber_list_attrs = api_client.find_or_create_subscriber_list(params)
+            .to_hash
+            .fetch("subscriber_list")
+
+          assert_equal(
+            "travel_advice",
+            subscriber_list_attrs.fetch("document_type")
+          )
+        end
+      end
+
+      describe "when both tags and links are provided" do
+        let(:links) {
+          {
+            "format" => ["some-document-format"]
+          }
+        }
+
+        let(:params) {
+          {
+            "title" => title,
+            "tags" => tags,
+            "links" => links,
+          }
+        }
+
+        before do
+          email_alert_api_has_subscriber_list(
+            "title" => "Some Title",
+            "tags" => tags,
+            "links" => links,
+            "subscription_url" => expected_subscription_url,
+          )
+        end
+
+        it "excludes that attribute from the query string" do
+          assert_raises do
+            api_client.find_or_create_subscriber_list(params)
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
https://trello.com/c/oqGCU2XP/525-add-email-signup-links-to-travel-advice-on-frontend

As part of the work to migrate Travel Advice over to using the email-alert-frontend workflow, we need to be able to support subscriber lists that have a document_type but no tags or links. The email-alert-api now supports this (see https://github.com/alphagov/email-alert-api/commit/a6301c403f8b44f2244606c1c1cfd3f5dfee38b2).

This work makes it so that the adapters can pass a document_type through without tags or links.