### PR TITLE
Add notifications and notification endpoints...

### DIFF
--- a/lib/gds_api/email_alert_api.rb
+++ b/lib/gds_api/email_alert_api.rb
@@ -1,8 +1,14 @@
 require_relative 'base'
 require_relative 'exceptions'
 
+# Adapter for the Email Alert API
+#
+# @see https://github.com/alphagov/email-alert-api
 class GdsApi::EmailAlertApi < GdsApi::Base
 
+  # Get or Post subscriber list
+  #
+  # @param attributes [Hash] document_type, links, tags used to search existing subscriber lists
   def find_or_create_subscriber_list(attributes)
     tags = attributes["tags"]
     links = attributes["links"]
@@ -23,8 +29,31 @@ class GdsApi::EmailAlertApi < GdsApi::Base
     create_subscriber_list(attributes)
   end
 
+  # Post notification
+  #
+  # @param publication [Hash] Valid publication attributes
   def send_alert(publication)
     post_json!("#{endpoint}/notifications", publication)
+  end
+
+  # Get notifications
+  #
+  # @option start_at [String] Optional GovDelivery bulletin id to page back through notifications
+  #
+  # @return [Hash] notifications
+  def notifications(start_at=nil)
+    url = "#{endpoint}/notifications"
+    url += "?start_at=#{start_at}" if start_at
+    get_json!(url)
+  end
+
+  # Get notification
+  #
+  # @param id [String] GovDelivery bulletin id
+  #
+  # @return [Hash] notification
+  def notification(id)
+    get_json!("#{endpoint}/notifications/#{id}")
   end
 
 private

--- a/lib/gds_api/test_helpers/email_alert_api.rb
+++ b/lib/gds_api/test_helpers/email_alert_api.rb
@@ -74,6 +74,27 @@ module GdsApi
         assert_requested(:post, notifications_url, times: 1, &matcher)
       end
 
+      def email_alert_api_has_notifications(notifications, start_at=nil)
+        url = notifications_url
+        url += "?start_at=#{start_at}" if start_at
+        url_regexp = Regexp.new("^#{Regexp.escape(url)}$")
+
+        stub_request(:get, url_regexp)
+          .to_return(
+            status: 200,
+            body: notifications.to_json
+          )
+      end
+
+      def email_alert_api_has_notification(notification)
+        url = "#{notifications_url}/#{notification['web_service_bulletin']['to_param']}"
+
+        stub_request(:get, url).to_return(
+          status: 200,
+          body: notification.to_json
+        )
+      end
+
     private
 
       def subscriber_lists_url(attributes = nil)

--- a/test/email_alert_api_test.rb
+++ b/test/email_alert_api_test.rb
@@ -159,4 +159,33 @@ describe GdsApi::EmailAlertApi do
       end
     end
   end
+  describe "notifications" do
+    it "retrieves notifications" do
+      stubbed_request = email_alert_api_has_notifications([
+        {"subject" => "Foo"}, {"subject" => "Bar"}
+      ])
+      api_client.notifications
+      assert_requested(stubbed_request)
+    end
+
+    it "uses the start_at param if present" do
+      stubbed_request = email_alert_api_has_notifications([
+        {"subject" => "Foo"}, {"subject" => "Bar"}
+      ], "101AA")
+      api_client.notifications("101AA")
+      assert_requested(stubbed_request)
+    end
+  end
+
+  describe "notification" do
+    before do
+      @stubbed_request = email_alert_api_has_notification({
+        "web_service_bulletin" => { "to_param" => "10001001" }
+      })
+    end
+    it "retrieves a notification by id" do
+      api_client.notification("10001001")
+      assert_requested(@stubbed_request)
+    end
+  end
 end


### PR DESCRIPTION
Exposes the endpoints `/notifications` and `/notifications/:id` from the email-alert-api,
these list recent notifications (aka GovDelivery bulletins) and show the detail of a notification respectively.
No subscriber information is revealed via these methods.

[Email Alert API endpoints this PR exposes](https://github.com/alphagov/email-alert-api/commit/72e0f98cddeb8e9f9f1b0607b27bd645710bce9a)