### PR TITLE
Fix flakey tests on Jenkins

### DIFF
--- a/test/govuk_headers_test.rb
+++ b/test/govuk_headers_test.rb
@@ -6,6 +6,10 @@ describe GdsApi::GovukHeaders do
     Thread.current[:headers] = nil if Thread.current[:headers]
   end
 
+  after :each do
+    GdsApi::GovukHeaders.clear_headers
+  end
+
   it "supports read/write of headers" do
     GdsApi::GovukHeaders.set_header("GDS-Request-Id", "123-456")
     GdsApi::GovukHeaders.set_header("Content-Type", "application/pdf")


### PR DESCRIPTION
Depending on the order of tests, global state was being set
on the GovukHeaders singleton, which then interfered with
the pact tests that were checking the content type header.