### PR TITLE
Allow base_path lookups for a single given state

### DIFF
--- a/lib/gds_api/publishing_api_v2.rb
+++ b/lib/gds_api/publishing_api_v2.rb
@@ -49,6 +49,7 @@ class GdsApi::PublishingApiV2 < GdsApi::Base
   # Find the content_ids for a list of base_paths.
   #
   # @param base_paths [Array]
+  # @param state String
   # @return [Hash] a hash, keyed by `base_path` with `content_id` as value
   # @example
   #
@@ -56,8 +57,11 @@ class GdsApi::PublishingApiV2 < GdsApi::Base
   #   # => { "/foo" => "51ac4247-fd92-470a-a207-6b852a97f2db", "/bar" => "261bd281-f16c-48d5-82d2-9544019ad9ca" }
   #
   # @see https://github.com/alphagov/publishing-api/blob/master/doc/publishing-api-syntactic-usage.md#post-lookup-by-base-path
-  def lookup_content_ids(base_paths:)
-    response = post_json!("#{endpoint}/lookup-by-base-path", base_paths: base_paths)
+  def lookup_content_ids(base_paths:, state: nil)
+    options = { base_paths: base_paths }.tap do |opts|
+      opts[:state] = state if state
+    end
+    response = post_json!("#{endpoint}/lookup-by-base-path", options)
     response.to_hash
   end
 
@@ -76,8 +80,8 @@ class GdsApi::PublishingApiV2 < GdsApi::Base
   #   # => "51ac4247-fd92-470a-a207-6b852a97f2db"
   #
   # @see https://github.com/alphagov/publishing-api/blob/master/doc/publishing-api-syntactic-usage.md#post-lookup-by-base-path
-  def lookup_content_id(base_path:)
-    lookups = lookup_content_ids(base_paths: [base_path])
+  def lookup_content_id(base_path:, state: nil)
+    lookups = lookup_content_ids(base_paths: [base_path], state: state)
     lookups[base_path]
   end
 

--- a/lib/gds_api/publishing_api_v2.rb
+++ b/lib/gds_api/publishing_api_v2.rb
@@ -48,8 +48,9 @@ class GdsApi::PublishingApiV2 < GdsApi::Base
 
   # Find the content_ids for a list of base_paths.
   #
-  # @param base_paths [Array]
-  # @param state String
+  # @param base_paths [Array] A list of base_paths to look up
+  # @param state String an (optional) single state to filter by, e.g. 'draft', 'published'
+  #
   # @return [Hash] a hash, keyed by `base_path` with `content_id` as value
   # @example
   #
@@ -70,7 +71,8 @@ class GdsApi::PublishingApiV2 < GdsApi::Base
   # Convenience method if you only need to look up one content_id for a
   # base_path. For multiple base_paths, use {GdsApi::PublishingApiV2#lookup_content_ids}.
   #
-  # @param base_path [String]
+  # @param base_path [Array] A base path to look up
+  # @param state String an (optional) single state to filter by, e.g. 'draft', 'published'
   #
   # @return [UUID] the `content_id` for the `base_path`
   #

--- a/test/publishing_api_v2/lookup_test.rb
+++ b/test/publishing_api_v2/lookup_test.rb
@@ -35,11 +35,39 @@ describe GdsApi::PublishingApiV2 do
 
       assert_equal "08f86d00-e95f-492f-af1d-470c5ba4752e", content_id
     end
+
+    it "returns the content_id for a base_path and state" do
+      publishing_api
+        .given("there are draft content items with base_paths /foo and /bar,"\
+               "and foo is in draft")
+        .upon_receiving("a /lookup-by-base-path-request")
+        .with(
+          method: :post,
+          path: "/lookup-by-base-path",
+          body: {
+            base_paths: ["/foo"],
+            state: "draft"
+          },
+          headers: {
+            "Content-Type" => "application/json",
+          },
+        )
+        .will_respond_with(
+          status: 200,
+          body: {
+            "/foo" => "08f86d00-e95f-492f-af1d-470c5ba4752e"
+          }
+        )
+
+      content_id = @api_client.lookup_content_id(base_path: "/foo", state: "draft")
+
+      assert_equal "08f86d00-e95f-492f-af1d-470c5ba4752e", content_id
+    end
   end
 
   describe "#lookup_content_ids" do
-    it "returns the content_id for a base_path" do
-      reponse_hash = {
+    it "returns the content_ids for a base_path" do
+      response_hash = {
         "/foo" => "08f86d00-e95f-492f-af1d-470c5ba4752e",
         "/bar" => "ca6c58a6-fb9d-479d-b3e6-74908781cb18",
       }
@@ -59,12 +87,43 @@ describe GdsApi::PublishingApiV2 do
         )
         .will_respond_with(
           status: 200,
-          body: reponse_hash,
+          body: response_hash,
         )
 
       content_id = @api_client.lookup_content_ids(base_paths: ["/foo", "/bar"])
 
-      assert_equal(reponse_hash, content_id)
+      assert_equal(response_hash, content_id)
+    end
+
+    it "returns the content_ids for a base_path and state" do
+      response_hash = {
+        "/foo" => "08f86d00-e95f-492f-af1d-470c5ba4752e",
+        "/bar" => "ca6c58a6-fb9d-479d-b3e6-74908781cb18",
+      }
+
+      publishing_api
+        .given("there are live content items with base_paths /foo and /bar, "\
+               "and both are in draft")
+        .upon_receiving("a request for multiple base_paths")
+        .with(
+          method: :post,
+          path: "/lookup-by-base-path",
+          body: {
+            base_paths: ["/foo", "/bar"],
+            state: "draft"
+          },
+          headers: {
+            "Content-Type" => "application/json",
+          },
+        )
+        .will_respond_with(
+          status: 200,
+          body: response_hash,
+        )
+
+      content_id = @api_client.lookup_content_ids(base_paths: ["/foo", "/bar"])
+
+      assert_equal(response_hash, content_id)
     end
   end
 end


### PR DESCRIPTION
* Gives us a way to see what existing item is causing a collision in
  dfid-transition
* Don't allow multiple state query, as some combinations (e.g.
  live/draft) are inadvisable

## Related PRs

* [ ] https://github.com/alphagov/publishing-api/pull/410