### PR TITLE
Add a new MapIt method, `area_for_code_type`

### DIFF
--- a/lib/gds_api/mapit.rb
+++ b/lib/gds_api/mapit.rb
@@ -12,6 +12,10 @@ class GdsApi::Mapit < GdsApi::Base
     get_json("#{base_url}/areas/#{type}.json")
   end
 
+  def area_for_code(code_type, code)
+    get_json("#{base_url}/code/#{code_type}/#{code}.json")
+  end
+
   class Location
     attr_reader :response
 

--- a/lib/gds_api/test_helpers/mapit.rb
+++ b/lib/gds_api/test_helpers/mapit.rb
@@ -28,7 +28,8 @@ module GdsApi
           [i, {
             'codes' => {
               'ons' => area['ons'],
-              'gss' => area['gss']
+              'gss' => area['gss'],
+              'govuk_slug' => area['govuk_slug']
             },
             'name' => area['name'],
             'type' => area['type']
@@ -59,6 +60,16 @@ module GdsApi
       def mapit_does_not_have_areas(area_type)
         stub_request(:get, "#{MAPIT_ENDPOINT}/areas/" + area_type + ".json")
           .to_return(:body => [].to_json, :status => 200)
+      end
+
+      def mapit_has_area_for_code(code_type, code, area)
+        stub_request(:get, "#{MAPIT_ENDPOINT}/code/#{code_type}/#{code}.json")
+          .to_return(:body => area.to_json, :status => 200)
+      end
+
+      def mapit_does_not_have_area_for_code(code_type, code)
+        stub_request(:get, "#{MAPIT_ENDPOINT}/code/#{code_type}/#{code}.json")
+        .to_return(:body => { "code" => 404, "error" => "No areas were found that matched code #{code_type} = #{code}." }.to_json, :status => 404)
       end
     end
   end

--- a/test/mapit_test.rb
+++ b/test/mapit_test.rb
@@ -59,6 +59,7 @@ describe GdsApi::Mapit do
       end
     end
   end
+
   describe "areas_for_type" do
     before do
        mapit_has_areas('EUR', {
@@ -83,6 +84,32 @@ describe GdsApi::Mapit do
       response = @api.areas_for_type('FOO')
 
       assert_empty response
+    end
+  end
+
+  describe "area_for_code" do
+    before do
+      south_ribble_area = {
+        name: "South Ribble Borough Council",
+        codes: {
+          ons: "30UN",
+          gss: "E07000126",
+          unit_id: "4834"
+        },
+        type: "DIS"
+      }
+      mapit_has_area_for_code('ons', '30UN', south_ribble_area)
+      mapit_does_not_have_area_for_code('govuk_slug', 'neverland')
+    end
+
+    it "should return area for a code type" do
+      area = @api.area_for_code('ons', '30UN')
+
+      assert_equal "South Ribble Borough Council", area["name"]
+    end
+
+    it "should return 404 for a missing area of a certain code type" do
+      assert_nil @api.area_for_code('govuk_slug', 'neverland')
     end
   end
 end


### PR DESCRIPTION
- This is used in some work we're doing in `frontend`
  (https://github.com/alphagov/frontend/tree/use_authorities_from_mapit) to get
  areas data from MapIt directly:
  https://trello.com/c/YZEWeHwX/404-switch-frontend-to-get-la-slugs-from-mapit-instead-of-authorities-json-3.
- We expose the MapIt endpoint for `/code/<code_type>/<code>` as documented [in this merged MapIt PR](https://github.com/mysociety/mapit/pull/242)
- After [adding the CodeType 'govuk_slug' to MapIt](https://github.com/alphagov/mapit/pull/20), we need to update to `mapit_has_a_postcode_and_areas` test helper to include it