### PR TITLE
Fix local-links-manager test helpers

### DIFF
--- a/lib/gds_api/test_helpers/local_links_manager.rb
+++ b/lib/gds_api/test_helpers/local_links_manager.rb
@@ -4,7 +4,7 @@ module GdsApi
   module TestHelpers
     module LocalLinksManager
 
-      LOCAL_LINKS_MANAGER_ENDPOINT = Plek.current.find('local_links_manager')
+      LOCAL_LINKS_MANAGER_ENDPOINT = Plek.current.find('local-links-manager')
 
       def local_links_manager_has_a_link(authority_slug:, lgsl:, lgil:, url:)
         response = {

--- a/test/local_links_manager_api_test.rb
+++ b/test/local_links_manager_api_test.rb
@@ -7,7 +7,7 @@ describe GdsApi::LocalLinksManager do
   include GdsApi::TestHelpers::LocalLinksManager
 
   before do
-    @base_api_url = Plek.current.find("local_links_manager")
+    @base_api_url = Plek.current.find("local-links-manager")
     @api = GdsApi::LocalLinksManager.new(@base_api_url)
   end
 


### PR DESCRIPTION
We used `local_links_manager` instead of `local-links-manager` when setting
up the test URLs with Plek.  This resulted in `http://locallinksmanager...`
rather than `http://local-links-manager...` type URLs.