### PR TITLE
Support api review spam

### DIFF
--- a/lib/gds_api/support_api.rb
+++ b/lib/gds_api/support_api.rb
@@ -47,4 +47,50 @@ class GdsApi::SupportApi < GdsApi::Base
   def feedback_export_request(id)
     get_json!("#{endpoint}/anonymous-feedback/export-requests/#{id}")
   end
+
+  # Fetch a list of problem reports.
+  #
+  # Makes a +GET+ request.
+  #
+  # If no options are supplied, the first page of unreviewed feedback is returned.
+  #
+  # The results are ordered date descending.
+  #
+  # # ==== Options [+Hash+]
+  #
+  # * +:from_date+ - from date for list of reports.
+  # * +:to_date+ - to date for list of reports.
+  # * +:page+ - page number for reports.
+  # * +:include_reviewed+ - if true, includes reviewed reports in the list.
+  #
+  # # @example
+  #
+  #  support_api.problem_reports({ from_date: '2016-12-12', to_date: '2016-12-13', page: 1, include_reviewed: true }).to_h
+  #
+  #  #=> {
+  #    results: [
+  #      {
+  #        id: 1,
+  #        type: "problem-report",
+  #        what_wrong: "Yeti",
+  #        what_doing: "Skiing",
+  #        url: "http://www.dev.gov.uk/skiing",
+  #        referrer: "https://www.gov.uk/browse",
+  #        user_agent: "Safari",
+  #        path: "/skiing",
+  #        marked_as_spam: false,
+  #        reviewed: true,
+  #        created_at: "2015-01-01T16:00:00.000Z"
+  #      },
+  #      ...
+  #    ]
+  #    total_count: 1000,
+  #    current_page: 1,
+  #    pages: 50,
+  #    page_size: 50
+  #  }
+  def problem_reports(options = {})
+    uri = "#{endpoint}/anonymous-feedback/problem-reports" + query_string(options)
+    get_json!(uri)
+  end
 end

--- a/lib/gds_api/support_api.rb
+++ b/lib/gds_api/support_api.rb
@@ -93,4 +93,29 @@ class GdsApi::SupportApi < GdsApi::Base
     uri = "#{endpoint}/anonymous-feedback/problem-reports" + query_string(options)
     get_json!(uri)
   end
+
+  # Update multiple problem reports as reviewed for spam.
+  #
+  # Makes a +PUT+ request.
+  #
+  # @param request_details [Hash] Containing keys that match IDs of Problem
+  #                               Reports mapped to a boolean value - true if
+  #                               that report is to be marked as spam, or false otherwise.
+  #
+  # # @example
+  #
+  #  support_api.mark_reviewed_for_spam({ "1" => false, "2" => true }).to_h
+  #
+  # #=> { "success" => true } (status: 200)
+  #
+  # # @example
+  #
+  # Where there is no problem report with ID of 1.
+  #
+  #  support_api.mark_reviewed_for_spam({ "1" => true }).to_h
+  #
+  # #=> { "success" =>  false} (status: 400)
+  def mark_reviewed_for_spam(request_details)
+    put_json!("#{endpoint}/anonymous-feedback/problem-reports/mark-reviewed-for-spam", { reviewed_problem_report_ids: request_details })
+  end
 end

--- a/lib/gds_api/test_helpers/support_api.rb
+++ b/lib/gds_api/test_helpers/support_api.rb
@@ -44,6 +44,12 @@ module GdsApi
         get_stub.to_return(response)
       end
 
+      def stub_support_problem_reports(params, response_body = {})
+        stub_http_request(:get, "#{SUPPORT_API_ENDPOINT}/anonymous-feedback/problem-reports").
+          with(query: params).
+          to_return(status: 200, body: response_body.to_json)
+      end
+
       def support_api_isnt_available
         stub_request(:post, /#{SUPPORT_API_ENDPOINT}\/.*/).to_return(:status => 503)
       end

--- a/lib/gds_api/test_helpers/support_api.rb
+++ b/lib/gds_api/test_helpers/support_api.rb
@@ -50,6 +50,12 @@ module GdsApi
           to_return(status: 200, body: response_body.to_json)
       end
 
+      def stub_support_mark_reviewed_for_spam(request_details = nil, response_body = {})
+        post_stub = stub_http_request(:put, "#{SUPPORT_API_ENDPOINT}/anonymous-feedback/problem-reports/mark-reviewed-for-spam")
+        post_stub.with(:body => { reviewed_problem_report_ids: request_details}) unless request_details.nil?
+        post_stub.to_return(status: 200, body: response_body.to_json)
+      end
+
       def support_api_isnt_available
         stub_request(:post, /#{SUPPORT_API_ENDPOINT}\/.*/).to_return(:status => 503)
       end

--- a/test/support_api_test.rb
+++ b/test/support_api_test.rb
@@ -163,4 +163,16 @@ describe GdsApi::SupportApi do
       assert_requested(stub_get)
     end
   end
+
+  describe "POST /anonymous-feedback/problem-reports/mark-reviewed-for-spam" do
+    it "makes a PUT request to the support API" do
+      params = { "1" => true, "2" => true }
+
+      stub_post = stub_support_mark_reviewed_for_spam(params)
+
+      @api.mark_reviewed_for_spam(params)
+
+      assert_requested(stub_post)
+    end
+  end
 end

--- a/test/support_api_test.rb
+++ b/test/support_api_test.rb
@@ -71,7 +71,7 @@ describe GdsApi::SupportApi do
         page: 55,
       )
 
-      result = @api.anonymous_feedback(
+      @api.anonymous_feedback(
         path_prefix: "/vat-rates",
         page: 55,
       )
@@ -112,7 +112,7 @@ describe GdsApi::SupportApi do
       assert_requested(stub_post)
     end
   end
-  
+
   describe "POST /anonymous-feedback/global-export-requests" do
     it "makes a POST request to the support API" do
       params = {from_date: "1 June 2016", to_date: "8 June 2016", notification_email: "foo@example.com"}
@@ -148,6 +148,17 @@ describe GdsApi::SupportApi do
       stub_get = stub_organisation("foo")
 
       @api.organisation("foo")
+
+      assert_requested(stub_get)
+    end
+  end
+
+  describe "GET /anonymous-feedback/problem-reports" do
+    it "fetches a list of problem reports" do
+      params = { from_date: '2016-12-12', to_date: '2016-12-13', page: 1, exclude_reviewed: true }
+      stub_get = stub_support_problem_reports(params)
+
+      @api.problem_reports(params)
 
       assert_requested(stub_get)
     end


### PR DESCRIPTION
The support API has two new endpoints. These are used to fetch lists of problem reports and to update specified reports as spam.