### PR TITLE
Improve documentation for publishing-api and rummager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ pkg/
 /spec/pacts
 /log
 .yardoc
+doc

--- a/README.md
+++ b/README.md
@@ -1,15 +1,19 @@
-A set of API adapters to work with the GDS APIs, extracted from the frontend
-app.
+# GDS API Adapters
+
+A set of API adapters to work with the GDS APIs.
 
 Example usage:
 
-    publisher_api = GdsApi::Publisher.new("environment")
-    ostruct_publication = publisher_api.publication_for_slug('my-published-item')
+```ruby
+publishing_api = GdsApi::Publisher.new(Plek.new.find('publishing-api'))
+content_item = publishing_api.get_content(content_id)
+```
 
-    panopticon_api = GdsApi::Panopticon.new("environment")
-    ostruct_metadata = panopticon_api.artefact_for_slug('my-published-item')
+Example adapters for frequently used applications:
 
-Very much still a work in progress.
+- [Publishing API](lib/gds_api/publishing_api_v2.rb) ([docs](http://www.rubydoc.info/gems/gds-api-adapters/GdsApi/PublishingApiV2), [test helper code](https://github.com/alphagov/gds-api-adapters/blob/master/lib/gds_api/test_helpers/publishing_api_v2.rb), [test helper docs](http://www.rubydoc.info/gems/gds-api-adapters/GdsApi/TestHelpers/PublishingApiV2))
+- [Content Store](lib/gds_api/content_store.rb) ([docs](http://www.rubydoc.info/gems/gds-api-adapters/GdsApi/ContentStore), [test helper code](https://github.com/alphagov/gds-api-adapters/blob/master/lib/gds_api/test_helpers/content_store.rb), [test helper docs](http://www.rubydoc.info/gems/gds-api-adapters/GdsApi/TestHelpers/ContentStore))
+- [Rummager](lib/gds_api/publishing_api_v2.rb) ([docs](http://www.rubydoc.info/gems/gds-api-adapters/GdsApi/Rummager), [test helper code](https://github.com/alphagov/gds-api-adapters/blob/master/lib/gds_api/test_helpers/rummager.rb), [test helper docs](http://www.rubydoc.info/gems/gds-api-adapters/GdsApi/TestHelpers/Rummager))
 
 ## Logging
 

--- a/lib/gds_api/publishing_api_v2.rb
+++ b/lib/gds_api/publishing_api_v2.rb
@@ -1,9 +1,12 @@
 require_relative 'base'
 
+# Adapter for the Publishing API.
+#
+# @see https://github.com/alphagov/publishing-api
+# @see https://github.com/alphagov/publishing-api/blob/master/doc/publishing-application-examples.md
+# @see https://github.com/alphagov/publishing-api/blob/master/doc/object-model-explanation.md
 class GdsApi::PublishingApiV2 < GdsApi::Base
   # Put a content item
-  #
-  # This creates a new draft item, which will be sent to the draft content store.
   #
   # @param content_id [UUID]
   # @param payload [Hash] A valid content item

--- a/lib/gds_api/publishing_api_v2.rb
+++ b/lib/gds_api/publishing_api_v2.rb
@@ -1,6 +1,14 @@
 require_relative 'base'
 
 class GdsApi::PublishingApiV2 < GdsApi::Base
+  # Put a content item
+  #
+  # This creates a new draft item, which will be sent to the draft content store.
+  #
+  # @param content_id [UUID]
+  # @param payload [Hash] A valid content item
+  #
+  # @see https://github.com/alphagov/publishing-api/blob/master/doc/publishing-api-syntactic-usage.md#put-v2contentcontent_id
   def put_content(content_id, payload)
     put_json!(content_url(content_id), payload)
   end
@@ -14,6 +22,7 @@ class GdsApi::PublishingApiV2 < GdsApi::Base
   # @option params [String] locale The language, defaults to 'en' in publishing-api.
   #
   # @return [GdsApi::Response] a content item
+  # @see https://github.com/alphagov/publishing-api/blob/master/doc/publishing-api-syntactic-usage.md#get-v2contentcontent_id
   def get_content(content_id, params = {})
     get_json(content_url(content_id, params))
   end
@@ -29,6 +38,7 @@ class GdsApi::PublishingApiV2 < GdsApi::Base
   # @return [GdsApi::Response] a content item
   #
   # @raise [HTTPNotFound] when the content item is not found
+  # @see https://github.com/alphagov/publishing-api/blob/master/doc/publishing-api-syntactic-usage.md#get-v2contentcontent_id
   def get_content!(content_id, params = {})
     get_json!(content_url(content_id, params))
   end
@@ -42,6 +52,7 @@ class GdsApi::PublishingApiV2 < GdsApi::Base
   #   publishing_api.lookup_content_ids(base_paths: ['/foo', '/bar'])
   #   # => { "/foo" => "51ac4247-fd92-470a-a207-6b852a97f2db", "/bar" => "261bd281-f16c-48d5-82d2-9544019ad9ca" }
   #
+  # @see https://github.com/alphagov/publishing-api/blob/master/doc/publishing-api-syntactic-usage.md#post-lookup-by-base-path
   def lookup_content_ids(base_paths:)
     response = post_json!("#{endpoint}/lookup-by-base-path", base_paths: base_paths)
     response.to_hash
@@ -61,11 +72,23 @@ class GdsApi::PublishingApiV2 < GdsApi::Base
   #   publishing_api.lookup_content_id(base_path: '/foo')
   #   # => "51ac4247-fd92-470a-a207-6b852a97f2db"
   #
+  # @see https://github.com/alphagov/publishing-api/blob/master/doc/publishing-api-syntactic-usage.md#post-lookup-by-base-path
   def lookup_content_id(base_path:)
     lookups = lookup_content_ids(base_paths: [base_path])
     lookups[base_path]
   end
 
+  # Publish a content item
+  #
+  # The publishing-api will "publish" a draft item, so that it will be visible
+  # on the public site.
+  #
+  # @param content_id [UUID]
+  # @param update_type [String] Either 'major', 'minor' or 'republish'
+  # @param params [Hash]
+  # @option params [String] locale The language, defaults to 'en' in publishing-api.
+  #
+  # @see https://github.com/alphagov/publishing-api/blob/master/doc/publishing-api-syntactic-usage.md#post-v2contentcontent_idpublish
   def publish(content_id, update_type, options = {})
     params = {
       update_type: update_type
@@ -81,6 +104,15 @@ class GdsApi::PublishingApiV2 < GdsApi::Base
     post_json!(publish_url(content_id), params)
   end
 
+  # Discard a draft
+  #
+  # Deletes the draft content item.
+  #
+  # @param params [Hash]
+  # @option params [String] locale The language, defaults to 'en' in publishing-api.
+  # @option params [Integer] previous_version used to ensure the request is discarding the latest lock version of the draft
+  #
+  # @see https://github.com/alphagov/publishing-api/blob/master/doc/publishing-api-syntactic-usage.md#post-v2contentcontent_iddiscard-draft
   def discard_draft(content_id, options = {})
     optional_keys = [
       :locale,
@@ -92,10 +124,28 @@ class GdsApi::PublishingApiV2 < GdsApi::Base
     post_json!(discard_url(content_id), params)
   end
 
+  # FIXME: Add documentation
+  #
+  # @see https://github.com/alphagov/publishing-api/blob/master/doc/publishing-api-syntactic-usage.md#get-v2linkscontent_id
   def get_links(content_id)
     get_json(links_url(content_id))
   end
 
+  # Patch the links of a content item
+  #
+  # @param content_id [UUID]
+  # @param payload [Hash] A "links hash"
+  # @example
+  #
+  #   publishing_api.patch_links(
+  #     '86963c13-1f57-4005-b119-e7cf3cb92ecf',
+  #     {
+  #       topics: ['d6e1527d-d0c0-40d5-9603-b9f3e6866b8a'],
+  #       mainstream_browse_pages: ['d6e1527d-d0c0-40d5-9603-b9f3e6866b8a'],
+  #     }
+  #   )
+  #
+  # @see https://github.com/alphagov/publishing-api/blob/master/doc/publishing-api-syntactic-usage.md#patch-v2linkscontent_id
   def patch_links(content_id, payload)
     params = {
       links: payload.fetch(:links)
@@ -106,11 +156,17 @@ class GdsApi::PublishingApiV2 < GdsApi::Base
     patch_json!(links_url(content_id), params)
   end
 
+  # FIXME: Add documentation
+  #
+  # @see https://github.com/alphagov/publishing-api/blob/master/doc/publishing-api-syntactic-usage.md#get-v2content
   def get_content_items(params)
     query = query_string(params)
     get_json("#{endpoint}/v2/content#{query}")
   end
 
+  # FIXME: Add documentation
+  #
+  # @see https://github.com/alphagov/publishing-api/blob/master/doc/publishing-api-syntactic-usage.md#get-v2linkables
   def get_linkables(document_type: nil, format: nil)
     if document_type.nil?
       if format.nil?
@@ -127,6 +183,9 @@ class GdsApi::PublishingApiV2 < GdsApi::Base
     get_json("#{endpoint}/v2/linkables?document_type=#{document_type}")
   end
 
+  # FIXME: Add documentation
+  #
+  # @see https://github.com/alphagov/publishing-api/blob/master/doc/publishing-api-syntactic-usage.md#get-v2linkedcontent_id
   def get_linked_items(content_id, params = {})
     query = query_string(params)
     validate_content_id(content_id)

--- a/lib/gds_api/rummager.rb
+++ b/lib/gds_api/rummager.rb
@@ -4,17 +4,32 @@ require 'rack/utils'
 module GdsApi
   class Rummager < Base
 
+    # Unified search
+    #
+    # Perform a search
+    #
+    # @param query [Hash] A valid search query. See Rummager documentation for options.
+    #
+    # @see https://github.com/alphagov/rummager/blob/master/docs/unified-search-api.md
     def unified_search(args)
       request_url = "#{base_url}/unified_search.json?#{Rack::Utils.build_nested_query(args)}"
       get_json!(request_url)
     end
 
+    # Advanced search
+    #
+    # @deprecated Only in use by Whitehall. Use the `unified_search` method.
     def advanced_search(args)
       raise ArgumentError.new("Args cannot be blank") if args.nil? || args.empty?
       request_path = "#{base_url}/advanced_search?#{Rack::Utils.build_nested_query(args)}"
       get_json!(request_path)
     end
 
+    # Add a document
+    #
+    # Adds a document to the index
+    #
+    # @see https://github.com/alphagov/rummager/blob/master/docs/documents.md
     def add_document(type, id, document)
       post_json!(
         documents_url,
@@ -39,7 +54,7 @@ module GdsApi
     # Retrieves a content-document from the index. Content documents are pages
     # on GOV.UK returned by search index.
     #
-    # @param base_path Base path of the page on GOV.UK.
+    # @param base_path [String] Base path of the page on GOV.UK.
     # @see https://github.com/alphagov/rummager/blob/master/docs/content-api.md
     def get_content!(base_path)
       request_url = "#{base_url}/content?link=#{base_path}"
@@ -51,7 +66,8 @@ module GdsApi
     # Delete any document from the search index. Unlike `delete_content!` this
     # needs a type, but can be used to delete non-content documents from the
     # index.
-    # @deprecated
+    #
+    # @deprecated Use `delete_content!`
     def delete_document(type, id)
       delete_json!(
         "#{documents_url}/#{id}",


### PR DESCRIPTION
This PR adds some extra documentation to the publishing-api and rummager clients and updates the readme. 

It doesn't cover all the methods in Publishing API. Where documentation is missing I've added links to the publishing-api documentation in the repo. This may help new starters find their way around GOV.UK a little better.