### PR TITLE
Release version 36.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 36.1.0
+
+* Add helpers for the support-api for fetching problem reports and
+  for marking problem reports as spam.
+
 # 36.0.1
 
 * Add option to return results as a hash in `GdsApi::ListResponse`.

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '36.0.1'
+  VERSION = '36.1.0'
 end


### PR DESCRIPTION
This release adds helpers for the support api for fetching problem reports and
for marking problem reports as spam.