### PR TITLE
Change Publishing API's port in tests

### DIFF
--- a/test/publishing_api_test.rb
+++ b/test/publishing_api_test.rb
@@ -8,7 +8,7 @@ describe GdsApi::PublishingApi do
 
   before do
     @base_api_url = Plek.current.find("publishing-api")
-    @api_client = GdsApi::PublishingApi.new('http://localhost:3093')
+    @api_client = GdsApi::PublishingApi.new(publishing_api_host)
   end
 
   describe "#put_content_item" do

--- a/test/publishing_api_v2/get_expanded_links_test.rb
+++ b/test/publishing_api_v2/get_expanded_links_test.rb
@@ -6,7 +6,7 @@ describe GdsApi::PublishingApiV2 do
   include PactTest
 
   before do
-    @api_client = GdsApi::PublishingApiV2.new('http://localhost:3093')
+    @api_client = GdsApi::PublishingApiV2.new(publishing_api_host)
     @content_id = "bed722e6-db68-43e5-9079-063f623335a7"
   end
 

--- a/test/publishing_api_v2/get_links_test.rb
+++ b/test/publishing_api_v2/get_links_test.rb
@@ -6,7 +6,7 @@ describe GdsApi::PublishingApiV2 do
   include PactTest
 
   before do
-    @api_client = GdsApi::PublishingApiV2.new('http://localhost:3093')
+    @api_client = GdsApi::PublishingApiV2.new(publishing_api_host)
     @content_id = "bed722e6-db68-43e5-9079-063f623335a7"
   end
 

--- a/test/publishing_api_v2/lookup_test.rb
+++ b/test/publishing_api_v2/lookup_test.rb
@@ -6,7 +6,7 @@ describe GdsApi::PublishingApiV2 do
   include PactTest
 
   before do
-    @api_client = GdsApi::PublishingApiV2.new('http://localhost:3093')
+    @api_client = GdsApi::PublishingApiV2.new(publishing_api_host)
   end
 
   describe "#lookup_content_id" do

--- a/test/publishing_api_v2_test.rb
+++ b/test/publishing_api_v2_test.rb
@@ -29,7 +29,7 @@ describe GdsApi::PublishingApiV2 do
     @bearer_token = "example-bearer-token"
     @base_api_url = Plek.current.find("publishing-api")
     @api_client = GdsApi::PublishingApiV2.new(
-      "http://localhost:3093",
+      publishing_api_host,
       bearer_token: @bearer_token,
     )
 

--- a/test/test_helpers/pact_helper.rb
+++ b/test/test_helpers/pact_helper.rb
@@ -1,7 +1,13 @@
+PUBLISHING_API_PORT=3001
+
+def publishing_api_host
+  "http://localhost:#{PUBLISHING_API_PORT}"
+end
+
 Pact.service_consumer "GDS API Adapters" do
   has_pact_with "Publishing API" do
     mock_service :publishing_api do
-      port 3093
+      port PUBLISHING_API_PORT
     end
   end
 end


### PR DESCRIPTION
We were using port `3093` in the tests for a mocked version of the Publishing
API. That is also the port used in development mode. This means that if we run the
publishing api in development mode and run the gds-api-adapters' tests, we get a
bunch of failures, as the code hits the actual Publishing API endpoints.

This commit changes the port of the test Publishing API and makes it easier to
change it later on by using a method to return the localhost URL of the
publishing API.