### PR TITLE
Add option to return hash from all requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 * Add option to always raise for 404 and 410.
+* Add option to make `GdsApi::Response` just behave like a hash, not an OpenStruct  
 
 # 32.2.1
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,22 @@ Example adapters for frequently used applications:
 - [Content Store](lib/gds_api/content_store.rb) ([docs](http://www.rubydoc.info/github/alphagov/gds-api-adapters/master/GdsApi/ContentStore), [test helper code](https://github.com/alphagov/gds-api-adapters/blob/master/lib/gds_api/test_helpers/content_store.rb), [test helper docs](http://www.rubydoc.info/github/alphagov/gds-api-adapters/master/GdsApi/TestHelpers/ContentStore))
 - [Rummager](lib/gds_api/rummager.rb) ([docs](http://www.rubydoc.info/github/alphagov/gds-api-adapters/master/GdsApi/Rummager), [test helper code](https://github.com/alphagov/gds-api-adapters/blob/master/lib/gds_api/test_helpers/rummager.rb), [test helper docs](http://www.rubydoc.info/github/alphagov/gds-api-adapters/master/GdsApi/TestHelpers/Rummager))
 
+## Configuration
+
+We're currently deprecating some behaviour of this gem. You can opt-in to the
+new behaviour now by adding configuration like this:
+
+```ruby
+# config/initializers/gds_api_adapters.rb
+GdsApi.configure do |config|
+  # Never return nil when a server responds with 404 or 410.
+  config.always_raise_for_not_found = true
+
+  # Return a hash, not an OpenStruct from a request.
+  config.hash_response_for_requests = true
+end
+```
+
 ## Logging
 
 Each HTTP request can be logged as JSON. Example:

--- a/lib/gds_api/config.rb
+++ b/lib/gds_api/config.rb
@@ -17,5 +17,13 @@ module GdsApi
     # behaviour now. We'll change this to default to true on October 1st, 2016
     # and remove the option entirely on December 1st, 2016.
     attr_accessor :always_raise_for_not_found
+
+    # Set to true to make `GdsApi::Response` behave like a simple hash, instead
+    # of an OpenStruct. This will prevent nil-errors.
+    #
+    # This configuration allows some time to upgrade - you should opt-in to this
+    # behaviour now. We'll change this to default to true on October 1st, 2016
+    # and remove the option entirely on December 1st, 2016.
+    attr_accessor :hash_response_for_requests
   end
 end

--- a/lib/gds_api/response.rb
+++ b/lib/gds_api/response.rb
@@ -75,14 +75,17 @@ module GdsApi
     end
 
     def to_ostruct
+      raise NoMethodError if GdsApi.config.hash_response_for_requests
       @ostruct ||= self.class.build_ostruct_recursively(to_hash)
     end
 
     def method_missing(method_sym, *arguments, &block)
+      super if GdsApi.config.hash_response_for_requests
       to_ostruct.public_send(method_sym, *arguments, &block)
     end
 
     def respond_to_missing?(method, include_private)
+      super if GdsApi.config.hash_response_for_requests
       to_ostruct.respond_to?(method, include_private)
     end
 

--- a/test/json_client_test.rb
+++ b/test/json_client_test.rb
@@ -608,6 +608,25 @@ class JsonClientTest < MiniTest::Spec
     assert_equal 2, response.a.b
   end
 
+  def test_cant_access_attributes_of_response_directly_if_hash_only
+    url = "http://some.endpoint/some.json"
+    payload = {a: 1}
+    stub_request(:put, url).with(body: payload.to_json).to_return(:body => '{"a":{"b":2}}', :status => 200)
+    response = @client.put_json(url, payload)
+
+    GdsApi.configure do |config|
+      config.hash_response_for_requests = true
+    end
+
+    assert_raises NoMethodError do
+      response.a.b
+    end
+
+    GdsApi.configure do |config|
+      config.hash_response_for_requests = false
+    end
+  end
+
   def test_accessing_non_existent_attribute_of_response_returns_nil
     url = "http://some.endpoint/some.json"
     stub_request(:put, url).to_return(:body => '{"a":1}', :status => 200)


### PR DESCRIPTION
The `hash_response_for_requests` config will configure `GdsApi::Response` so that it won't return OpenStruct objects, but will behave like a normal hash. This will prevent nil-errors.

Some background by @tuzz: https://trello.com/c/GHlFpkuw

Related: https://github.com/alphagov/gds-api-adapters/pull/544