### PR TITLE
Add "delete assets" method to asset manager adapter

### DIFF
--- a/lib/gds_api/asset_manager.rb
+++ b/lib/gds_api/asset_manager.rb
@@ -91,6 +91,29 @@ class GdsApi::AssetManager < GdsApi::Base
     get_json("#{base_url}/assets/#{id}")
   end
 
+  # Deletes an asset given an id
+  #
+  # Makes a +DELETE+ request to the asset manager api to delete an asset.
+  #
+  # @param id [String] The asset identifier (a UUID).
+  # @return [GdsApi::Response] The wrapped http response from the api. Behaves
+  #   both as a +Hash+ and an +OpenStruct+, and responds to the following:
+  #     :id           the URL of the asset
+  #     :name         the filename of the asset that will be served
+  #     :content_type the content_type of the asset
+  #     :file_url     the URL from which the asset will be served when it has
+  #                   passed a virus scan
+  #     :state        One of 'unscanned', 'clean', or 'infected'. Unless the state is
+  #                   'clean' the asset at the :file_url will 404
+  #
+  # @raise [HTTPErrorResponse] if the request returns an error
+  # @example Delete a file from disk
+  #   uuid = '594602dd-75b3-4e6f-b5d1-cacf8c4d4164'
+  #   asset_manager.delete_asset(uuid)
+  def delete_asset(id)
+    delete_json("#{base_url}/assets/#{id}")
+  end
+
   private
     def base_url
       endpoint

--- a/test/asset_manager_test.rb
+++ b/test/asset_manager_test.rb
@@ -69,4 +69,14 @@ describe GdsApi::AssetManager do
       assert_equal "http://fooey.gov.uk/media/photo.jpg", asset.file_url
     end
   end
+
+  it "deletes an asset for the given id" do
+    req = stub_request(:delete, "#{base_api_url}/assets/#{asset_id}").
+      to_return(:body => JSON.dump(asset_manager_response), :status => 200)
+
+    response = api.delete_asset(asset_id)
+
+    assert_equal "#{base_api_url}/assets/#{asset_id}", response.asset.id
+    assert_requested(req)
+  end
 end

--- a/test/asset_manager_test.rb
+++ b/test/asset_manager_test.rb
@@ -22,6 +22,14 @@ describe GdsApi::AssetManager do
     }
   }
 
+  before do
+    GdsApi.config.always_raise_for_not_found = true
+  end
+
+  after do
+    GdsApi.config.always_raise_for_not_found = false
+  end
+
   it "creates an asset with a file" do
     req = stub_request(:post, "#{base_api_url}/assets").
       with(:body => %r{Content\-Disposition: form\-data; name="asset\[file\]"; filename="hello\.txt"\r\nContent\-Type: text/plain}).
@@ -33,10 +41,12 @@ describe GdsApi::AssetManager do
     assert_requested(req)
   end
 
-  it "returns nil when an asset does not exist" do
+  it "returns not found when an asset does not exist" do
     asset_manager_does_not_have_an_asset("not-really-here")
 
-    assert_nil api.asset("not-really-here")
+    assert_raises GdsApi::HTTPNotFound do
+      api.asset("not-really-here")
+    end
   end
 
   describe "an asset exists" do


### PR DESCRIPTION
Part of https://trello.com/c/zLrCEavw/263-delete-attachments-feature-medium

Adapter work to allow applications to use the delete assets route in asset-manager:
https://github.com/alphagov/asset-manager/pull/51
