### PR TITLE
Release version 36.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 36.0.1
+
+* Add option to return results as a hash in `GdsApi::ListResponse`.
+
 # 36.0.0
 
 * Remove `GdsApi::Rummager#unified_search`. The `/unified_search` endpoint

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '36.0.0'
+  VERSION = '36.0.1'
 end


### PR DESCRIPTION
This release returns a results hash instead of an OpenStruct in `GdsApi::ListResponse` if `GdsApi.config.hash_response_for_requests` is set to true.