### PR TITLE
Add api adaptor for local links manager local authority endpoint

### DIFF
--- a/lib/gds_api/local_links_manager.rb
+++ b/lib/gds_api/local_links_manager.rb
@@ -6,4 +6,9 @@ class GdsApi::LocalLinksManager < GdsApi::Base
     url += "&lgil=#{lgil}" if lgil
     get_json(url)
   end
+
+  def local_authority(authority_slug)
+    url = "#{endpoint}/api/local-authority?authority_slug=#{authority_slug}"
+    get_json(url)
+  end
 end

--- a/lib/gds_api/test_helpers/local_links_manager.rb
+++ b/lib/gds_api/test_helpers/local_links_manager.rb
@@ -108,6 +108,71 @@ module GdsApi
           .with(query: params)
           .to_return(body: {}.to_json, status: 404)
       end
+
+      def local_links_manager_has_a_local_authority(authority_slug)
+        response = {
+          "local_authorities" => [
+            {
+              "name" => authority_slug.capitalize,
+              "homepage_url" => "http://#{authority_slug}.example.com",
+              "tier" => "unitary"
+            }
+          ]
+        }
+
+        stub_request(:get, "#{LOCAL_LINKS_MANAGER_ENDPOINT}/api/local-authority")
+          .with(query: {authority_slug: authority_slug})
+          .to_return(body: response.to_json, status: 200)
+      end
+
+      def local_links_manager_has_a_district_and_county_local_authority(district_slug, county_slug)
+        response = {
+          "local_authorities" => [
+            {
+              "name" => district_slug.capitalize,
+              "homepage_url" => "http://#{district_slug}.example.com",
+              "tier" => "district"
+            },
+            {
+              "name" => county_slug.capitalize,
+              "homepage_url" => "http://#{county_slug}.example.com",
+              "tier" => "county"
+            }
+          ]
+        }
+
+        stub_request(:get, "#{LOCAL_LINKS_MANAGER_ENDPOINT}/api/local-authority")
+          .with(query: {authority_slug: district_slug})
+          .to_return(body: response.to_json, status: 200)
+      end
+
+      def local_links_manager_request_without_local_authority_slug
+        stub_request(:get, "#{LOCAL_LINKS_MANAGER_ENDPOINT}/api/local-authority")
+        .with(query: {authority_slug: ''})
+        .to_return(body: {}.to_json, status: 400)
+      end
+
+      def local_links_manager_does_not_have_an_authority(authority_slug)
+        stub_request(:get, "#{LOCAL_LINKS_MANAGER_ENDPOINT}/api/local-authority")
+        .with(query: {authority_slug: authority_slug})
+        .to_return(body: {}.to_json, status: 404)
+      end
+
+      def local_links_manager_has_a_local_authority_without_homepage(authority_slug)
+        response = {
+          "local_authorities" => [
+            {
+              "name" => authority_slug.capitalize,
+              "homepage_url" => "",
+              "tier" => "unitary"
+            }
+          ]
+        }
+
+        stub_request(:get, "#{LOCAL_LINKS_MANAGER_ENDPOINT}/api/local-authority")
+          .with(query: {authority_slug: authority_slug})
+          .to_return(body: response.to_json, status: 200)
+      end
     end
   end
 end

--- a/test/local_links_manager_api_test.rb
+++ b/test/local_links_manager_api_test.rb
@@ -1,7 +1,6 @@
 require "test_helper"
 require "gds_api/local_links_manager"
 require "gds_api/test_helpers/local_links_manager"
-require 'pry'
 
 describe GdsApi::LocalLinksManager do
   include GdsApi::TestHelpers::LocalLinksManager
@@ -164,6 +163,70 @@ describe GdsApi::LocalLinksManager do
         local_links_manager_does_not_have_required_objects("blackburn", 2, 9)
 
         response = @api.local_link("blackburn", 2, 9)
+        assert_equal nil, response
+      end
+    end
+  end
+
+  describe '#local_authority' do
+    describe 'when making a request for a local authority with a parent' do
+      it 'should return the local authority and its parent' do
+        local_links_manager_has_a_district_and_county_local_authority('blackburn', 'rochester')
+
+        expected_response = {
+          "local_authorities" => [
+            {
+              "name" => 'Blackburn',
+              "homepage_url" => "http://blackburn.example.com",
+              "tier" => "district"
+            },
+            {
+              "name" => 'Rochester',
+              "homepage_url" => "http://rochester.example.com",
+              "tier" => "county"
+            }
+          ]
+        }
+
+        response = @api.local_authority('blackburn')
+        assert_equal expected_response, response.to_hash
+      end
+    end
+
+    describe 'when making a request for a local authority without a parent' do
+      it 'should return the local authority' do
+        local_links_manager_has_a_local_authority('blackburn')
+
+        expected_response = {
+          "local_authorities" => [
+            {
+              "name" => 'Blackburn',
+              "homepage_url" => "http://blackburn.example.com",
+              "tier" => "unitary"
+            }
+          ]
+        }
+
+        response = @api.local_authority('blackburn')
+        assert_equal expected_response, response.to_hash
+      end
+    end
+
+    describe 'when making a request without the required parameters' do
+      it "raises HTTPClientError when authority_slug is missing" do
+        local_links_manager_request_without_local_authority_slug
+
+        assert_raises GdsApi::HTTPClientError do
+          @api.local_authority(nil)
+        end
+      end
+    end
+
+    describe 'when making a request with invalid required parameters' do
+      it "returns nil when authority_slug is invalid" do
+        local_links_manager_does_not_have_an_authority("hogwarts")
+
+        response = @api.local_authority("hogwarts")
         assert_equal nil, response
       end
     end


### PR DESCRIPTION
[Trello card](https://trello.com/c/R2rJjDbs/435-2-of-3-ensure-the-api-supports-find-my-local-council-3)

Mobbed with @h-lame, @emmabeynon 