### PR TITLE
Use `document_type` & `schema_name` in special routes

### DIFF
--- a/lib/gds_api/publishing_api/special_route_publisher.rb
+++ b/lib/gds_api/publishing_api/special_route_publisher.rb
@@ -14,7 +14,8 @@ module GdsApi
 
         put_content_response = publishing_api.put_content(options.fetch(:content_id), {
           base_path: options.fetch(:base_path),
-          format: "special_route",
+          document_type: "special_route",
+          schema_name: "special_route",
           title: options.fetch(:title),
           description: options[:description] || "",
           routes: [

--- a/test/publishing_api/special_route_publisher_test.rb
+++ b/test/publishing_api/special_route_publisher_test.rb
@@ -32,7 +32,8 @@ describe GdsApi::PublishingApi::SpecialRoutePublisher do
 
         expected_payload = {
           base_path: special_route[:base_path],
-          format: "special_route",
+          document_type: "special_route",
+          schema_name: "special_route",
           title: special_route[:title],
           description: special_route[:description],
           routes: [


### PR DESCRIPTION
`document_type` & `schema_name` is replacing `format`.