### PR TITLE
Add "global export request" support api endpoint

### DIFF
--- a/lib/gds_api/support_api.rb
+++ b/lib/gds_api/support_api.rb
@@ -17,6 +17,10 @@ class GdsApi::SupportApi < GdsApi::Base
     post_json!("#{endpoint}/anonymous-feedback/export-requests", export_request: request_details)
   end
 
+  def create_global_export_request(request_details)
+    post_json!("#{endpoint}/anonymous-feedback/global-export-requests", global_export_request: request_details)
+  end
+
   def problem_report_daily_totals_for(date)
     date_string = date.strftime("%Y-%m-%d")
     get_json!("#{endpoint}/anonymous-feedback/problem-reports/#{date_string}/totals")

--- a/lib/gds_api/test_helpers/support_api.rb
+++ b/lib/gds_api/test_helpers/support_api.rb
@@ -30,6 +30,12 @@ module GdsApi
         post_stub.to_return(:status => 202)
       end
 
+      def stub_support_global_export_request_creation(request_details = nil)
+        post_stub = stub_http_request(:post, "#{SUPPORT_API_ENDPOINT}/anonymous-feedback/global-export-requests")
+        post_stub.with(:body => { global_export_request: request_details }) unless request_details.nil?
+        post_stub.to_return(:status => 202)
+      end
+
       def stub_problem_report_daily_totals_for(date, expected_results = nil)
         date_string = date.strftime("%Y-%m-%d")
         get_stub = stub_http_request(:get, "#{SUPPORT_API_ENDPOINT}/anonymous-feedback/problem-reports/#{date_string}/totals")

--- a/test/support_api_test.rb
+++ b/test/support_api_test.rb
@@ -112,6 +112,16 @@ describe GdsApi::SupportApi do
       assert_requested(stub_post)
     end
   end
+  
+  describe "POST /anonymous-feedback/global-export-requests" do
+    it "makes a POST request to the support API" do
+      params = {from_date: "1 June 2016", to_date: "8 June 2016", notification_email: "foo@example.com"}
+      stub_post = stub_support_global_export_request_creation(params)
+
+      @api.create_global_export_request(params)
+      assert_requested(stub_post)
+    end
+  end
 
   describe "GET /anonymous-feedback/export-requests/:id" do
     it "fetches the export request details from the API" do


### PR DESCRIPTION
The Support API now has a new endpoint to export global statistics about the volume of support requests.

TODO before merge:
- [x] Merge https://github.com/alphagov/support-api/pull/89
- [x] Deploy `support-api`

TODO after merge:
- [ ] Bump gem version (minor, proposed new version 33.1.0)
- [ ] Bump version in `support` app and raise PR for frontend functionality