### PR TITLE
Add option to resturn results as a hash

### DIFF
--- a/lib/gds_api/list_response.rb
+++ b/lib/gds_api/list_response.rb
@@ -26,7 +26,11 @@ module GdsApi
       # support group_by results from the content api by checking if there is a
       # grouped_results key present first. if it's not, then fallback to the
       # results key
-      to_ostruct.grouped_results || to_ostruct.results
+      if GdsApi.config.hash_response_for_requests
+        to_hash["grouped_results"] || to_hash["results"]
+      else
+        to_ostruct.grouped_results || to_ostruct.results
+      end
     end
 
     def has_next_page?


### PR DESCRIPTION
This change checks if GdsApi.config.hash_response_for_requests is set to true, and returns a results hash instead of an OpenStruct in ListResponse.  We discovered this was necessary after opting in to the new GDS API Adapters behaviour in contacts-admin (see PR [here](alphagov/contacts-admin#248) and Trello card [here](https://trello.com/c/B5z6Dq8q/495-get-our-apps-up-to-date-on-new-api-adapters-behaviour-update-at-stand-up), and found that tests were failing due to results returning an OpenStruct.