### PR TITLE
Update links to rubydoc.info

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ results = rummager.unified_search(q: "taxes")
 
 Example adapters for frequently used applications:
 
-- [Publishing API](lib/gds_api/publishing_api_v2.rb) ([docs](http://www.rubydoc.info/gems/gds-api-adapters/GdsApi/PublishingApiV2), [test helper code](https://github.com/alphagov/gds-api-adapters/blob/master/lib/gds_api/test_helpers/publishing_api_v2.rb), [test helper docs](http://www.rubydoc.info/gems/gds-api-adapters/GdsApi/TestHelpers/PublishingApiV2))
-- [Content Store](lib/gds_api/content_store.rb) ([docs](http://www.rubydoc.info/gems/gds-api-adapters/GdsApi/ContentStore), [test helper code](https://github.com/alphagov/gds-api-adapters/blob/master/lib/gds_api/test_helpers/content_store.rb), [test helper docs](http://www.rubydoc.info/gems/gds-api-adapters/GdsApi/TestHelpers/ContentStore))
-- [Rummager](lib/gds_api/publishing_api_v2.rb) ([docs](http://www.rubydoc.info/gems/gds-api-adapters/GdsApi/Rummager), [test helper code](https://github.com/alphagov/gds-api-adapters/blob/master/lib/gds_api/test_helpers/rummager.rb), [test helper docs](http://www.rubydoc.info/gems/gds-api-adapters/GdsApi/TestHelpers/Rummager))
+- [Publishing API](lib/gds_api/publishing_api_v2.rb) ([docs](http://www.rubydoc.info/github/alphagov/gds-api-adapters/master/GdsApi/PublishingApiV2), [test helper code](https://github.com/alphagov/gds-api-adapters/blob/master/lib/gds_api/test_helpers/publishing_api_v2.rb), [test helper docs](http://www.rubydoc.info/github/alphagov/gds-api-adapters/master/GdsApi/TestHelpers/PublishingApiV2))
+- [Content Store](lib/gds_api/content_store.rb) ([docs](http://www.rubydoc.info/github/alphagov/gds-api-adapters/master/GdsApi/ContentStore), [test helper code](https://github.com/alphagov/gds-api-adapters/blob/master/lib/gds_api/test_helpers/content_store.rb), [test helper docs](http://www.rubydoc.info/github/alphagov/gds-api-adapters/master/GdsApi/TestHelpers/ContentStore))
+- [Rummager](lib/gds_api/publishing_api_v2.rb) ([docs](http://www.rubydoc.info/github/alphagov/gds-api-adapters/master/GdsApi/Rummager), [test helper code](https://github.com/alphagov/gds-api-adapters/blob/master/lib/gds_api/test_helpers/rummager.rb), [test helper docs](http://www.rubydoc.info/github/alphagov/gds-api-adapters/master/GdsApi/TestHelpers/Rummager))
 
 ## Logging
 


### PR DESCRIPTION
The current links give a little unpredictable results (you often see the docs for 30.X, while were at 30.2.X). I've set up a GitHub webhook from this repo, so master should always be up to date. It also allows easy switching to the docs for a branch, which could be nice in code review.