### PR TITLE
Release version 35.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 35.0.0
+
+* Remove methods for `with_tag` endpoint for content api. These methods are not
+  used by any client. The endpoint is scheduled to be removed soon.
+* Add test helper for Gone items in content store
+
 # 34.1.0
 
 * Deprecate `GdsApi::Rummager#unified_search`. The `/unified_search` endpoint

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '34.1.0'
+  VERSION = '35.0.0'
 end


### PR DESCRIPTION
This release removes methods for `with_tag` endpoint for content api and adds a test helper for Gone items in the content store.