### PR TITLE
More correct headers.

### DIFF
--- a/lib/gds_api/base.rb
+++ b/lib/gds_api/base.rb
@@ -22,7 +22,7 @@ class GdsApi::Base
                           :post_json, :post_json!,
                           :put_json, :put_json!,
                           :patch_json, :patch_json!,
-                          :delete_json, :delete_json!,
+                          :delete_json, :delete_json!, :delete_json_with_params!,
                           :get_raw, :get_raw!,
                           :put_multipart,
                           :post_multipart

--- a/lib/gds_api/need_api.rb
+++ b/lib/gds_api/need_api.rb
@@ -42,7 +42,8 @@ class GdsApi::NeedApi < GdsApi::Base
 
   def reopen(need_id, author)
     # author params: { "author" => { ... } }"
-    delete_json!("#{endpoint}/needs/#{CGI.escape(need_id.to_s)}/closed", author)
+    # NB: This should really be a POST
+    delete_json_with_params!("#{endpoint}/needs/#{CGI.escape(need_id.to_s)}/closed", author)
   end
 
   def create_note(note)

--- a/test/publishing_api_v2_test.rb
+++ b/test/publishing_api_v2_test.rb
@@ -1121,9 +1121,7 @@ describe GdsApi::PublishingApiV2 do
           method: :get,
           path: "/v2/linkables",
           query: "document_type=topic",
-          headers: {
-            "Content-Type" => "application/json",
-          },
+          headers: {},
         )
         .will_respond_with(
           status: 200,
@@ -1150,9 +1148,7 @@ describe GdsApi::PublishingApiV2 do
           method: :get,
           path: "/v2/content",
           query: "content_format=topic&fields%5B%5D=title&fields%5B%5D=base_path",
-          headers: {
-            "Content-Type" => "application/json",
-          },
+          headers: {},
         )
         .will_respond_with(
           status: 200,
@@ -1196,9 +1192,7 @@ describe GdsApi::PublishingApiV2 do
           method: :get,
           path: "/v2/content",
           query: "content_format=topic&fields%5B%5D=content_id&fields%5B%5D=locale",
-          headers: {
-            "Content-Type" => "application/json",
-          },
+          headers: {},
         )
         .will_respond_with(
           status: 200,
@@ -1240,9 +1234,7 @@ describe GdsApi::PublishingApiV2 do
           method: :get,
           path: "/v2/content",
           query: "content_format=topic&fields%5B%5D=content_id&fields%5B%5D=locale&locale=fr",
-          headers: {
-            "Content-Type" => "application/json",
-          },
+          headers: {},
         )
         .will_respond_with(
           status: 200,
@@ -1284,9 +1276,7 @@ describe GdsApi::PublishingApiV2 do
           method: :get,
           path: "/v2/content",
           query: "content_format=topic&fields%5B%5D=content_id&fields%5B%5D=locale&locale=all",
-          headers: {
-            "Content-Type" => "application/json",
-          },
+          headers: {},
         )
         .will_respond_with(
           status: 200,
@@ -1333,9 +1323,7 @@ describe GdsApi::PublishingApiV2 do
           method: :get,
           path: "/v2/content",
           query: "content_format=topic&fields%5B%5D=content_id&fields%5B%5D=details",
-          headers: {
-            "Content-Type" => "application/json",
-          },
+          headers: {},
         )
         .will_respond_with(
           status: 200,
@@ -1509,9 +1497,7 @@ describe GdsApi::PublishingApiV2 do
             method: :get,
             path: "/v2/linked/" + @linked_content_item['content_id'],
             query: "fields%5B%5D=content_id&fields%5B%5D=base_path&link_type=topic",
-            headers: {
-              "Content-Type" => "application/json",
-            },
+            headers: {},
           )
           .will_respond_with(
             status: 200,


### PR DESCRIPTION
According to HTTP RFC 2616, GET and DELETE request
bodies should be ignored, so we shouldn't be using
them.

Sending a Content-Type header with a bodyless
request makes no sense and causes some servers to
fail as they try to JSON parse an empty string
(which is invalid).

This change removes the Content-Type header from
GET and DELETE requests and deprecates sending
a body with a DELETE request (currently only used
by the need API where a POST would be more appropriate).