### PR TITLE
Return pagination results from publishing_api_has_content

### DIFF
--- a/lib/gds_api/test_helpers/publishing_api_v2.rb
+++ b/lib/gds_api/test_helpers/publishing_api_v2.rb
@@ -169,7 +169,20 @@ module GdsApi
       #)
       def publishing_api_has_content(items, params = {})
         url = PUBLISHING_API_V2_ENDPOINT + "/content"
-        stub_request(:get, url).with(:query => params).to_return(status: 200, body: { results: items }.to_json, headers: {})
+        per_page = params.fetch(:per_page, 50)
+        page = params.fetch(:page, 1)
+        number_of_pages = items.count < per_page ? 1 : items.count / per_page
+
+        body = {
+          results: items,
+          total: items.count,
+          pages: number_of_pages,
+          current_page: page
+        }
+
+        stub_request(:get, url)
+          .with(query: params)
+          .to_return(status: 200, body: body.to_json, headers: {})
       end
 
       # This method has been refactored into publishing_api_has_content (above)

--- a/test/test_helpers/publishing_api_v2_test.rb
+++ b/test/test_helpers/publishing_api_v2_test.rb
@@ -25,6 +25,47 @@ describe GdsApi::TestHelpers::PublishingApiV2 do
 
       assert_equal([{ "content_id" => "2878337b-bed9-4e7f-85b6-10ed2cbcd504" }], response)
     end
+
+    it 'allows params' do
+      publishing_api_has_content(
+        [{
+          "content_id" => "2878337b-bed9-4e7f-85b6-10ed2cbcd504"
+        }],
+        document_type: 'document_collection',
+        query: 'query',
+      )
+
+      response = publishing_api.get_content_items(
+        document_type: 'document_collection',
+        query: 'query'
+      )['results']
+
+      assert_equal(
+        [{ "content_id" => "2878337b-bed9-4e7f-85b6-10ed2cbcd504" }],
+        response
+      )
+    end
+
+    it 'returns pagination results' do
+      publishing_api_has_content(
+        [
+          { "content_id" => "2878337b-bed9-4e7f-85b6-10ed2cbcd504" },
+          { "content_id" => "2878337b-bed9-4e7f-85b6-10ed2cbcd505" },
+          { "content_id" => "2878337b-bed9-4e7f-85b6-10ed2cbcd506" },
+          { "content_id" => "2878337b-bed9-4e7f-85b6-10ed2cbcd507" },
+        ],
+        {
+          page: 1,
+          per_page: 2
+        }
+      )
+
+      response = publishing_api.get_content_items({ page: 1, per_page: 2 })
+
+      assert_equal(response['total'], 4)
+      assert_equal(response['pages'], 2)
+      assert_equal(response['current_page'], 1)
+    end
   end
 
   describe "#publishing_api_has_expanded_links" do


### PR DESCRIPTION
A request to `/v2/content` returns pagination information besides the results.
The keys available on the response are:

```
["total", "pages", "current_page", "links", "results"]
```

This commit adds pagination-specific information to the response so we closely
match what a production request would look like.

The values are dummy for now, but we could potentially build logic to return
more appropriate results in the future in case that's important.

This information will be useful in content-tagger as we are interested in
pagination information.