### PR TITLE
[WIP] Update `areas` param handling

### DIFF
--- a/lib/gds_api/test_helpers/mapit.rb
+++ b/lib/gds_api/test_helpers/mapit.rb
@@ -24,19 +24,8 @@ module GdsApi
           "postcode"  => postcode
         }
 
-        area_response = Hash[areas.map.with_index {|area, i|
-          [i, {
-            'codes' => {
-              'ons' => area['ons'],
-              'gss' => area['gss']
-            },
-            'name' => area['name'],
-            'type' => area['type']
-          }]
-        }]
-
         stub_request(:get, "#{MAPIT_ENDPOINT}/postcode/" + postcode.gsub(' ','+') + ".json")
-          .to_return(:body => response.merge({'areas' => area_response}).to_json, :status => 200)
+          .to_return(:body => response.merge({'areas' => areas_response(areas)}).to_json, :status => 200)
         stub_request(:get, "#{MAPIT_ENDPOINT}/postcode/partial/" + postcode.split(' ').first + ".json")
           .to_return(:body => response.to_json, :status => 200)
       end
@@ -53,12 +42,26 @@ module GdsApi
 
       def mapit_has_areas(area_type, areas)
         stub_request(:get, "#{MAPIT_ENDPOINT}/areas/" + area_type + ".json")
-          .to_return(:body => areas.to_json, :status => 200)
+          .to_return(:body => areas_response(areas).to_json, :status => 200)
       end
 
       def mapit_does_not_have_areas(area_type)
         stub_request(:get, "#{MAPIT_ENDPOINT}/areas/" + area_type + ".json")
           .to_return(:body => [].to_json, :status => 200)
+      end
+
+      def areas_response(areas)
+        Hash[areas.map.with_index {|area, i|
+          [i, {
+            'codes' => {
+              'ons' => area['ons'],
+              'gss' => area['gss'],
+              'govuk_slug' => area['govuk_slug']
+            },
+            'name' => area['name'],
+            'type' => area['type']
+          }]
+        }]
       end
     end
   end

--- a/test/mapit_test.rb
+++ b/test/mapit_test.rb
@@ -61,25 +61,26 @@ describe GdsApi::Mapit do
   end
   describe "areas_for_type" do
     before do
-       mapit_has_areas('EUR', {
-        "123" => { "name" => "Eastern", "id" => "123", "country_name" => "England" },
-        "234" => { "name" => "North West", "id" => "234", "country_name" => "England" },
-        "345" => { "name" => "Scotland", "id" => "345", "country_name" => "Scotland" }
-      })
+       mapit_has_areas('EUR', [
+          { "name" => "Eastern", "id" => "123", "country_name" => "England", 'ons' => '123' },
+          { "name" => "North West", "id" => "234", "country_name" => "England", 'ons' => '456' },
+          { "name" => "Scotland", "id" => "345", "country_name" => "Scotland", 'ons' => '789' },
+        ]
+      )
       mapit_does_not_have_areas('FOO')
     end
     it "should return areas of a type" do
       areas = @api.areas_for_type('EUR').to_hash
 
       assert_equal 3, areas.size
-      assert_equal "Eastern", areas["123"]["name"]
-      assert_equal "England", areas["123"]["country_name"]
-      assert_equal "North West", areas["234"]["name"]
-      assert_equal "England", areas["234"]["country_name"]
-      assert_equal "Scotland", areas["345"]["name"]
-      assert_equal "Scotland", areas["345"]["country_name"]
+      assert_equal "Eastern", areas["0"]["name"]
+      assert_equal "123", areas["0"]["codes"]["ons"]
+      assert_equal "North West", areas["1"]["name"]
+      assert_equal "456", areas["1"]["codes"]["ons"]
+      assert_equal "Scotland", areas["2"]["name"]
+      assert_equal "789", areas["2"]["codes"]["ons"]
     end
-    it "should return and empty result for an unknown area type" do
+    it "should return an empty result for an unknown area type" do
       response = @api.areas_for_type('FOO')
 
       assert_empty response


### PR DESCRIPTION
The `mapit_has_a_postcode_and_areas` helper allows to pass it a simplified `areas` array by converting it to the correct mapit data structure inside the helper method. The `mapit_has_areas` methods was not doing that, which made using the two helpers together awkward in tests. This brings the `mapit_has_areas` helper into line so that the two methods will convert the passed in `areas` arrays similarly.