### PR TITLE
Release version 34.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+# 34.1.0
+
+* Deprecate `GdsApi::Rummager#unified_search`. The `/unified_search` endpoint
+  has been deprecated in rummager in favor of `/search`.
+
+# 34.0.0
+
+* De-deprecate `delete_document` helpers, because the endpoint is still useful.
+* Allow `/document/` helpers to take an optional index parameter, mirroring the API.
+* Allow all assert methods to pass through additional webmock options
+* Change `stub_any_rummager_post` to behave the same as
+  `stub_any_rummager_post_with_queueing_enabled`: rummager always returns 202 and
+  so should our stubs.
+* Deprecate `stub_any_rummager_post_with_queueing_enabled` as it is now redundant.
+
 # 33.2.2
 
 * Fix JsonClient not explicitly requiring the config

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '34.0.0'
+  VERSION = '34.1.0'
 end


### PR DESCRIPTION
This release deprecates `unified_search` for rummager and replaces it with `search`. This provides consistency between the internal and external APIs in terms of naming.

See https://github.com/alphagov/rummager/pull/694 for the equivalent changes to rummager.

Trello: https://trello.com/c/cj8UX2jX

Also adds changelog information for release 34.0.0 since they were missing.