### PR TITLE
Bump version to 31.0.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 Please use this place to add information of work that hasn't been released,
 and specify if that is backwards-compatible.
 
+# 31.0.0
+
+* Remove `format` from expected results in Pact tests.
+
 # 30.9.0
 
 * Add `assert_publishing_api_unpublish` test-helper

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '30.9.0'
+  VERSION = '31.0.0'
 end


### PR DESCRIPTION
The only thing that has changed is the expected results in the Pact
tests, but that still makes it a backwards-incompatible change hence
the major version bump.