### PR TITLE
Add `publishing_api_has_lookups` test helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 * Add `GdsApi::PublishingApiV2#lookup_content_id` and `GdsApi::PublishingApiV2#lookup_content_id`
+* Add `publishing_api_has_lookups` test helpers
 
 # 29.5.0
 

--- a/lib/gds_api/test_helpers/publishing_api_v2.rb
+++ b/lib/gds_api/test_helpers/publishing_api_v2.rb
@@ -175,7 +175,24 @@ module GdsApi
         stub_request(:get, url).to_return(status: 404, body: resource_not_found(content_id, "link set").to_json, headers: {})
       end
 
+      # Stub calls to the lookups endpoint
+      #
+      # @param lookup_hash [Hash] Hash with base_path as key, content_id as value.
+      #
+      # @example
+      #
+      #   publishing_api_has_lookups({
+      #     "/foo" => "51ac4247-fd92-470a-a207-6b852a97f2db",
+      #     "/bar" => "261bd281-f16c-48d5-82d2-9544019ad9ca"
+      #   })
+      #
+      def publishing_api_has_lookups(lookup_hash)
+        url = Plek.current.find('publishing-api') + '/lookup-by-base-path'
+        stub_request(:post, url).to_return(body: lookup_hash.to_json)
+      end
+
     private
+
       def stub_publishing_api_put(*args)
         stub_publishing_api_postlike_call(:put, *args)
       end

--- a/test/test_helpers/publishing_api_v2_test.rb
+++ b/test/test_helpers/publishing_api_v2_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+require 'gds_api/publishing_api_v2'
+require 'gds_api/test_helpers/publishing_api_v2'
+
+describe GdsApi::TestHelpers::PublishingApiV2 do
+  include GdsApi::TestHelpers::PublishingApiV2
+  let(:publishing_api) { GdsApi::PublishingApiV2.new(Plek.current.find("publishing-api")) }
+
+  describe "#publishing_api_has_lookups" do
+    it "stubs the lookup for content items" do
+      lookup_hash = { "/foo" => "2878337b-bed9-4e7f-85b6-10ed2cbcd504" }
+
+      publishing_api_has_lookups(lookup_hash)
+
+      assert_equal publishing_api.lookup_content_ids(base_paths: ["/foo"]), lookup_hash
+      assert_equal publishing_api.lookup_content_id(base_path: "/foo"), "2878337b-bed9-4e7f-85b6-10ed2cbcd504"
+    end
+  end
+end


### PR DESCRIPTION
This can be used to stub calls to the lookup endpoint introduced in https://github.com/alphagov/gds-api-adapters/pull/474.