### PR TITLE
Stubbed request to support pagination

### DIFF
--- a/lib/gds_api/test_helpers/publishing_api_v2.rb
+++ b/lib/gds_api/test_helpers/publishing_api_v2.rb
@@ -139,6 +139,16 @@ module GdsApi
         end
       end
 
+
+      # Example of use:
+      # publishing_api_has_content(
+      #   vehicle_recalls_and_faults,   # this is a variable containing an array of content items
+      #   document_type: described_class.publishing_api_document_type,   #example of a document_type: "vehicle_recalls_and_faults_alert"
+      #   fields: fields,   #example: let(:fields) { %i[base_path content_id public_updated_at title publication_state] }
+      #   page: 1,
+      #   per_page: 50
+      #)
+
       def publishing_api_has_content(items, params = {})
         body = Array(items).map { |item|
           item.with_indifferent_access.slice(*params[:fields])

--- a/lib/gds_api/test_helpers/publishing_api_v2.rb
+++ b/lib/gds_api/test_helpers/publishing_api_v2.rb
@@ -139,32 +139,15 @@ module GdsApi
         end
       end
 
-      def publishing_api_has_fields_for_document(format, items, fields)
+      def publishing_api_has_content(items, params = {})
         body = Array(items).map { |item|
-          item.with_indifferent_access.slice(*fields)
+          item.with_indifferent_access.slice(*params[:fields])
         }
 
-        query_params = fields.map { |f|
-          "&fields%5B%5D=#{f}"
-        }
+        query_string = params.to_query
 
-        url = PUBLISHING_API_V2_ENDPOINT + "/content?document_type=#{format}#{query_params.join('')}"
-
-        stub_request(:get, url).to_return(:status => 200, :body => { results: body }.to_json, :headers => {})
-      end
-
-      def publishing_api_has_fields_for_document_with_pagination(format, items, fields, page, per_page)
-        body = Array(items).map { |item|
-          item.with_indifferent_access.slice(*fields)
-        }
-
-        query_params = fields.map { |f|
-          "&fields%5B%5D=#{f}"
-        }
-
-        url = PUBLISHING_API_V2_ENDPOINT + "/content?document_type=#{format}#{query_params.join('')}&page=#{page}&per_page=#{per_page}"
-
-        stub_request(:get, url).to_return(:status => 200, :body => { results: body }.to_json, :headers => {})
+        url = PUBLISHING_API_V2_ENDPOINT + "/content?#{query_string}"
+        stub_request(:get, url).to_return(status: 200, body: { results: body }.to_json, headers: {})
       end
 
       def publishing_api_has_linkables(linkables, document_type:)

--- a/lib/gds_api/test_helpers/publishing_api_v2.rb
+++ b/lib/gds_api/test_helpers/publishing_api_v2.rb
@@ -139,8 +139,8 @@ module GdsApi
         end
       end
 
-
       # Example of use:
+
       # publishing_api_has_content(
       #   vehicle_recalls_and_faults,   # this is a variable containing an array of content items
       #   document_type: described_class.publishing_api_document_type,   #example of a document_type: "vehicle_recalls_and_faults_alert"
@@ -148,16 +148,25 @@ module GdsApi
       #   page: 1,
       #   per_page: 50
       #)
-
       def publishing_api_has_content(items, params = {})
+        url = PUBLISHING_API_V2_ENDPOINT + "/content"
+        stub_request(:get, url).with(:query => params).to_return(status: 200, body: { results: items }.to_json, headers: {})
+      end
+
+      # This method has been refactored into publishing_api_has_content (above)
+      # publishing_api_has_content allows for flexible passing in of arguments, please use instead
+      def publishing_api_has_fields_for_document(format, items, fields)
         body = Array(items).map { |item|
-          item.with_indifferent_access.slice(*params[:fields])
+          item.with_indifferent_access.slice(*fields)
         }
 
-        query_string = params.to_query
+        query_params = fields.map { |f|
+          "&fields%5B%5D=#{f}"
+        }
 
-        url = PUBLISHING_API_V2_ENDPOINT + "/content?#{query_string}"
-        stub_request(:get, url).to_return(status: 200, body: { results: body }.to_json, headers: {})
+        url = PUBLISHING_API_V2_ENDPOINT + "/content?document_type=#{format}#{query_params.join('')}"
+
+        stub_request(:get, url).to_return(:status => 200, :body => { results: body }.to_json, :headers => {})
       end
 
       def publishing_api_has_linkables(linkables, document_type:)

--- a/lib/gds_api/test_helpers/publishing_api_v2.rb
+++ b/lib/gds_api/test_helpers/publishing_api_v2.rb
@@ -153,6 +153,20 @@ module GdsApi
         stub_request(:get, url).to_return(:status => 200, :body => { results: body }.to_json, :headers => {})
       end
 
+      def publishing_api_has_fields_for_document_with_pagination(format, items, fields, page, per_page)
+        body = Array(items).map { |item|
+          item.with_indifferent_access.slice(*fields)
+        }
+
+        query_params = fields.map { |f|
+          "&fields%5B%5D=#{f}"
+        }
+
+        url = PUBLISHING_API_V2_ENDPOINT + "/content?document_type=#{format}#{query_params.join('')}&page=#{page}&per_page=#{per_page}"
+
+        stub_request(:get, url).to_return(:status => 200, :body => { results: body }.to_json, :headers => {})
+      end
+
       def publishing_api_has_linkables(linkables, document_type:)
         url = PUBLISHING_API_V2_ENDPOINT + "/linkables?document_type=#{document_type}"
         stub_request(:get, url).to_return(:status => 200, :body => linkables.to_json, :headers => {})

--- a/test/test_helpers/publishing_api_v2_test.rb
+++ b/test/test_helpers/publishing_api_v2_test.rb
@@ -16,4 +16,14 @@ describe GdsApi::TestHelpers::PublishingApiV2 do
       assert_equal publishing_api.lookup_content_id(base_path: "/foo"), "2878337b-bed9-4e7f-85b6-10ed2cbcd504"
     end
   end
+
+  describe "#publishing_api_has_content" do
+    it "stubs the call to get content items" do
+      publishing_api_has_content([{"content_id" => "2878337b-bed9-4e7f-85b6-10ed2cbcd504"}])
+
+      response = publishing_api.get_content_items({})['results']
+
+      assert_equal([{ "content_id" => "2878337b-bed9-4e7f-85b6-10ed2cbcd504" }], response)
+    end
+  end
 end


### PR DESCRIPTION
Stubbed request for testing pagination within `specialist-publisher`.

In order to paginate content items within `specialist-publisher`, a user can pass  `page` and `per_page` params into the url query string.

The change in this commit stubs a request to `publishing-api` which includes pagination params. This is then used in tests within `specialist-publisher`. These tests can be found on [this branch](https://github.com/alphagov/specialist-publisher/tree/pagination-phase-2) - probably best to scroll through 'files changed', most model specs and some feature specs!