### PR TITLE
Release 29.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 29.6.0
+
 * Add `GdsApi::PublishingApiV2#lookup_content_id` and `GdsApi::PublishingApiV2#lookup_content_id`
 * Add `publishing_api_has_lookups` test helpers
 

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '29.5.0'
+  VERSION = '29.6.0'
 end


### PR DESCRIPTION
This releases new methods for the publishing-api's lookup endpoints.

