### PR TITLE
Add option to always raise for 404s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Add option to always raise for 404 and 410.
+
 # 32.2.1
 
 * Fix LocalLinksManager test URLs

--- a/lib/gds-api-adapters.rb
+++ b/lib/gds-api-adapters.rb
@@ -1,2 +1,3 @@
 require 'gds_api/railtie' if defined?(Rails)
 require 'gds_api/exceptions'
+require 'gds_api/config'

--- a/lib/gds_api/config.rb
+++ b/lib/gds_api/config.rb
@@ -1,0 +1,17 @@
+module GdsApi
+  def self.configure
+    yield(config)
+  end
+
+  def self.config
+    @config ||= Config.new
+  end
+
+  class Config
+    # Always raise a `HTTPNotFound` exception when the server returns 404 or
+    # 410. This avoids nil-errors in your code and makes debugging easier.
+    #
+    # Currently defaults to false, but will be enabled by default in the future.
+    attr_accessor :always_raise_for_not_found
+  end
+end

--- a/lib/gds_api/config.rb
+++ b/lib/gds_api/config.rb
@@ -11,7 +11,11 @@ module GdsApi
     # Always raise a `HTTPNotFound` exception when the server returns 404 or
     # 410. This avoids nil-errors in your code and makes debugging easier.
     #
-    # Currently defaults to false, but will be enabled by default in the future.
+    # Currently defaults to false.
+    #
+    # This configuration allows some time to upgrade - you should opt-in to this
+    # behaviour now. We'll change this to default to true on October 1st, 2016
+    # and remove the option entirely on December 1st, 2016.
     attr_accessor :always_raise_for_not_found
   end
 end

--- a/lib/gds_api/json_client.rb
+++ b/lib/gds_api/json_client.rb
@@ -85,6 +85,16 @@ module GdsApi
         if GdsApi.config.always_raise_for_not_found
           send (method_name + "!"), url, *args, &block
         else
+          warn <<-doc
+            DEPRECATION NOTICE: You are making requests that will potentially
+            return nil. Please set `GdsApi.config.always_raise_for_not_found = true`
+            to make sure all responses with 404 or 410 raise an exception.
+
+            Raising exceptions will be the default behaviour from October 1st, 2016.
+
+            Called from: #{caller[2]}
+          doc
+
           ignoring_missing do
             send (method_name + "!"), url, *args, &block
           end

--- a/lib/gds_api/json_client.rb
+++ b/lib/gds_api/json_client.rb
@@ -82,8 +82,12 @@ module GdsApi
     [:get, :post, :put, :patch, :delete].each do |http_method|
       method_name = "#{http_method}_json"
       define_method method_name do |url, *args, &block|
-        ignoring_missing do
+        if GdsApi.config.always_raise_for_not_found
           send (method_name + "!"), url, *args, &block
+        else
+          ignoring_missing do
+            send (method_name + "!"), url, *args, &block
+          end
         end
       end
     end

--- a/test/content_store_test.rb
+++ b/test/content_store_test.rb
@@ -25,6 +25,22 @@ describe GdsApi::ContentStore do
 
       assert_nil @api.content_item("/non-existent")
     end
+
+    it "raises if the item doesn't exist and `always_raise_for_not_found` enabled" do
+      GdsApi.configure do |config|
+        config.always_raise_for_not_found = true
+      end
+
+      content_store_does_not_have_item("/non-existent")
+
+      assert_raises GdsApi::HTTPNotFound do
+        @api.content_item("/non-existent")
+      end
+
+      GdsApi.configure do |config|
+        config.always_raise_for_not_found = false
+      end
+    end
   end
 
   describe "#content_item!" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,6 +13,7 @@ require 'simplecov'
 require 'simplecov-rcov'
 require 'mocha/mini_test'
 require 'timecop'
+require 'gds-api-adapters'
 
 SimpleCov.start do
   add_filter "/test/"


### PR DESCRIPTION
This commit adds an option to ensure that the publishing-api and content-store clients raise a `GdsApi::NotFound` error when the server returns a 404 (Not Found) or 410 (Gone).

This was previously only the case for some methods. In some cases a pattern was to have a `bang!` method and a non-`bang!` method, so that the client could opt-in to this behaviour. Clients like Rummager use the `get_json!` method exclusively.

Reasons to change:

- This makes the behaviour consistent across the most used clients (publishing-api, content-store and rummager)
- Less duplication between `bang!` and `non_bang` methods.
- Makes it less likely that we inadvertently introduce nils, which generate errors that are hard to spot and to debug.

To keep backwards compatibility, we make this opt-in behaviour, providing a friendlier upgrade path.

Follow up from https://github.com/alphagov/gds-api-adapters/pull/526

## Usage notes

Add this to opt-in to the new behaviour:

```ruby
# config/initializers/gds_api_adapters.rb
GdsApi.configure do |config|
  config.always_raise_for_not_found = true
end
```