### PR TITLE
Release version 36.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 36.0.0
+
+* Remove `GdsApi::Rummager#unified_search`. The `/unified_search` endpoint
+  has been removed in rummager in favor of `/search`.
+  **This is a breaking change**, which means applications currently using
+  `#unified_search` need to migrate to `#search`.
+
 # 35.0.1
 
 * Fix issue where Pact would hit the Publishing API in development if the

--- a/lib/gds_api/rummager.rb
+++ b/lib/gds_api/rummager.rb
@@ -8,7 +8,7 @@ module GdsApi
     #
     # @param query [Hash] A valid search query. See Rummager documentation for options.
     #
-    # @see https://github.com/alphagov/rummager/blob/master/docs/unified-search-api.md
+    # @see https://github.com/alphagov/rummager/blob/master/docs/search-api.md
     def search(args)
       request_url = "#{base_url}/search.json?#{Rack::Utils.build_nested_query(args)}"
       get_json!(request_url)

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '35.0.1'
+  VERSION = '36.0.0'
 end


### PR DESCRIPTION
This release removes `unified_search` for rummager and replaces it with `search`. This provides consistency between the internal and external APIs in terms of naming.

`unified_search` was deprecated in version 34.1.0 and all alphagov apps using it have now been migrated to `search`.

Trello: https://trello.com/c/cj8UX2jX