### PR TITLE
Extend #stub_publishing_api_publish to take response hash

### DIFF
--- a/lib/gds_api/test_helpers/publishing_api_v2.rb
+++ b/lib/gds_api/test_helpers/publishing_api_v2.rb
@@ -30,9 +30,14 @@ module GdsApi
         stub_publishing_api_patch(content_id, body, '/links')
       end
 
-      def stub_publishing_api_publish(content_id, body)
+      def stub_publishing_api_publish(content_id, body, response_hash = {})
         url = PUBLISHING_API_V2_ENDPOINT + "/content/#{content_id}/publish"
-        stub_request(:post, url).with(body: body).to_return(status: 200, body: '{}', headers: {"Content-Type" => "application/json; charset=utf-8"})
+        response = {
+          status: 200,
+          body: '{}',
+          headers: {"Content-Type" => "application/json; charset=utf-8"}
+        }.merge(response_hash)
+        stub_request(:post, url).with(body: body).to_return(response)
       end
 
       def stub_publishing_api_discard_draft(content_id)


### PR DESCRIPTION
This allows stubbing a non-200 response for testing unhappy paths
