### PR TITLE
Add test_helper for gone content item

### DIFF
--- a/lib/gds_api/test_helpers/content_item_helpers.rb
+++ b/lib/gds_api/test_helpers/content_item_helpers.rb
@@ -18,6 +18,19 @@ module GdsApi
         }
       end
 
+      def gone_content_item_for_base_path(base_path)
+        {
+          "title" => nil,
+          "description" => nil,
+          "format" => "gone",
+          "schema_name" => "gone",
+          "public_updated_at" => nil,
+          "base_path" => base_path,
+          "withdrawn_notice" => {},
+          "details" => {}
+        }
+      end
+
       def titleize_base_path(base_path, options = {})
         if options[:title_case]
           base_path.gsub("-", " ").gsub(/\b./) {|m| m.upcase }

--- a/lib/gds_api/test_helpers/content_store.rb
+++ b/lib/gds_api/test_helpers/content_store.rb
@@ -43,6 +43,41 @@ module GdsApi
         stub_request(:get, url).to_return(status: 404, headers: {})
       end
 
+      # Content store has gone item
+      #
+      # Stubs a content item in the content store to respond with 410 HTTP Status Code and response body with 'format' set to 'gone'.
+      #
+      # @param base_path [String]
+      # @param body [Hash]
+      # @param options [Hash]
+      # @option options [String] draft Will point to the draft content store if set to true
+      #
+      # @example
+      #
+      #   content_store.content_store_has_gone_item('/sample-slug')
+      #
+      #   # Will return HTTP Status Code 410 and the following response body:
+      #   {
+      #     "title" => nil,
+      #     "description" => nil,
+      #     "format" => "gone",
+      #     "schema_name" => "gone",
+      #     "public_updated_at" => nil,
+      #     "base_path" => "/sample-slug",
+      #     "withdrawn_notice" => {},
+      #     "details" => {}
+      #   }
+      def content_store_has_gone_item(base_path, body = gone_content_item_for_base_path(base_path), options = {})
+        url = content_store_endpoint(options[:draft]) + "/content" + base_path
+        body = body.to_json unless body.is_a?(String)
+
+        stub_request(:get, url).to_return(
+          status: 410,
+          body: body,
+          headers: {}
+        )
+      end
+
       def content_store_isnt_available
         stub_request(:any, /#{content_store_endpoint}\/.*/).to_return(:status => 503)
       end

--- a/test/content_store_test.rb
+++ b/test/content_store_test.rb
@@ -41,6 +41,28 @@ describe GdsApi::ContentStore do
         config.always_raise_for_not_found = false
       end
     end
+
+    it "returns nil if the item is gone" do
+      content_store_has_gone_item("/it-is-gone")
+
+      assert_nil @api.content_item("/it-is-gone")
+    end
+
+    it "raises if the item is gone and `always_raise_for_not_found` enabled" do
+      GdsApi.configure do |config|
+        config.always_raise_for_not_found = true
+      end
+
+      content_store_has_gone_item("/it-is-gone")
+
+      assert_raises GdsApi::HTTPGone do
+        @api.content_item("/it-is-gone")
+      end
+
+      GdsApi.configure do |config|
+        config.always_raise_for_not_found = false
+      end
+    end
   end
 
   describe "#content_item!" do


### PR DESCRIPTION
Now that 'not found' and 'gone' content items raise exceptions (see https://github.com/alphagov/gds-api-adapters/commit/7e17dd8ae2bc41bf38671f7a68776440a51b0bc8), it is useful to have a test helper for gone items to mimic the correct response.