### PR TITLE
[Discuss, don't merge] Always raise when publishing-api & content-store return not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 Please use this place to add information of work that hasn't been released,
 and specify if that is backwards-compatible.
 
+* Publishing API client always raises when it encounters a 404. *NOT BACKWARDS COMPATIBLE*
+
 # 31.2.0
 
 * Add an `area_for_code` method to the MapIt API adapter.

--- a/lib/gds_api/content_store.rb
+++ b/lib/gds_api/content_store.rb
@@ -9,10 +9,6 @@ class GdsApi::ContentStore < GdsApi::Base
     end
   end
 
-  def content_item(base_path)
-    get_json(content_item_url(base_path))
-  end
-
   def incoming_links!(base_path, params = {})
     query = query_string(params)
     get_json!("#{endpoint}/incoming-links#{base_path}#{query}")
@@ -20,7 +16,7 @@ class GdsApi::ContentStore < GdsApi::Base
     raise ItemNotFound.build_from(e)
   end
 
-  def content_item!(base_path)
+  def content_item(base_path)
     get_json!(content_item_url(base_path))
   rescue GdsApi::HTTPNotFound => e
     raise ItemNotFound.build_from(e)
@@ -30,5 +26,9 @@ class GdsApi::ContentStore < GdsApi::Base
 
   def content_item_url(base_path)
     "#{endpoint}/content#{base_path}"
+  end
+
+  def get_json(*)
+    raise "Use `get_json!()` instead"
   end
 end

--- a/lib/gds_api/publishing_api_v2.rb
+++ b/lib/gds_api/publishing_api_v2.rb
@@ -18,20 +18,6 @@ class GdsApi::PublishingApiV2 < GdsApi::Base
 
   # Return a content item
   #
-  # Returns nil if the content item doesn't exist.
-  #
-  # @param content_id [UUID]
-  # @param params [Hash]
-  # @option params [String] locale The language, defaults to 'en' in publishing-api.
-  #
-  # @return [GdsApi::Response] a content item
-  # @see https://github.com/alphagov/publishing-api/blob/master/doc/publishing-api-syntactic-usage.md#get-v2contentcontent_id
-  def get_content(content_id, params = {})
-    get_json(content_url(content_id, params))
-  end
-
-  # Return a content item
-  #
   # Raises exception if the item doesn't exist.
   #
   # @param content_id [UUID]
@@ -42,7 +28,7 @@ class GdsApi::PublishingApiV2 < GdsApi::Base
   #
   # @raise [HTTPNotFound] when the content item is not found
   # @see https://github.com/alphagov/publishing-api/blob/master/doc/publishing-api-syntactic-usage.md#get-v2contentcontent_id
-  def get_content!(content_id, params = {})
+  def get_content(content_id, params = {})
     get_json!(content_url(content_id, params))
   end
 
@@ -157,9 +143,11 @@ class GdsApi::PublishingApiV2 < GdsApi::Base
 
   # FIXME: Add documentation
   #
+  # Raises exception if the item doesn't exist.
+  #
   # @see https://github.com/alphagov/publishing-api/blob/master/doc/publishing-api-syntactic-usage.md#get-v2linkscontent_id
   def get_links(content_id)
-    get_json(links_url(content_id))
+    get_json!(links_url(content_id))
   end
 
   # Get expanded links
@@ -189,7 +177,7 @@ class GdsApi::PublishingApiV2 < GdsApi::Base
   def get_expanded_links(content_id)
     validate_content_id(content_id)
     url = "#{endpoint}/v2/expanded-links/#{content_id}"
-    get_json(url)
+    get_json!(url)
   end
 
   # Patch the links of a content item
@@ -227,7 +215,7 @@ class GdsApi::PublishingApiV2 < GdsApi::Base
   # @see https://github.com/alphagov/publishing-api/blob/master/doc/publishing-api-syntactic-usage.md#get-v2content
   def get_content_items(params)
     query = query_string(params)
-    get_json("#{endpoint}/v2/content#{query}")
+    get_json!("#{endpoint}/v2/content#{query}")
   end
 
   # FIXME: Add documentation
@@ -246,7 +234,7 @@ class GdsApi::PublishingApiV2 < GdsApi::Base
       end
     end
 
-    get_json("#{endpoint}/v2/linkables?document_type=#{document_type}")
+    get_json!("#{endpoint}/v2/linkables?document_type=#{document_type}")
   end
 
   # FIXME: Add documentation
@@ -255,7 +243,7 @@ class GdsApi::PublishingApiV2 < GdsApi::Base
   def get_linked_items(content_id, params = {})
     query = query_string(params)
     validate_content_id(content_id)
-    get_json("#{endpoint}/v2/linked/#{content_id}#{query}")
+    get_json!("#{endpoint}/v2/linked/#{content_id}#{query}")
   end
 
 private
@@ -294,5 +282,9 @@ private
 
   def validate_content_id(content_id)
     raise ArgumentError, "content_id cannot be nil" unless content_id
+  end
+
+  def get_json(*)
+    raise "Use `get_json!()` instead"
   end
 end

--- a/test/content_store_test.rb
+++ b/test/content_store_test.rb
@@ -20,28 +20,11 @@ describe GdsApi::ContentStore do
       assert_equal base_path, response["base_path"]
     end
 
-    it "returns nil if the item doesn't exist" do
-      content_store_does_not_have_item("/non-existent")
-
-      assert_nil @api.content_item("/non-existent")
-    end
-  end
-
-  describe "#content_item!" do
-    it "returns the item" do
-      base_path = "/test-from-content-store"
-      content_store_has_item(base_path)
-
-      response = @api.content_item!(base_path)
-
-      assert_equal base_path, response["base_path"]
-    end
-
     it "raises if the item doesn't exist" do
       content_store_does_not_have_item("/non-existent")
 
       e = assert_raises GdsApi::ContentStore::ItemNotFound do
-        @api.content_item!("/non-existent")
+        @api.content_item("/non-existent")
       end
 
       assert_equal 404, e.code

--- a/test/publishing_api_v2/get_expanded_links_test.rb
+++ b/test/publishing_api_v2/get_expanded_links_test.rb
@@ -65,7 +65,7 @@ describe GdsApi::PublishingApiV2 do
       assert_equal({}, response.to_h['expanded_links'])
     end
 
-    it "responds with 404 if there's no link set entry" do
+    it "raises if there's no link set entry" do
       publishing_api
         .given("no links exist for content_id #{@content_id}")
         .upon_receiving("a get-expanded-links request")
@@ -77,9 +77,9 @@ describe GdsApi::PublishingApiV2 do
           status: 404
         )
 
-      response = @api_client.get_expanded_links(@content_id)
-
-      assert_nil response
+      assert_raises GdsApi::HTTPNotFound do
+        @api_client.get_expanded_links(@content_id)
+      end
     end
   end
 end

--- a/test/publishing_api_v2/get_links_test.rb
+++ b/test/publishing_api_v2/get_links_test.rb
@@ -77,8 +77,9 @@ describe GdsApi::PublishingApiV2 do
       end
 
       it "responds with 404" do
-        response = @api_client.get_links(@content_id)
-        assert_nil response
+        assert_raises GdsApi::HTTPNotFound do
+          @api_client.get_links(@content_id)
+        end
       end
     end
   end

--- a/test/publishing_api_v2_test.rb
+++ b/test/publishing_api_v2_test.rb
@@ -309,8 +309,10 @@ describe GdsApi::PublishingApiV2 do
           )
       end
 
-      it "responds with 404" do
-        assert_nil @api_client.get_content(@content_id)
+      it "raises for 404s" do
+        assert_raises GdsApi::HTTPNotFound do
+          @api_client.get_content(@content_id)
+        end
       end
     end
   end
@@ -1356,14 +1358,15 @@ describe GdsApi::PublishingApiV2 do
       end
 
       it "404s" do
-        response = @api_client.get_linked_items(
-          @content_id,
-          {
-            link_type: "topic",
-            fields: ["content_id", "base_path"],
-          }
-        )
-        assert_nil response
+        assert_raises GdsApi::HTTPNotFound do
+          @api_client.get_linked_items(
+            @content_id,
+            {
+              link_type: "topic",
+              fields: ["content_id", "base_path"],
+            }
+          )
+        end
       end
     end
 


### PR DESCRIPTION
This commit makes sure that the publishing-api and content-store clients raise a `GdsApi::NotFound` error when the server returns a 404 (Not Found) or 410 (Gone). 

API calls won't return `nil` anymore.

This was previously only the case for some methods. In some cases a pattern was to have a `bang!` method and a non-`bang!` method, so that the client could opt-in to this behaviour. But clients like Rummager use the `get_json!` method exclusively.

Reasons to change:

- This makes the behaviour consistent across the most used clients (publishing-api, content-store and rummager)
- Less duplication between `bang!` and `non_bang` methods.
- Makes it less likely that we inadvertently introduce nils, which generate errors that are hard to spot and to debug.

**Don't merge**: I'd like feedback about this first, as it's quite a backwards-incompatible change. 