### PR TITLE
Allow passing a locale to patch_links

### DIFF
--- a/lib/gds_api/publishing_api_v2.rb
+++ b/lib/gds_api/publishing_api_v2.rb
@@ -180,7 +180,7 @@ class GdsApi::PublishingApiV2 < GdsApi::Base
       links: payload.fetch(:links)
     }
 
-    params = merge_optional_keys(params, payload, [:previous_version])
+    params = merge_optional_keys(params, payload, [:previous_version, :locale])
 
     patch_json!(links_url(content_id), params)
   end

--- a/test/publishing_api_v2_test.rb
+++ b/test/publishing_api_v2_test.rb
@@ -854,7 +854,8 @@ describe GdsApi::PublishingApiV2 do
             body: {
               links: {
                 topics: ["225df4a8-2945-4e9b-8799-df7424a90b69"],
-              }
+              },
+              locale: "en"
             },
             headers: {
               "Content-Type" => "application/json",
@@ -872,7 +873,7 @@ describe GdsApi::PublishingApiV2 do
       end
 
       it "adds the new type of links and responds with the whole link set" do
-        response = @api_client.patch_links(@content_id, links: {
+        response = @api_client.patch_links(@content_id, locale: "en", links: {
           topics: ["225df4a8-2945-4e9b-8799-df7424a90b69"],
         })
 


### PR DESCRIPTION
The PATCH links publishing api endpoint accepts a locale parameter so
that it can publish the correct locale to the content store. This
change passes the parameter through from the calling client.