### PR TITLE
Depend on RestClient 2.0.0

### DIFF
--- a/gds-api-adapters.gemspec
+++ b/gds-api-adapters.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'null_logger'
   s.add_dependency 'link_header'
   s.add_dependency 'lrucache', '~> 0.1.1'
-  s.add_dependency 'rest-client', '~> 1.8.0'
+  s.add_dependency 'rest-client', '~> 2.0'
   s.add_dependency 'rack-cache'
 
   s.add_development_dependency 'gem_publisher', '~> 1.5.0'

--- a/lib/gds_api/json_client.rb
+++ b/lib/gds_api/json_client.rb
@@ -272,12 +272,9 @@ module GdsApi
       logger.error loggable.merge(status: 'refused', error_message: e.message, error_class: e.class.name, end_time: Time.now.to_f).to_json
       raise GdsApi::EndpointNotFound.new("Could not connect to #{url}")
 
-    rescue RestClient::RequestTimeout => e
+    rescue RestClient::Exceptions::Timeout => e
       logger.error loggable.merge(status: 'timeout', error_message: e.message, error_class: e.class.name, end_time: Time.now.to_f).to_json
       raise GdsApi::TimedOutException.new
-
-    rescue RestClient::MaxRedirectsReached => e
-      raise GdsApi::TooManyRedirects
 
     rescue RestClient::Exception => e
       # Log the error here, since we have access to loggable, but raise the

--- a/test/json_client_test.rb
+++ b/test/json_client_test.rb
@@ -768,7 +768,10 @@ class JsonClientTest < MiniTest::Spec
   def test_client_can_post_multipart_responses
     url = "http://some.endpoint/some.json"
     stub_request(:post, url).
-      with(:body => %r{Content\-Disposition: form\-data; name="a"\r\n\r\n123}, :headers => {'Content-Type' => %r{multipart/form-data; boundary=\d+}}).
+      with(:body => %r{------RubyFormBoundary\w+\r\nContent-Disposition: form-data; name="a"\r\n\r\n123\r\n------RubyFormBoundary\w+--\r\n},
+           :headers => {
+             'Content-Type' => %r{multipart/form-data; boundary=----RubyFormBoundary\w+}
+           }).
       to_return(:body => '{"b": "1"}', :status => 200)
 
     response = @client.post_multipart("http://some.endpoint/some.json", {"a" => "123"})
@@ -797,7 +800,10 @@ class JsonClientTest < MiniTest::Spec
   def test_client_can_put_multipart_responses
     url = "http://some.endpoint/some.json"
     stub_request(:put, url).
-      with(:body => %r{Content\-Disposition: form\-data; name="a"\r\n\r\n123}, :headers => {'Content-Type' => %r{multipart/form-data; boundary=\d+}}).
+      with(:body => %r{------RubyFormBoundary\w+\r\nContent-Disposition: form-data; name="a"\r\n\r\n123\r\n------RubyFormBoundary\w+--\r\n},
+           :headers => {
+             'Content-Type' => %r{multipart/form-data; boundary=----RubyFormBoundary\w+}
+           }).
       to_return(:body => '{"b": "1"}', :status => 200)
 
     response = @client.put_multipart("http://some.endpoint/some.json", {"a" => "123"})

--- a/test/json_client_test.rb
+++ b/test/json_client_test.rb
@@ -477,7 +477,7 @@ class JsonClientTest < MiniTest::Spec
     failure = lambda { |request| flunk("Request called too many times") }
     stub_request(:get, url).to_return(redirect).times(11).then.to_return(failure)
 
-    assert_raises GdsApi::TooManyRedirects do
+    assert_raises GdsApi::HTTPErrorResponse do
       @client.get_json(url)
     end
   end
@@ -502,7 +502,7 @@ class JsonClientTest < MiniTest::Spec
     stub_request(:get, first_url).to_return(first_redirect).times(6).then.to_return(failure)
     stub_request(:get, second_url).to_return(second_redirect).times(6).then.to_return(failure)
 
-    assert_raises GdsApi::TooManyRedirects do
+    assert_raises GdsApi::HTTPErrorResponse do
       @client.get_json(first_url)
     end
   end


### PR DESCRIPTION
RestClient generates lots of warnings when this gem is required under Ruby 2.3.0:

```
[warning] The response contained in an RestClient::Exception is now a RestClient::Response instead of a Net::HTTPResponse, please update your code
```

Upgrading to RestClient 2 makes them go away.

cc/ alphagov/frontend#990 and alphagov/specialist-publisher-rebuild#706