### PR TITLE
Require `config` in JsonClient

### DIFF
--- a/lib/gds_api/json_client.rb
+++ b/lib/gds_api/json_client.rb
@@ -1,3 +1,4 @@
+require_relative 'config'
 require_relative 'response'
 require_relative 'exceptions'
 require_relative 'version'


### PR DESCRIPTION
This class calls `GdsApi.config` which doesn't seem to be required automatically.