### PR TITLE
Pin Webmock to 1.24.2

### DIFF
--- a/gds-api-adapters.gemspec
+++ b/gds-api-adapters.gemspec
@@ -37,6 +37,11 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'simplecov', '~> 0.5.4'
   s.add_development_dependency 'simplecov-rcov'
   s.add_development_dependency 'timecop', '~> 0.5.1'
-  s.add_development_dependency 'webmock', '~> 1.19'
+
+  # Webmock 1.24.3 complains that "WebMock does not support matching body for multipart/form-data requests"
+  # This is currently breaks existing tests. Revisit this when new version of
+  # webmock is released. 
+  s.add_development_dependency 'webmock', '1.24.2'
+
   s.add_development_dependency 'pact_broker-client', '~> 1.0.0'
 end


### PR DESCRIPTION
Webmock 1.24.3 (released yesterday) complains that "WebMock does not support matching body for multipart/form-data requests"

This is currently breaks existing tests and holding up development in this repo.

Example breakage:

https://ci.dev.publishing.service.gov.uk/job/govuk_gds_api_adapters_branches/745/console