### PR TITLE
Remove implicit dependency between JsonClient and GdsApi::Base

### DIFF
--- a/lib/gds_api/base.rb
+++ b/lib/gds_api/base.rb
@@ -41,7 +41,8 @@ class GdsApi::Base
   def initialize(endpoint_url, options={})
     options[:endpoint_url] = endpoint_url
     raise InvalidAPIURL unless endpoint_url =~ URI::regexp
-    default_options = GdsApi::Base.default_options || {}
+    base_options = { logger: self.class.logger }
+    default_options = base_options.merge(GdsApi::Base.default_options || {})
     @options = default_options.merge(options)
     self.endpoint = options[:endpoint_url]
   end

--- a/lib/gds_api/json_client.rb
+++ b/lib/gds_api/json_client.rb
@@ -5,6 +5,7 @@ require_relative 'null_cache'
 require_relative 'govuk_headers'
 require 'lrucache'
 require 'rest-client'
+require 'null_logger'
 
 module GdsApi
   class JsonClient
@@ -38,7 +39,7 @@ module GdsApi
         raise "It is no longer possible to disable the timeout."
       end
 
-      @logger = options[:logger] || GdsApi::Base.logger
+      @logger = options[:logger] || NullLogger.instance
 
       if options[:disable_cache] || (options[:cache_size] == 0)
         @cache = NullCache.new

--- a/test/gds_api_base_test.rb
+++ b/test/gds_api_base_test.rb
@@ -88,4 +88,24 @@ class GdsApiBaseTest < Minitest::Test
       ConcreteApi.new('invalid-url')
     end.must_raise GdsApi::Base::InvalidAPIURL
   end
+
+  def test_should_set_json_client_logger_to_own_logger_by_default
+    api = ConcreteApi.new("http://bar")
+    assert_same GdsApi::Base.logger, api.client.logger
+  end
+
+  def test_should_set_json_client_logger_to_logger_in_default_options
+    custom_logger = stub('custom-logger')
+    GdsApi::Base.default_options = { logger: custom_logger }
+    api = ConcreteApi.new("http://bar")
+    assert_same custom_logger, api.client.logger
+  end
+
+  def test_should_set_json_client_logger_to_logger_in_options
+    custom_logger = stub('custom-logger')
+    GdsApi::Base.default_options = { logger: custom_logger }
+    another_logger = stub('another-logger')
+    api = ConcreteApi.new("http://bar", logger: another_logger)
+    assert_same another_logger, api.client.logger
+  end
 end

--- a/test/gds_api_base_test.rb
+++ b/test/gds_api_base_test.rb
@@ -15,6 +15,7 @@ class GdsApiBaseTest < Minitest::Test
   end
 
   def teardown
+    GdsApi::Base.default_options = nil
     GdsApi::JsonClient.cache = @orig_cache
   end
 

--- a/test/json_client_test.rb
+++ b/test/json_client_test.rb
@@ -2,6 +2,7 @@ require_relative 'test_helper'
 require 'gds_api/base'
 require 'gds_api/json_client'
 require 'base64'
+require 'null_logger'
 
 class JsonClientTest < MiniTest::Spec
   def setup
@@ -825,5 +826,15 @@ class JsonClientTest < MiniTest::Spec
     end
   ensure
     ENV['GOVUK_APP_NAME'] = previous_govuk_app_name
+  end
+
+  def test_should_default_to_using_null_logger
+    assert_same @client.logger, NullLogger.instance
+  end
+
+  def test_should_use_custom_logger_specified_in_options
+    custom_logger = stub('custom-logger')
+    client = GdsApi::JsonClient.new(logger: custom_logger)
+    assert_same client.logger, custom_logger
   end
 end


### PR DESCRIPTION
Previously `JsonClient` used `GdsApi::Base.logger` as its default logger. However, there was no corresponding `require 'base'` statement at the top of the file. This caused a [problem in Smart Answers][1] which (for better or worse) currently uses `JsonClient` directly.

It's not possible to fix this by adding such a `require` statement, because this would introduce a circular dependency. So as an alternative, I've used `NullLogger.instance` as the default value, but at the same time ensured that `GdsApi::Base` always specifies a logger in the options passed to `JsonClient#initialize`. I'm pretty confident this means that the behaviour hasn't really changed and yet there is no longer a dependency between `JsonClient` and `GdsApi::Base`.

I don't know whether I'm doing something wrong, but running the tests with the default Rake task seemed very flakey i.e. I kept seeing a lot of test failures even before making any changes. However, every couple of runs, the tests seem to work OK and they all passed.

[1]: https://github.com/alphagov/smart-answers/pull/2538