### PR TITLE
Release 30.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 30.2.1
+
+* Update README and add documentation. See http://www.rubydoc.info/gems/gds-api-adapters/GdsApi/PublishingApiV2 for example.
+* Remove content-register
+
 # 30.2.0
 
 * Add `GdsApi::GovukHeaders.clear_headers`

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '30.2.0'
+  VERSION = '30.2.1'
 end


### PR DESCRIPTION
- Update README and add documentation. See http://www.rubydoc.info/gems/gds-api-adapters/GdsApi/PublishingApiV2 for example.
- Removes content-register
