### PR TITLE
Make get raw symmetrical with get json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Extend option to always raise for 404 and 410 to `get_raw`.
+
 # 33.2.0
 
 * Update RestClient version to 2.0.0

--- a/lib/gds_api/json_client.rb
+++ b/lib/gds_api/json_client.rb
@@ -69,8 +69,22 @@ module GdsApi
     end
 
     def get_raw(url)
-      ignoring_missing do
+      if GdsApi.config.always_raise_for_not_found
         get_raw!(url)
+      else
+        warn <<-doc
+          DEPRECATION NOTICE: You are making requests that will potentially
+          return nil. Please set `GdsApi.config.always_raise_for_not_found = true`
+          to make sure all responses with 404 or 410 raise an exception.
+
+          Raising exceptions will be the default behaviour from October 1st, 2016.
+
+          Called from: #{caller[2]}
+        doc
+
+        ignoring_missing do
+          get_raw!(url)
+        end
       end
     end
 

--- a/test/json_client_test.rb
+++ b/test/json_client_test.rb
@@ -442,6 +442,66 @@ class JsonClientTest < MiniTest::Spec
     end
   end
 
+  def test_get_raw_should_be_nil_if_404_returned_from_endpoint_and_always_raise_for_not_found_is_disabled
+    @old_always_raise = GdsApi.config.always_raise_for_not_found
+    GdsApi.configure do |config|
+      config.always_raise_for_not_found = false
+    end
+    url = "http://some.endpoint/some.json"
+    stub_request(:get, url).to_return(:body => "{}", :status => 404)
+    assert_nil @client.get_raw(url)
+  ensure
+    GdsApi.configure do |config|
+      config.always_raise_for_not_found = @old_always_raise
+    end
+  end
+
+  def test_get_raw_should_be_nil_if_410_returned_from_endpoint_and_always_raise_for_not_found_is_disabled
+    @old_always_raise = GdsApi.config.always_raise_for_not_found
+    GdsApi.configure do |config|
+      config.always_raise_for_not_found = false
+    end
+    url = "http://some.endpoint/some.json"
+    stub_request(:get, url).to_return(:body => "{}", :status => 410)
+    assert_nil @client.get_raw(url)
+  ensure
+    GdsApi.configure do |config|
+      config.always_raise_for_not_found = @old_always_raise
+    end
+  end
+
+  def test_get_raw_should_be_nil_if_404_returned_from_endpoint_and_always_raise_for_not_found_is_enabled
+    @old_always_raise = GdsApi.config.always_raise_for_not_found
+    GdsApi.configure do |config|
+      config.always_raise_for_not_found = true
+    end
+    url = "http://some.endpoint/some.json"
+    stub_request(:get, url).to_return(:body => "{}", :status => 404)
+    assert_raises GdsApi::HTTPNotFound do
+      @client.get_raw(url)
+    end
+  ensure
+    GdsApi.configure do |config|
+      config.always_raise_for_not_found = @old_always_raise
+    end
+  end
+
+  def test_get_raw_should_be_nil_if_410_returned_from_endpoint_and_always_raise_for_not_found_is_enabled
+    @old_always_raise = GdsApi.config.always_raise_for_not_found
+    GdsApi.configure do |config|
+      config.always_raise_for_not_found = true
+    end
+    url = "http://some.endpoint/some.json"
+    stub_request(:get, url).to_return(:body => "{}", :status => 410)
+    assert_raises GdsApi::HTTPGone do
+      @client.get_raw(url)
+    end
+  ensure
+    GdsApi.configure do |config|
+      config.always_raise_for_not_found = @old_always_raise
+    end
+  end
+
   def test_get_should_raise_error_if_non_404_non_410_error_code_returned_from_endpoint
     url = "http://some.endpoint/some.json"
     stub_request(:get, url).to_return(:body => "{}", :status => 500)

--- a/test/json_client_test.rb
+++ b/test/json_client_test.rb
@@ -382,16 +382,64 @@ class JsonClientTest < MiniTest::Spec
     end
   end
 
-  def test_get_should_be_nil_if_404_returned_from_endpoint
+  def test_get_should_be_nil_if_404_returned_from_endpoint_and_always_raise_for_not_found_is_disabled
+    @old_always_raise = GdsApi.config.always_raise_for_not_found
+    GdsApi.configure do |config|
+      config.always_raise_for_not_found = false
+    end
     url = "http://some.endpoint/some.json"
     stub_request(:get, url).to_return(:body => "{}", :status => 404)
     assert_nil @client.get_json(url)
+  ensure
+    GdsApi.configure do |config|
+      config.always_raise_for_not_found = @old_always_raise
+    end
   end
 
-  def test_get_should_be_nil_if_410_returned_from_endpoint
+  def test_get_should_be_nil_if_410_returned_from_endpoint_and_always_raise_for_not_found_is_disabled
+    @old_always_raise = GdsApi.config.always_raise_for_not_found
+    GdsApi.configure do |config|
+      config.always_raise_for_not_found = false
+    end
     url = "http://some.endpoint/some.json"
     stub_request(:get, url).to_return(:body => "{}", :status => 410)
     assert_nil @client.get_json(url)
+  ensure
+    GdsApi.configure do |config|
+      config.always_raise_for_not_found = @old_always_raise
+    end
+  end
+
+  def test_get_should_be_nil_if_404_returned_from_endpoint_and_always_raise_for_not_found_is_enabled
+    @old_always_raise = GdsApi.config.always_raise_for_not_found
+    GdsApi.configure do |config|
+      config.always_raise_for_not_found = true
+    end
+    url = "http://some.endpoint/some.json"
+    stub_request(:get, url).to_return(:body => "{}", :status => 404)
+    assert_raises GdsApi::HTTPNotFound do
+      @client.get_json(url)
+    end
+  ensure
+    GdsApi.configure do |config|
+      config.always_raise_for_not_found = @old_always_raise
+    end
+  end
+
+  def test_get_should_be_nil_if_410_returned_from_endpoint_and_always_raise_for_not_found_is_enabled
+    @old_always_raise = GdsApi.config.always_raise_for_not_found
+    GdsApi.configure do |config|
+      config.always_raise_for_not_found = true
+    end
+    url = "http://some.endpoint/some.json"
+    stub_request(:get, url).to_return(:body => "{}", :status => 410)
+    assert_raises GdsApi::HTTPGone do
+      @client.get_json(url)
+    end
+  ensure
+    GdsApi.configure do |config|
+      config.always_raise_for_not_found = @old_always_raise
+    end
   end
 
   def test_get_should_raise_error_if_non_404_non_410_error_code_returned_from_endpoint
@@ -402,7 +450,7 @@ class JsonClientTest < MiniTest::Spec
     end
   end
 
-  def test_get_should_raise_conflict_for_410
+  def test_get_should_raise_conflict_for_409
     url = "http://some.endpoint/some.json"
     stub_request(:delete, url).to_return(:body => "{}", :status => 409)
     assert_raises GdsApi::HTTPConflict do


### PR DESCRIPTION
`get_raw` didn't have the same toggle for `always_raise_for_not_found` that the other `<verb>_json` methods had, so we add it to make them behave the same.