### PR TITLE
Change all instances of unified_search to search

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 ## Git workflow ##
 
-- Pull requests must contain a succint, clear summary of what the user need is driving this feature change.
+- Pull requests must contain a succinct, clear summary of what the user need is driving this feature change.
 - Follow our [Git styleguide](https://github.com/alphagov/styleguides/blob/master/git.md)
 - Make a feature branch
 - Ensure your branch contains logical atomic commits before sending a pull request - follow our [Git styleguide](https://github.com/alphagov/styleguides/blob/master/git.md)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Example usage:
 ```ruby
 require 'gds_api/rummager'
 rummager = GdsApi::Rummager.new(Plek.new.find('rummager'))
-results = rummager.unified_search(q: "taxes")
+results = rummager.search(q: "taxes")
 ```
 
 Example adapters for frequently used applications:

--- a/lib/gds_api/test_helpers/rummager.rb
+++ b/lib/gds_api/test_helpers/rummager.rb
@@ -94,27 +94,27 @@ module GdsApi
       end
 
       def rummager_has_no_policies_for_any_type
-        stub_request(:get, %r{/unified_search.json})
+        stub_request(:get, %r{/search.json})
           .to_return(body: no_search_results_found)
       end
 
       def rummager_has_policies_for_every_type(options = {})
         if count = options[:count]
-          stub_request(:get, %r{/unified_search.json.*count=#{count}.*})
+          stub_request(:get, %r{/search.json.*count=#{count}.*})
             .to_return(body: first_n_results(new_policies_results, n: count))
         else
-          stub_request(:get, %r{/unified_search.json})
+          stub_request(:get, %r{/search.json})
             .to_return(body: new_policies_results)
         end
       end
 
     private
       def stub_request_for(result_set)
-        stub_request(:get, /example.com\/unified_search/).to_return(body: result_set)
+        stub_request(:get, /example.com\/search/).to_return(body: result_set)
       end
 
       def run_example_query
-        client.unified_search(example_query)
+        client.search(example_query)
       end
 
       def search_results_found

--- a/test/rummager_test.rb
+++ b/test/rummager_test.rb
@@ -5,6 +5,7 @@ describe GdsApi::Rummager do
   before(:each) do
     stub_request(:get, /example.com\/advanced_search/).to_return(body: "[]")
     stub_request(:get, /example.com\/unified_search/).to_return(body: "[]")
+    stub_request(:get, /example.com\/search/).to_return(body: "[]")
   end
 
   # tests for #advanced_search
@@ -122,6 +123,74 @@ describe GdsApi::Rummager do
 
   it "#unified_search should issue a request for all the params supplied" do
     GdsApi::Rummager.new("http://example.com").unified_search(
+      q: "query & stuff",
+      filter_topics: ["1", "2"],
+      order: "-public_timestamp",
+    )
+
+    assert_requested :get, /q=query%20%26%20stuff/
+    assert_requested :get, /filter_topics\[\]=1&filter_topics\[\]=2/
+    assert_requested :get, /order=-public_timestamp/
+  end
+
+  # tests for search
+
+  it "#search should raise an exception if the service at the search URI returns a 500" do
+    stub_request(:get, /example.com\/search.json/).to_return(status: [500, "Internal Server Error"])
+    assert_raises(GdsApi::HTTPServerError) do
+      GdsApi::Rummager.new("http://example.com").search(q: "query")
+    end
+  end
+
+  it "#search should raise an exception if the service at the search URI returns a 404" do
+    stub_request(:get, /example.com\/search/).to_return(status: [404, "Not Found"])
+    assert_raises(GdsApi::HTTPNotFound) do
+      GdsApi::Rummager.new("http://example.com").search(q: "query")
+    end
+  end
+
+  it "#search should raise an exception if the service at the unified search URI returns a 400" do
+    stub_request(:get, /example.com\/search/).to_return(
+      status: [400, "Bad Request"],
+      body: %q("error":"Filtering by \"coffee\" is not allowed"),
+    )
+    assert_raises(GdsApi::HTTPClientError) do
+      GdsApi::Rummager.new("http://example.com").search(q: "query", filter_coffee: "tea")
+    end
+  end
+
+  it "#search should raise an exception if the service at the unified search URI returns a 422" do
+    stub_request(:get, /example.com\/search/).to_return(
+      status: [422, "Bad Request"],
+      body: %q("error":"Filtering by \"coffee\" is not allowed"),
+    )
+    assert_raises(GdsApi::HTTPClientError) do
+      GdsApi::Rummager.new("http://example.com").search(q: "query", filter_coffee: "tea")
+    end
+  end
+
+  it "#search should raise an exception if the service at the search URI times out" do
+    stub_request(:get, /example.com\/search/).to_timeout
+    assert_raises(GdsApi::TimedOutException) do
+      GdsApi::Rummager.new("http://example.com").search(q: "query")
+    end
+  end
+
+  it "#search should return the search deserialized from json" do
+    search_results = [{"title" => "document-title"}]
+    stub_request(:get, /example.com\/search/).to_return(body: search_results.to_json)
+    results = GdsApi::Rummager.new("http://example.com").search(q: "query")
+    assert_equal search_results, results.to_hash
+  end
+
+  it "#search should request the search results in JSON format" do
+    GdsApi::Rummager.new("http://example.com").search(q: "query")
+
+    assert_requested :get, /.*/, headers: {"Accept" => "application/json"}
+  end
+
+  it "#search should issue a request for all the params supplied" do
+    GdsApi::Rummager.new("http://example.com").search(
       q: "query & stuff",
       filter_topics: ["1", "2"],
       order: "-public_timestamp",


### PR DESCRIPTION
This commit deprecates `unified_search` for rummager and replaces it with `search`. This provides consistency between the internal and external APIs in terms of naming.

See https://github.com/alphagov/rummager/pull/694 for the equivalent changes to rummager.

Trello: https://trello.com/c/cj8UX2jX