### PR TITLE
Add API adapter for Local Links Manager

### DIFF
--- a/lib/gds_api/local_links_manager.rb
+++ b/lib/gds_api/local_links_manager.rb
@@ -1,0 +1,9 @@
+require_relative 'base'
+
+class GdsApi::LocalLinksManager < GdsApi::Base
+  def local_link(authority_slug, lgsl, lgil=nil)
+    url = "#{endpoint}/api/link?authority_slug=#{authority_slug}&lgsl=#{lgsl}"
+    url += "&lgil=#{lgil}" if lgil
+    get_json(url)
+  end
+end

--- a/lib/gds_api/test_helpers/local_links_manager.rb
+++ b/lib/gds_api/test_helpers/local_links_manager.rb
@@ -1,0 +1,113 @@
+require 'gds_api/test_helpers/json_client_helper'
+
+module GdsApi
+  module TestHelpers
+    module LocalLinksManager
+
+      LOCAL_LINKS_MANAGER_ENDPOINT = Plek.current.find('local_links_manager')
+
+      def local_links_manager_has_a_link(authority_slug:, lgsl:, lgil:, url:)
+        response = {
+          "local_authority" => {
+            "name" => authority_slug.capitalize,
+            "snac" => "00AG",
+            "tier" => "unitary",
+            "homepage_url" => "http://#{authority_slug}.example.com",
+          },
+          "local_interaction" => {
+            "lgsl_code" => lgsl,
+            "lgil_code" => lgil,
+            "url" => url,
+          }
+        }
+
+        stub_request(:get, "#{LOCAL_LINKS_MANAGER_ENDPOINT}/api/link")
+          .with(query: {authority_slug: authority_slug, lgsl: lgsl, lgil: lgil})
+          .to_return(body: response.to_json, status: 200)
+      end
+
+      def local_links_manager_has_no_link(authority_slug:, lgsl:, lgil:)
+        response = {
+          "local_authority" => {
+            "name" => authority_slug.capitalize,
+            "snac" => "00AG",
+            "tier" => "unitary",
+            "homepage_url" => "http://#{authority_slug}.example.com",
+          },
+        }
+
+        stub_request(:get, "#{LOCAL_LINKS_MANAGER_ENDPOINT}/api/link")
+          .with(query: {authority_slug: authority_slug, lgsl: lgsl, lgil: lgil})
+          .to_return(body: response.to_json, status: 200)
+      end
+
+      def local_links_manager_has_no_link_and_no_homepage_url(authority_slug:, lgsl:, lgil:)
+        response = {
+          "local_authority" => {
+            "name" => authority_slug.capitalize,
+            "snac" => "00AG",
+            "tier" => "unitary",
+            "homepage_url" => nil,
+          },
+        }
+
+        stub_request(:get, "#{LOCAL_LINKS_MANAGER_ENDPOINT}/api/link")
+          .with(query: {authority_slug: authority_slug, lgsl: lgsl, lgil: lgil})
+          .to_return(body: response.to_json, status: 200)
+      end
+
+      def local_links_manager_has_a_fallback_link(authority_slug:, lgsl:, lgil:, url:)
+        response = {
+          "local_authority" => {
+            "name" => authority_slug.capitalize,
+            "snac" => "00AG",
+            "tier" => "unitary",
+            "homepage_url" => "http://#{authority_slug}.example.com",
+          },
+          "local_interaction" => {
+            "lgsl_code" => lgsl,
+            "lgil_code" => lgil,
+            "url" => url,
+          }
+        }
+
+        stub_request(:get, "#{LOCAL_LINKS_MANAGER_ENDPOINT}/api/link")
+          .with(query: {authority_slug: authority_slug, lgsl: lgsl})
+          .to_return(body: response.to_json, status: 200)
+      end
+
+      def local_links_manager_has_no_fallback_link(authority_slug:, lgsl:)
+        response = {
+          "local_authority" => {
+            "name" => authority_slug.capitalize,
+            "snac" => "00AG",
+            "tier" => "unitary",
+            "homepage_url" => "http://#{authority_slug}.example.com",
+          },
+        }
+
+        stub_request(:get, "#{LOCAL_LINKS_MANAGER_ENDPOINT}/api/link")
+          .with(query: {authority_slug: authority_slug, lgsl: lgsl})
+          .to_return(body: response.to_json, status: 200)
+      end
+
+      def local_links_manager_request_with_missing_parameters(authority_slug, lgsl)
+        # convert nil to an empty string, otherwise query param is not expressed correctly
+        params = { authority_slug: authority_slug || "", lgsl: lgsl || "" }
+
+        stub_request(:get, "#{LOCAL_LINKS_MANAGER_ENDPOINT}/api/link")
+          .with(query: params)
+          .to_return(body: {}.to_json, status: 400)
+      end
+
+      def local_links_manager_does_not_have_required_objects(authority_slug, lgsl, lgil=nil)
+        params = { authority_slug: authority_slug, lgsl: lgsl }
+        params.merge!(lgil: lgil) if lgil
+
+        stub_request(:get, "#{LOCAL_LINKS_MANAGER_ENDPOINT}/api/link")
+          .with(query: params)
+          .to_return(body: {}.to_json, status: 404)
+      end
+    end
+  end
+end

--- a/test/local_links_manager_api_test.rb
+++ b/test/local_links_manager_api_test.rb
@@ -1,0 +1,171 @@
+require "test_helper"
+require "gds_api/local_links_manager"
+require "gds_api/test_helpers/local_links_manager"
+require 'pry'
+
+describe GdsApi::LocalLinksManager do
+  include GdsApi::TestHelpers::LocalLinksManager
+
+  before do
+    @base_api_url = Plek.current.find("local_links_manager")
+    @api = GdsApi::LocalLinksManager.new(@base_api_url)
+  end
+
+  describe "#link" do
+    describe "when making request for specific LGIL" do
+      it "returns the local authority and local interaction details if link present" do
+        local_links_manager_has_a_link(
+          authority_slug: "blackburn",
+          lgsl: 2,
+          lgil: 4,
+          url: "http://blackburn.example.com/abandoned-shopping-trolleys/report"
+        )
+
+        expected_response = {
+          "local_authority" => {
+            "name" => "Blackburn",
+              "snac" => "00AG",
+              "tier" => "unitary",
+              "homepage_url" => "http://blackburn.example.com",
+          },
+          "local_interaction" => {
+            "lgsl_code" => 2,
+            "lgil_code" => 4,
+            "url" => "http://blackburn.example.com/abandoned-shopping-trolleys/report",
+          }
+        }
+
+        response = @api.local_link("blackburn", 2, 4)
+        assert_equal expected_response, response.to_hash
+      end
+
+      it "returns the local authority details only if no link present" do
+        local_links_manager_has_no_link(
+          authority_slug: "blackburn",
+          lgsl: 2,
+          lgil: 4,
+        )
+
+        expected_response = {
+          "local_authority" => {
+            "name" => "Blackburn",
+              "snac" => "00AG",
+              "tier" => "unitary",
+              "homepage_url" => "http://blackburn.example.com",
+          },
+        }
+
+        response = @api.local_link("blackburn", 2, 4)
+        assert_equal expected_response, response.to_hash
+      end
+
+      it 'returns the local authority without a homepage url if no homepage link present' do
+        local_links_manager_has_no_link_and_no_homepage_url(
+          authority_slug: "blackburn",
+          lgsl: 2,
+          lgil: 4,
+        )
+
+        expected_response = {
+          "local_authority" => {
+            "name" => "Blackburn",
+              "snac" => "00AG",
+              "tier" => "unitary",
+              "homepage_url" => nil,
+          },
+        }
+
+        response = @api.local_link("blackburn", 2, 4)
+        assert_equal expected_response, response.to_hash
+      end
+    end
+
+    describe "when making request without LGIL" do
+      it "returns the local authority and local interaction details if link present" do
+        local_links_manager_has_a_fallback_link(
+          authority_slug: "blackburn",
+          lgsl: 2,
+          lgil: 3,
+          url: "http://blackburn.example.com/abandoned-shopping-trolleys/report"
+        )
+
+        expected_response = {
+          "local_authority" => {
+            "name" => "Blackburn",
+              "snac" => "00AG",
+              "tier" => "unitary",
+              "homepage_url" => "http://blackburn.example.com",
+          },
+          "local_interaction" => {
+            "lgsl_code" => 2,
+            "lgil_code" => 3,
+            "url" => "http://blackburn.example.com/abandoned-shopping-trolleys/report",
+          }
+        }
+
+        response = @api.local_link("blackburn", 2)
+        assert_equal expected_response, response.to_hash
+      end
+
+      it "returns the local authority and local interaction details if no link present" do
+        local_links_manager_has_no_fallback_link(
+          authority_slug: "blackburn",
+          lgsl: 2
+        )
+
+        expected_response = {
+          "local_authority" => {
+            "name" => "Blackburn",
+              "snac" => "00AG",
+              "tier" => "unitary",
+              "homepage_url" => "http://blackburn.example.com",
+          },
+        }
+
+        response = @api.local_link("blackburn", 2)
+        assert_equal expected_response, response.to_hash
+      end
+    end
+
+    describe "when making request with missing required parameters" do
+      it "raises HTTPClientError when authority_slug is missing" do
+        local_links_manager_request_with_missing_parameters(nil, 2)
+
+        assert_raises GdsApi::HTTPClientError do
+          @api.local_link(nil, 2)
+        end
+      end
+
+      it "raises HTTPClientError when LGSL is missing" do
+        local_links_manager_request_with_missing_parameters('blackburn', nil)
+
+        assert_raises GdsApi::HTTPClientError do
+          @api.local_link('blackburn', nil)
+        end
+      end
+    end
+
+    describe "when making request with invalid required parameters" do
+      it "returns nil when authority_slug is invalid" do
+        local_links_manager_does_not_have_required_objects("hogwarts", 2)
+
+        response = @api.local_link("hogwarts", 2)
+        assert_equal nil, response
+      end
+
+      it "returns nil when LGSL is invalid" do
+        local_links_manager_does_not_have_required_objects("blackburn", 999)
+
+        response = @api.local_link("blackburn", 999)
+        assert_equal nil, response
+      end
+
+      it "returns nil when the LGSL and LGIL combination is invalid" do
+        local_links_manager_does_not_have_required_objects("blackburn", 2, 9)
+
+        response = @api.local_link("blackburn", 2, 9)
+        assert_equal nil, response
+      end
+    end
+  end
+end


### PR DESCRIPTION
Added #local_link for Local Links Manager

[Corresponding PR](https://github.com/alphagov/local-links-manager/pull/44)

[Trello card](https://trello.com/c/yLMi98ze/428-3-of-4-start-using-data-from-local-links-manager-for-local-transactions-in-production)