### PR TITLE
[DISCUSS] Spike wrapper for LocalLinksManager local authority endpoint

### DIFF
--- a/lib/gds_api/local_links_manager.rb
+++ b/lib/gds_api/local_links_manager.rb
@@ -6,4 +6,9 @@ class GdsApi::LocalLinksManager < GdsApi::Base
     url += "&lgil=#{lgil}" if lgil
     get_json(url)
   end
+
+  def local_authority(authority_slug)
+    url = "#{endpoint}/api/local_authority?authority_slug=#{authority_slug}"
+    get_json(url)    
+  end
 end

--- a/lib/gds_api/local_links_manager.rb
+++ b/lib/gds_api/local_links_manager.rb
@@ -1,0 +1,9 @@
+require_relative 'base'
+
+class GdsApi::LocalLinksManager < GdsApi::Base
+  def local_link(authority_slug, lgsl, lgil=nil)
+    url = "#{endpoint}/api/link?authority_slug=#{authority_slug}&lgsl=#{lgsl}"
+    url += "&lgil=#{lgil}" if lgil
+    get_json(url)
+  end
+end

--- a/lib/gds_api/test_helpers/local_links_manager.rb
+++ b/lib/gds_api/test_helpers/local_links_manager.rb
@@ -1,0 +1,95 @@
+require 'gds_api/test_helpers/json_client_helper'
+
+module GdsApi
+  module TestHelpers
+    module LocalLinksManager
+
+      LOCAL_LINKS_MANAGER_ENDPOINT = Plek.current.find('local_links_manager')
+
+      def local_links_manager_has_a_link(authority_slug:, lgsl:, lgil:, url:)
+        response = {
+          "local_authority" => {
+            "name" => authority_slug.capitalize,
+            "snac" => "00AG",
+            "tier" => "unitary",
+            "homepage_url" => "http://#{authority_slug}.example.com",
+          },
+          "local_interaction" => {
+            "lgsl_code" => lgsl,
+            "lgil_code" => lgil,
+            "url" => url,
+          }
+        }
+
+        stub_request(:get, "#{LOCAL_LINKS_MANAGER_ENDPOINT}/api/link")
+          .with(query: {authority_slug: authority_slug, lgsl: lgsl, lgil: lgil})
+          .to_return(body: response.to_json, status: 200)
+      end
+
+      def local_links_manager_has_no_link(authority_slug:, lgsl:, lgil:)
+        response = {
+          "local_authority" => {
+            "name" => authority_slug.capitalize,
+            "snac" => "00AG",
+            "tier" => "unitary",
+            "homepage_url" => "http://#{authority_slug}.example.com",
+          },
+        }
+
+        stub_request(:get, "#{LOCAL_LINKS_MANAGER_ENDPOINT}/api/link")
+          .with(query: {authority_slug: authority_slug, lgsl: lgsl, lgil: lgil})
+          .to_return(body: response.to_json, status: 200)
+      end
+
+      def local_links_manager_has_no_link_and_no_homepage_url(authority_slug:, lgsl:, lgil:)
+        response = {
+          "local_authority" => {
+            "name" => authority_slug.capitalize,
+            "snac" => "00AG",
+            "tier" => "unitary",
+            "homepage_url" => nil,
+          },
+        }
+
+        stub_request(:get, "#{LOCAL_LINKS_MANAGER_ENDPOINT}/api/link")
+          .with(query: {authority_slug: authority_slug, lgsl: lgsl, lgil: lgil})
+          .to_return(body: response.to_json, status: 200)
+      end
+
+      def local_links_manager_has_a_fallback_link(authority_slug:, lgsl:, lgil:, url:)
+        response = {
+          "local_authority" => {
+            "name" => authority_slug.capitalize,
+            "snac" => "00AG",
+            "tier" => "unitary",
+            "homepage_url" => "http://#{authority_slug}.example.com",
+          },
+          "local_interaction" => {
+            "lgsl_code" => lgsl,
+            "lgil_code" => lgil,
+            "url" => url,
+          }
+        }
+
+        stub_request(:get, "#{LOCAL_LINKS_MANAGER_ENDPOINT}/api/link")
+          .with(query: {authority_slug: authority_slug, lgsl: lgsl})
+          .to_return(body: response.to_json, status: 200)
+      end
+
+      def local_links_manager_has_no_fallback_link(authority_slug:, lgsl:)
+        response = {
+          "local_authority" => {
+            "name" => authority_slug.capitalize,
+            "snac" => "00AG",
+            "tier" => "unitary",
+            "homepage_url" => "http://#{authority_slug}.example.com",
+          },
+        }
+
+        stub_request(:get, "#{LOCAL_LINKS_MANAGER_ENDPOINT}/api/link")
+          .with(query: {authority_slug: authority_slug, lgsl: lgsl})
+          .to_return(body: response.to_json, status: 200)
+      end
+    end
+  end
+end

--- a/lib/gds_api/test_helpers/local_links_manager.rb
+++ b/lib/gds_api/test_helpers/local_links_manager.rb
@@ -90,6 +90,43 @@ module GdsApi
           .with(query: {authority_slug: authority_slug, lgsl: lgsl})
           .to_return(body: response.to_json, status: 200)
       end
+
+      def local_links_manager_has_a_local_authority(authority_slug)
+        response = {
+          "local_authorities" => [
+            {
+              "name" => authority_slug.capitalize,
+              "homepage_url" => "http://#{authority_slug}.example.com",
+              "type" => "unitary"
+            }
+          ]
+        }
+
+        stub_request(:get, "#{LOCAL_LINKS_MANAGER_ENDPOINT}/api/local_authority")
+          .with(query: {authority_slug: authority_slug})
+          .to_return(body: response.to_json, status: 200)
+      end
+
+      def local_links_manager_has_a_district_and_county_local_authority(district_slug, county_slug)
+        response = {
+          "local_authorities" => [
+            {
+              "name" => district_slug.capitalize,
+              "homepage_url" => "http://#{district_slug}.example.com",
+              "type" => "district"
+            },
+            {
+              "name" => county_slug.capitalize,
+              "homepage_url" => "http://#{county_slug}.example.com",
+              "type" => "county"
+            }
+          ],
+        }
+
+        stub_request(:get, "#{LOCAL_LINKS_MANAGER_ENDPOINT}/api/local_authority")
+          .with(query: {authority_slug: district_slug})
+          .to_return(body: response.to_json, status: 200)
+      end
     end
   end
 end

--- a/test/local_links_manager_api_test.rb
+++ b/test/local_links_manager_api_test.rb
@@ -1,0 +1,129 @@
+require "test_helper"
+require "gds_api/local_links_manager"
+require "gds_api/test_helpers/local_links_manager"
+
+describe GdsApi::LocalLinksManager do
+  include GdsApi::TestHelpers::LocalLinksManager
+
+  before do
+    @base_api_url = Plek.current.find("local_links_manager")
+    @api = GdsApi::LocalLinksManager.new(@base_api_url)
+  end
+
+  describe "#link" do
+    describe "when making request for specific LGIL" do
+      it "returns the local authority and local interaction details if link present" do
+        local_links_manager_has_a_link(
+          authority_slug: "blackburn",
+          lgsl: 2,
+          lgil: 4,
+          url: "http://blackburn.example.com/abandoned-shopping-trolleys/report"
+        )
+
+        expected_response = {
+          "local_authority" => {
+            "name" => "Blackburn",
+              "snac" => "00AG",
+              "tier" => "unitary",
+              "homepage_url" => "http://blackburn.example.com",
+          },
+          "local_interaction" => {
+            "lgsl_code" => 2,
+            "lgil_code" => 4,
+            "url" => "http://blackburn.example.com/abandoned-shopping-trolleys/report",
+          }
+        }
+
+        response = @api.local_link("blackburn", 2, 4)
+        assert_equal expected_response, response.to_hash
+      end
+
+      it "returns the local authority details only if no link present" do
+        local_links_manager_has_no_link(
+          authority_slug: "blackburn",
+          lgsl: 2,
+          lgil: 4,
+        )
+
+        expected_response = {
+          "local_authority" => {
+            "name" => "Blackburn",
+              "snac" => "00AG",
+              "tier" => "unitary",
+              "homepage_url" => "http://blackburn.example.com",
+          },
+        }
+
+        response = @api.local_link("blackburn", 2, 4)
+        assert_equal expected_response, response.to_hash
+      end
+
+      it 'returns the local authority without a homepage url if no homepage link present' do
+        local_links_manager_has_no_link_and_no_homepage_url(
+          authority_slug: "blackburn",
+          lgsl: 2,
+          lgil: 4,
+        )
+
+        expected_response = {
+          "local_authority" => {
+            "name" => "Blackburn",
+              "snac" => "00AG",
+              "tier" => "unitary",
+              "homepage_url" => nil,
+          },
+        }
+
+        response = @api.local_link("blackburn", 2, 4)
+        assert_equal expected_response, response.to_hash
+      end
+    end
+
+    describe "when making request without LGIL" do
+      it "returns the local authority and local interaction details if link present" do
+        local_links_manager_has_a_fallback_link(
+          authority_slug: "blackburn",
+          lgsl: 2,
+          lgil: 3,
+          url: "http://blackburn.example.com/abandoned-shopping-trolleys/report"
+        )
+
+        expected_response = {
+          "local_authority" => {
+            "name" => "Blackburn",
+              "snac" => "00AG",
+              "tier" => "unitary",
+              "homepage_url" => "http://blackburn.example.com",
+          },
+          "local_interaction" => {
+            "lgsl_code" => 2,
+            "lgil_code" => 3,
+            "url" => "http://blackburn.example.com/abandoned-shopping-trolleys/report",
+          }
+        }
+
+        response = @api.local_link("blackburn", 2)
+        assert_equal expected_response, response.to_hash
+      end
+
+      it "returns the local authority and local interaction details if no link present" do
+        local_links_manager_has_no_fallback_link(
+          authority_slug: "blackburn",
+          lgsl: 2
+        )
+
+        expected_response = {
+          "local_authority" => {
+            "name" => "Blackburn",
+              "snac" => "00AG",
+              "tier" => "unitary",
+              "homepage_url" => "http://blackburn.example.com",
+          },
+        }
+
+        response = @api.local_link("blackburn", 2)
+        assert_equal expected_response, response.to_hash
+      end
+    end
+  end
+end


### PR DESCRIPTION
This demonstrates the JSON response that we expect back from LocalLinksManager to support the new Find my local council page.

Works with https://github.com/alphagov/frontend/pull/983

Mobbed with @emmabeynon @klssmith @brenetic 

=============================

Response from LocalLinksManager we expect for unitary:

```
"local_authorities" => [
  {
    "name" => authority_slug.capitalize,
    "homepage_url" => "http://#{authority_slug}.example.com",
    "type" => "unitary"
  }
]
```


For district and county:

```
"local_authorities" => [
  {
    "name" => district_slug.capitalize,
    "homepage_url" => "http://#{district_slug}.example.com",
    "type" => "district"
  },
  {
    "name" => county_slug.capitalize,
    "homepage_url" => "http://#{county_slug}.example.com",
    "type" => "county"
  }
]
```