### PR TITLE
Passthru bulk_publishing for patch_links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Allow `bulk_publishing` flag for `PublishingApiV2#patch_links`
+
 Please use this place to add information of work that hasn't been released,
 and specify if that is backwards-compatible.
 

--- a/lib/gds_api/publishing_api_v2.rb
+++ b/lib/gds_api/publishing_api_v2.rb
@@ -212,7 +212,7 @@ class GdsApi::PublishingApiV2 < GdsApi::Base
       links: payload.fetch(:links)
     }
 
-    params = merge_optional_keys(params, payload, [:previous_version])
+    params = merge_optional_keys(params, payload, [:previous_version, :bulk_publishing])
 
     patch_json!(links_url(content_id), params)
   end


### PR DESCRIPTION
Setting this optional flag controls which priority jobs are given
within the publishing-api.

Uses https://github.com/alphagov/publishing-api/pull/329