### PR TITLE
Allow publishing apps to request a specific version.

### DIFF
--- a/test/publishing_api_v2_test.rb
+++ b/test/publishing_api_v2_test.rb
@@ -286,6 +286,124 @@ describe GdsApi::PublishingApiV2 do
       end
     end
 
+    describe "when a content item exists in with a superseded version" do
+      describe "when requesting the superseded version" do
+        before do
+          @content_item = content_item_for_content_id(@content_id)
+
+          publishing_api
+            .given("a content item exists in with a superseded version with content_id: #{@content_id}")
+            .upon_receiving("a request to return the superseded content item")
+            .with(
+              method: :get,
+              path: "/v2/content/#{@content_id}",
+              query: "version=1",
+            )
+            .will_respond_with(
+              status: 200,
+              body: {
+                "content_id" => @content_id,
+                "document_type" => Pact.like("special_route"),
+                "schema_name" => Pact.like("special_route"),
+                "publishing_app" => Pact.like("publisher"),
+                "rendering_app" => Pact.like("frontend"),
+                "locale" => Pact.like("en"),
+                "routes" => Pact.like([{}]),
+                "public_updated_at" => Pact.like("2015-07-30T13:58:11.000Z"),
+                "details" => Pact.like({}),
+                "publication_state" => "superseded"
+              },
+              headers: {
+                "Content-Type" => "application/json; charset=utf-8",
+              },
+            )
+        end
+
+        it "responds with 200 and the superseded content item" do
+          response = @api_client.get_content(@content_id, version: 1)
+          assert_equal 200, response.code
+          assert_equal response["publication_state"], "superseded"
+        end
+      end
+
+      describe "when requesting the published version" do
+        before do
+          @content_item = content_item_for_content_id(@content_id)
+
+          publishing_api
+            .given("a content item exists in with a superseded version with content_id: #{@content_id}")
+            .upon_receiving("a request to return the published content item")
+            .with(
+              method: :get,
+              path: "/v2/content/#{@content_id}",
+              query: "version=2",
+            )
+            .will_respond_with(
+              status: 200,
+              body: {
+                "content_id" => @content_id,
+                "document_type" => Pact.like("special_route"),
+                "schema_name" => Pact.like("special_route"),
+                "publishing_app" => Pact.like("publisher"),
+                "rendering_app" => Pact.like("frontend"),
+                "locale" => Pact.like("en"),
+                "routes" => Pact.like([{}]),
+                "public_updated_at" => Pact.like("2015-07-30T13:58:11.000Z"),
+                "details" => Pact.like({}),
+                "publication_state" => "live"
+              },
+              headers: {
+                "Content-Type" => "application/json; charset=utf-8",
+              },
+            )
+        end
+
+        it "responds with 200 and the published content item" do
+          response = @api_client.get_content(@content_id, version: 2)
+          assert_equal 200, response.code
+          assert_equal response["publication_state"], "live"
+        end
+      end
+
+      describe "when requesting no specific version" do
+        before do
+          @content_item = content_item_for_content_id(@content_id)
+
+          publishing_api
+            .given("a content item exists in with a superseded version with content_id: #{@content_id}")
+            .upon_receiving("a request to return the content item")
+            .with(
+              method: :get,
+              path: "/v2/content/#{@content_id}",
+            )
+            .will_respond_with(
+              status: 200,
+              body: {
+                "content_id" => @content_id,
+                "document_type" => Pact.like("special_route"),
+                "schema_name" => Pact.like("special_route"),
+                "publishing_app" => Pact.like("publisher"),
+                "rendering_app" => Pact.like("frontend"),
+                "locale" => Pact.like("en"),
+                "routes" => Pact.like([{}]),
+                "public_updated_at" => Pact.like("2015-07-30T13:58:11.000Z"),
+                "details" => Pact.like({}),
+                "publication_state" => "live"
+              },
+              headers: {
+                "Content-Type" => "application/json; charset=utf-8",
+              },
+            )
+        end
+
+        it "responds with 200 and the published content item" do
+          response = @api_client.get_content(@content_id)
+          assert_equal 200, response.code
+          assert_equal response["publication_state"], "live"
+        end
+      end
+    end
+
     describe "a non-existent item" do
       before do
         publishing_api


### PR DESCRIPTION
During the Specialist Publisher migration work, we found that we need to be able to retrieve the published version of content so that we can re-trigger email alerts if they fail to send (for whatever reason). Currently, you can only retrieve the latest piece of content, which is sometimes a draft if the content has been redrafted.

Additionally, existing applications provide features that allow users of those apps to view superseded content. Travel Advice Publisher, for example, allows users to view "archived" content which is not currently supported by the Publishing API.

Integration tests provided via these pact tests: https://github.com/alphagov/publishing-api/pull/414