### PR TITLE
Add grouped content and links

### DIFF
--- a/lib/gds_api/publishing_api_v2.rb
+++ b/lib/gds_api/publishing_api_v2.rb
@@ -253,6 +253,64 @@ class GdsApi::PublishingApiV2 < GdsApi::Base
     get_json("#{endpoint}/v2/linked/#{content_id}#{query}")
   end
 
+  # Get all content items and links grouped by content id.
+  # This can be used to extract data for batch processing tasks.
+  #
+  # The API is provisional and will be changed to return a single content item for
+  # each content id.
+  #
+  # @param last_seen_content_id [UUID] Filter out all items up to and including the item identified by this content id.
+  #
+  # @param page_size [Integer] Override the default page size (10).
+  #
+  # @return [Array] A list of result hashes grouped by and ordered by content id.
+  #
+  # @example
+  #  publishing_api.get_expanded_links(page_size: 2)
+  #
+  #  #=> {
+  #    last_seen_content_id: '9157589b-65e2-4df6-92ba-2c91d80006c0'
+  #    results': [
+  #      {
+  #        content_id: '86963c13-1f57-4005-b119-e7cf3cb92ecf',
+  #        content_items: [
+  #          {
+  #            base_path: "/foo",
+  #            publishing_app: "whitehall",
+  #            format: "guide",
+  #            user_facing_version: "1",
+  #            state: "published"
+  #          }
+  #        ],
+  #        links: {
+  #          topics: ['d6e1527d-d0c0-40d5-9603-b9f3e6866b8a'],
+  #        }
+  #      },
+  #      {
+  #        content_id: '9157589b-65e2-4df6-92ba-2c91d80006c0',
+  #        content_items: [
+  #          {
+  #            base_path: "/bar",
+  #            publishing_app: "whitehall",
+  #            format: "guide",
+  #            user_facing_version: "1",
+  #            state: "published"
+  #          }
+  #        ],
+  #        links: {}
+  #      }
+  #    ]
+  #  }
+  def get_grouped_content_and_links(last_seen_content_id: nil, page_size: nil)
+    params = {}
+    params["last_seen_content_id"] = last_seen_content_id unless last_seen_content_id.nil?
+    params["page_size"] = page_size unless page_size.nil?
+
+    query = query_string(params)
+
+    get_json("#{endpoint}/v2/grouped-content-and-links#{query}")
+  end
+
 private
 
   def content_url(content_id, params = {})

--- a/lib/gds_api/test_helpers/publishing_api_v2.rb
+++ b/lib/gds_api/test_helpers/publishing_api_v2.rb
@@ -159,7 +159,7 @@ module GdsApi
       #   per_page: 50
       #)
       def publishing_api_has_content(items, params = {})
-        url = PUBLISHING_API_V2_ENDPOINT + "/content"
+        url = url_for("content")
         stub_request(:get, url).with(:query => params).to_return(status: 200, body: { results: items }.to_json, headers: {})
       end
 
@@ -179,35 +179,44 @@ module GdsApi
       end
 
       def publishing_api_has_linkables(linkables, document_type:)
-        url = PUBLISHING_API_V2_ENDPOINT + "/linkables?document_type=#{document_type}"
+        url = url_for("linkables?document_type=#{document_type}")
         stub_request(:get, url).to_return(:status => 200, :body => linkables.to_json, :headers => {})
       end
 
       def publishing_api_has_item(item)
         item = item.with_indifferent_access
-        url = PUBLISHING_API_V2_ENDPOINT + "/content/" + item[:content_id]
+        url = url_for("content", item[:content_id])
         stub_request(:get, url).to_return(status: 200, body: item.to_json, headers: {})
       end
 
       def publishing_api_does_not_have_item(content_id)
-        url = PUBLISHING_API_V2_ENDPOINT + "/content/" + content_id
+        url = url_for("content" + content_id)
         stub_request(:get, url).to_return(status: 404, body: resource_not_found(content_id, "content item").to_json, headers: {})
       end
 
       def publishing_api_has_links(links)
         links = links.with_indifferent_access
-        url = PUBLISHING_API_V2_ENDPOINT + "/links/" + links[:content_id]
+        url = url_for("links", links[:content_id])
         stub_request(:get, url).to_return(status: 200, body: links.to_json, headers: {})
       end
 
       def publishing_api_has_expanded_links(links)
-        url = PUBLISHING_API_V2_ENDPOINT + "/expanded-links/" + links[:content_id]
+        url = url_for("expanded-links", links[:content_id])
         stub_request(:get, url).to_return(status: 200, body: links.to_json, headers: {})
       end
 
       def publishing_api_does_not_have_links(content_id)
-        url = PUBLISHING_API_V2_ENDPOINT + "/links/" + content_id
+        url = url_for("links", content_id)
         stub_request(:get, url).to_return(status: 404, body: resource_not_found(content_id, "link set").to_json, headers: {})
+      end
+
+      def publishing_api_has_grouped_content_and_links(groups, params: {})
+        body = {
+          results: groups,
+          last_seen_content_id: groups.last["content_id"]
+        }
+
+        stub_publishing_api_get("grouped-content-and-links", body: body, params: params)
       end
 
       # Stub calls to the lookups endpoint
@@ -240,12 +249,12 @@ module GdsApi
         url = url_for(resource_paths)
 
         stub_request(:get, url)
-            .with(:query => params)
-            .to_return({
-                status: 200,
-                body: body.to_json,
-                headers: {"Content-Type" => "application/json; charset=utf-8"}
-            })
+          .with(:query => params)
+          .to_return({
+            status: 200,
+            body: body.to_json,
+            headers: { "Content-Type" => "application/json; charset=utf-8" }
+          })
       end
 
       def stub_publishing_api_postlike_call(method, content_id, body, resource_path, override_response_hash = {})
@@ -283,7 +292,7 @@ module GdsApi
       end
 
       def url_for(*resource_paths)
-          resource_paths.unshift(PUBLISHING_API_V2_ENDPOINT).join("/")
+        resource_paths.unshift(PUBLISHING_API_V2_ENDPOINT).join("/")
       end
     end
   end

--- a/lib/gds_api/test_helpers/publishing_api_v2.rb
+++ b/lib/gds_api/test_helpers/publishing_api_v2.rb
@@ -101,7 +101,7 @@ module GdsApi
       end
 
       def assert_publishing_api_put_content(content_id, attributes_or_matcher = nil, times = 1)
-        url = PUBLISHING_API_V2_ENDPOINT + "/content/" + content_id
+        url = url_for("content", content_id)
         assert_publishing_api(:put, url, attributes_or_matcher, times)
       end
 
@@ -174,8 +174,7 @@ module GdsApi
           "&fields%5B%5D=#{f}"
         }
 
-        url = PUBLISHING_API_V2_ENDPOINT + "/content?document_type=#{format}#{query_params.join('')}"
-
+        url = url_for("content?document_type=#{format}#{query_params.join('')}")
         stub_request(:get, url).to_return(:status => 200, :body => { results: body }.to_json, :headers => {})
       end
 
@@ -237,6 +236,18 @@ module GdsApi
         stub_publishing_api_postlike_call(:patch, *args)
       end
 
+      def stub_publishing_api_get(*resource_paths, body:, params: {})
+        url = url_for(resource_paths)
+
+        stub_request(:get, url)
+            .with(:query => params)
+            .to_return({
+                status: 200,
+                body: body.to_json,
+                headers: {"Content-Type" => "application/json; charset=utf-8"}
+            })
+      end
+
       def stub_publishing_api_postlike_call(method, content_id, body, resource_path, override_response_hash = {})
         response_hash = {status: 200, body: '{}', headers: {"Content-Type" => "application/json; charset=utf-8"}}
         response_hash.merge!(override_response_hash)
@@ -269,6 +280,10 @@ module GdsApi
             message: "Could not find #{type} with content_id: #{content_id}",
           }
         }
+      end
+
+      def url_for(*resource_paths)
+          resource_paths.unshift(PUBLISHING_API_V2_ENDPOINT).join("/")
       end
     end
   end

--- a/test/test_helpers/publishing_api_v2_test.rb
+++ b/test/test_helpers/publishing_api_v2_test.rb
@@ -51,4 +51,31 @@ describe GdsApi::TestHelpers::PublishingApiV2 do
       }, response.to_h)
     end
   end
+
+  describe "#publishing_api_has_grouped_content_and_links" do
+    it "stubs the call to get grouped_content_and links" do
+      content_id = "2e20294a-d694-4083-985e-d8bedefc2354"
+      payload = [
+        {
+          "content_id" => content_id,
+          "content_items" => [{
+            "base_path" => "/foo",
+            "publishing_app" => "whitehall",
+            "format" => "guide",
+            "user_facing_version" => "1",
+            "state" => "published"
+          }],
+          "links" => {
+            "organisations" => ["a8a09822-1729-48a7-8a68-d08300de9d1e"]
+          }
+        }
+      ]
+
+      publishing_api_has_grouped_content_and_links(payload)
+      response = publishing_api.get_grouped_content_and_links
+
+      assert_equal(response["results"], payload)
+      assert_equal(response["last_seen_content_id"], content_id)
+    end
+  end
 end


### PR DESCRIPTION
Add an API adapter for the new grouped-content-and-links publishing API endpoint.