### PR TITLE
Add deprecation warning for rummager stubs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Provide a warning message for rummager deprecated stubs
+
 Please use this place to add information of work that hasn't been released,
 and specify if that is backwards-compatible.
 

--- a/lib/gds_api/test_helpers/rummager.rb
+++ b/lib/gds_api/test_helpers/rummager.rb
@@ -25,6 +25,7 @@ module GdsApi
 
       # @deprecated Rummager.delete_docment is deprecated, so is this stub!  Use `stub_any_rummager_delete_content`
       def stub_any_rummager_delete
+        warn "stub_any_rummager_delete is deprecated, instead use: stub_any_rummager_delete_content"
         stub_request(:delete, %r{#{Plek.new.find('search')}/documents/.*})
       end
 
@@ -34,6 +35,8 @@ module GdsApi
 
       # @deprecated Rummager.delete_docment is deprecated, so is this stub!  Use `assert_rummager_deleted_content`
       def assert_rummager_deleted_item(id)
+        warn "assert_rummager_deleted_item stub is deprecated, instead use: assert_rummager_deleted_content"
+
         if id =~ %r{^/}
           raise ArgumentError, 'Rummager id must not start with a slash'
         end


### PR DESCRIPTION
This will force people to replace those methods, commenting is not a good practice to keep projects up to date.