### PR TITLE
Add support for the publishing-api /lookup endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ pkg/
 .bundle
 /spec/pacts
 /log
+.yardoc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Add `GdsApi::PublishingApiV2#lookup_content_id` and `GdsApi::PublishingApiV2#lookup_content_id`
+
 # 29.5.0
 
 * Add `GdsApi::HTTPUnprocessableEntity` to represent a 422 error

--- a/README.md
+++ b/README.md
@@ -94,6 +94,14 @@ At time of writing, these are:
 
 * [WebMock](https://github.com/bblimke/webmock)
 
+### Documentation
+
+See [RubyDoc](http://www.rubydoc.info/gems/gds-api-adapters) for some limited documentation.
+
+To run a Yard server locally to preview documentation, run:
+
+    $ bundle exec yard server --reload
+
 ## Licence
 
 Released under the MIT Licence, a copy of which can be found in the file

--- a/gds-api-adapters.gemspec
+++ b/gds-api-adapters.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rack'
   s.add_development_dependency 'rack-test'
   s.add_development_dependency 'rake', '~> 0.9.2.2'
-  s.add_development_dependency 'rdoc', '3.12'
+  s.add_development_dependency 'yard', '0.8.7.6'
   s.add_development_dependency 'simplecov', '~> 0.5.4'
   s.add_development_dependency 'simplecov-rcov'
   s.add_development_dependency 'timecop', '~> 0.5.1'

--- a/lib/gds_api/publishing_api_v2.rb
+++ b/lib/gds_api/publishing_api_v2.rb
@@ -33,6 +33,39 @@ class GdsApi::PublishingApiV2 < GdsApi::Base
     get_json!(content_url(content_id, params))
   end
 
+  # Find the content_ids for a list of base_paths.
+  #
+  # @param base_paths [Array]
+  # @return [Hash] a hash, keyed by `base_path` with `content_id` as value
+  # @example
+  #
+  #   publishing_api.lookup_content_ids(base_paths: ['/foo', '/bar'])
+  #   # => { "/foo" => "51ac4247-fd92-470a-a207-6b852a97f2db", "/bar" => "261bd281-f16c-48d5-82d2-9544019ad9ca" }
+  #
+  def lookup_content_ids(base_paths:)
+    response = post_json!("#{endpoint}/lookup-by-base-path", base_paths: base_paths)
+    response.to_hash
+  end
+
+  # Find the content_id for a base_path.
+  #
+  # Convenience method if you only need to look up one content_id for a
+  # base_path. For multiple base_paths, use {GdsApi::PublishingApiV2#lookup_content_ids}.
+  #
+  # @param base_path [String]
+  #
+  # @return [UUID] the `content_id` for the `base_path`
+  #
+  # @example
+  #
+  #   publishing_api.lookup_content_id(base_path: '/foo')
+  #   # => "51ac4247-fd92-470a-a207-6b852a97f2db"
+  #
+  def lookup_content_id(base_path:)
+    lookups = lookup_content_ids(base_paths: [base_path])
+    lookups[base_path]
+  end
+
   def publish(content_id, update_type, options = {})
     params = {
       update_type: update_type

--- a/test/publishing_api_v2/lookup_test.rb
+++ b/test/publishing_api_v2/lookup_test.rb
@@ -1,0 +1,70 @@
+require 'test_helper'
+require 'gds_api/publishing_api_v2'
+require 'json'
+
+describe GdsApi::PublishingApiV2 do
+  include PactTest
+
+  before do
+    @api_client = GdsApi::PublishingApiV2.new('http://localhost:3093')
+  end
+
+  describe "#lookup_content_id" do
+    it "returns the content_id for a base_path" do
+      publishing_api
+        .given("there are live content items with base_paths /foo and /bar")
+        .upon_receiving("a /lookup-by-base-path-request")
+        .with(
+          method: :post,
+          path: "/lookup-by-base-path",
+          body: {
+            base_paths: ["/foo"]
+          },
+          headers: {
+            "Content-Type" => "application/json",
+          },
+        )
+        .will_respond_with(
+          status: 200,
+          body: {
+            "/foo" => "08f86d00-e95f-492f-af1d-470c5ba4752e"
+          }
+        )
+
+      content_id = @api_client.lookup_content_id(base_path: "/foo")
+
+      assert_equal "08f86d00-e95f-492f-af1d-470c5ba4752e", content_id
+    end
+  end
+
+  describe "#lookup_content_ids" do
+    it "returns the content_id for a base_path" do
+      reponse_hash = {
+        "/foo" => "08f86d00-e95f-492f-af1d-470c5ba4752e",
+        "/bar" => "ca6c58a6-fb9d-479d-b3e6-74908781cb18",
+      }
+
+      publishing_api
+        .given("there are live content items with base_paths /foo and /bar")
+        .upon_receiving("a request for multiple base_paths")
+        .with(
+          method: :post,
+          path: "/lookup-by-base-path",
+          body: {
+            base_paths: ["/foo", "/bar"]
+          },
+          headers: {
+            "Content-Type" => "application/json",
+          },
+        )
+        .will_respond_with(
+          status: 200,
+          body: reponse_hash,
+        )
+
+      content_id = @api_client.lookup_content_ids(base_paths: ["/foo", "/bar"])
+
+      assert_equal(reponse_hash, content_id)
+    end
+  end
+end


### PR DESCRIPTION
This endpoint was added in alphagov/publishing-api#230.

Documentation:

![screen shot 2016-03-10 at 15 05 55](https://cloud.githubusercontent.com/assets/233676/13673600/af2e96d2-e6d1-11e5-8ddb-4e544c104863.png)

(will appear at http://www.rubydoc.info/gems/gds-api-adapters/GdsApi/PublishingApiV2)