### PR TITLE
Add a param for 'allow_draft' unpublishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 Please use this place to add information of work that hasn't been released,
 and specify if that is backwards-compatible.
 
+* Add `allow_draft` flag that can optionally be set when unpublishing
+
 # 31.3.0
 
 * Add `stub_any_rummager_delete_content` and `assert_rummager_deleted_content`

--- a/lib/gds_api/publishing_api_v2.rb
+++ b/lib/gds_api/publishing_api_v2.rb
@@ -121,7 +121,7 @@ class GdsApi::PublishingApiV2 < GdsApi::Base
   # @param locale [String] (optional) The content item locale.
   #
   # @see https://github.com/alphagov/publishing-api/blob/master/doc/publishing-api-syntactic-usage.md#post-v2contentcontent_idunpublish
-  def unpublish(content_id, type:, explanation: nil, alternative_path: nil, discard_drafts: false, previous_version: nil, locale: nil)
+  def unpublish(content_id, type:, explanation: nil, alternative_path: nil, discard_drafts: false, allow_draft: false, previous_version: nil, locale: nil)
     params = {
       type: type
     }
@@ -130,6 +130,7 @@ class GdsApi::PublishingApiV2 < GdsApi::Base
     params.merge!(alternative_path: alternative_path) if alternative_path
     params.merge!(previous_version: previous_version) if previous_version
     params.merge!(discard_drafts: discard_drafts) if discard_drafts
+    params.merge!(allow_draft: allow_draft) if allow_draft
     params.merge!(locale: locale) if locale
 
     post_json!(unpublish_url(content_id), params)


### PR DESCRIPTION
This allows content items to transition from draft to
the unpublished state without being published. See:

https://github.com/alphagov/publishing-api/blob/master/doc/publishing-api-syntactic-usage.md#post-v2contentcontent_idunpublish