### PR TITLE
Remove unified_search adapter

### DIFF
--- a/lib/gds_api/rummager.rb
+++ b/lib/gds_api/rummager.rb
@@ -6,17 +6,6 @@ module GdsApi
 
     # Perform a search.
     #
-    # @deprecated Alias for `#search`.
-    # @param query [Hash] A valid search query. See Rummager documentation for options.
-    #
-    # @see https://github.com/alphagov/rummager/blob/master/docs/unified-search-api.md
-    def unified_search(args)
-      request_url = "#{base_url}/unified_search.json?#{Rack::Utils.build_nested_query(args)}"
-      get_json!(request_url)
-    end
-
-    # Perform a search.
-    #
     # @param query [Hash] A valid search query. See Rummager documentation for options.
     #
     # @see https://github.com/alphagov/rummager/blob/master/docs/unified-search-api.md

--- a/test/rummager_test.rb
+++ b/test/rummager_test.rb
@@ -4,7 +4,6 @@ require "gds_api/rummager"
 describe GdsApi::Rummager do
   before(:each) do
     stub_request(:get, /example.com\/advanced_search/).to_return(body: "[]")
-    stub_request(:get, /example.com\/unified_search/).to_return(body: "[]")
     stub_request(:get, /example.com\/search/).to_return(body: "[]")
   end
 
@@ -65,74 +64,6 @@ describe GdsApi::Rummager do
     assert_requested :get, /order\[public_timestamp\]=desc/
   end
 
-  # tests for unified search
-
-  it "#unified_search should raise an exception if the service at the search URI returns a 500" do
-    stub_request(:get, /example.com\/unified_search.json/).to_return(status: [500, "Internal Server Error"])
-    assert_raises(GdsApi::HTTPServerError) do
-      GdsApi::Rummager.new("http://example.com").unified_search(q: "query")
-    end
-  end
-
-  it "#unified_search should raise an exception if the service at the search URI returns a 404" do
-    stub_request(:get, /example.com\/unified_search/).to_return(status: [404, "Not Found"])
-    assert_raises(GdsApi::HTTPNotFound) do
-      GdsApi::Rummager.new("http://example.com").unified_search(q: "query")
-    end
-  end
-
-  it "#unified_search should raise an exception if the service at the unified search URI returns a 400" do
-    stub_request(:get, /example.com\/unified_search/).to_return(
-      status: [400, "Bad Request"],
-      body: %q("error":"Filtering by \"coffee\" is not allowed"),
-    )
-    assert_raises(GdsApi::HTTPClientError) do
-      GdsApi::Rummager.new("http://example.com").unified_search(q: "query", filter_coffee: "tea")
-    end
-  end
-
-  it "#unified_search should raise an exception if the service at the unified search URI returns a 422" do
-    stub_request(:get, /example.com\/unified_search/).to_return(
-      status: [422, "Bad Request"],
-      body: %q("error":"Filtering by \"coffee\" is not allowed"),
-    )
-    assert_raises(GdsApi::HTTPClientError) do
-      GdsApi::Rummager.new("http://example.com").unified_search(q: "query", filter_coffee: "tea")
-    end
-  end
-
-  it "#unified_search should raise an exception if the service at the search URI times out" do
-    stub_request(:get, /example.com\/unified_search/).to_timeout
-    assert_raises(GdsApi::TimedOutException) do
-      GdsApi::Rummager.new("http://example.com").unified_search(q: "query")
-    end
-  end
-
-  it "#unified_search should return the search deserialized from json" do
-    search_results = [{"title" => "document-title"}]
-    stub_request(:get, /example.com\/unified_search/).to_return(body: search_results.to_json)
-    results = GdsApi::Rummager.new("http://example.com").unified_search(q: "query")
-    assert_equal search_results, results.to_hash
-  end
-
-  it "#unified_search should request the search results in JSON format" do
-    GdsApi::Rummager.new("http://example.com").unified_search(q: "query")
-
-    assert_requested :get, /.*/, headers: {"Accept" => "application/json"}
-  end
-
-  it "#unified_search should issue a request for all the params supplied" do
-    GdsApi::Rummager.new("http://example.com").unified_search(
-      q: "query & stuff",
-      filter_topics: ["1", "2"],
-      order: "-public_timestamp",
-    )
-
-    assert_requested :get, /q=query%20%26%20stuff/
-    assert_requested :get, /filter_topics\[\]=1&filter_topics\[\]=2/
-    assert_requested :get, /order=-public_timestamp/
-  end
-
   # tests for search
 
   it "#search should raise an exception if the service at the search URI returns a 500" do
@@ -149,7 +80,7 @@ describe GdsApi::Rummager do
     end
   end
 
-  it "#search should raise an exception if the service at the unified search URI returns a 400" do
+  it "#search should raise an exception if the service at the search URI returns a 400" do
     stub_request(:get, /example.com\/search/).to_return(
       status: [400, "Bad Request"],
       body: %q("error":"Filtering by \"coffee\" is not allowed"),
@@ -159,7 +90,7 @@ describe GdsApi::Rummager do
     end
   end
 
-  it "#search should raise an exception if the service at the unified search URI returns a 422" do
+  it "#search should raise an exception if the service at the search URI returns a 422" do
     stub_request(:get, /example.com\/search/).to_return(
       status: [422, "Bad Request"],
       body: %q("error":"Filtering by \"coffee\" is not allowed"),


### PR DESCRIPTION
This has now been replaced by `search`

![screen shot 2016-09-09 at 11 29 28](https://cloud.githubusercontent.com/assets/87579/18384303/b5cc2078-7681-11e6-8d31-8161db5e8ece.png)

https://trello.com/c/cj8UX2jX/93-alias-search-json-to-unified-search-json-in-rummager-so-internal-external-apis-work-the-same