### PR TITLE
Add assert_publishing_api_unpublish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 Please use this place to add information of work that hasn't been released,
 and specify if that is backwards-compatible.
 
+# 30.9.0
+
+* Add `assert_publishing_api_unpublish` test-helper
+
 # 30.8.0
 
 * Stubs successful and failing attachment uploads to asset manager.

--- a/lib/gds_api/test_helpers/publishing_api_v2.rb
+++ b/lib/gds_api/test_helpers/publishing_api_v2.rb
@@ -110,6 +110,11 @@ module GdsApi
         assert_publishing_api(:post, url, attributes_or_matcher, times)
       end
 
+      def assert_publishing_api_unpublish(content_id, attributes_or_matcher = nil, times = 1)
+        url = PUBLISHING_API_V2_ENDPOINT + "/content/#{content_id}/unpublish"
+        assert_publishing_api(:post, url, attributes_or_matcher, times)
+      end
+
       def assert_publishing_api_patch_links(content_id, attributes_or_matcher = nil, times = 1)
         url = PUBLISHING_API_V2_ENDPOINT + "/links/" + content_id
         assert_publishing_api(:patch, url, attributes_or_matcher, times)

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '30.8.0'
+  VERSION = '30.9.0'
 end


### PR DESCRIPTION
A test-helper that is similar to assert_publishing_api_publish but for the unpublish endpoint.
I'm aware this is not DRY but I believe the pattern in test-helpers prioritises rich-info, readability over DRY-ness.

Also bumping gem version to include the test-helper for use in specialist-publisher-rebuild.