### PR TITLE
Allow params to be matcher-like a la 'hash_including'

### DIFF
--- a/lib/gds_api/test_helpers/publishing_api_v2.rb
+++ b/lib/gds_api/test_helpers/publishing_api_v2.rb
@@ -169,8 +169,13 @@ module GdsApi
       #)
       def publishing_api_has_content(items, params = {})
         url = PUBLISHING_API_V2_ENDPOINT + "/content"
-        per_page = params.fetch(:per_page, 50)
-        page = params.fetch(:page, 1)
+        if params.respond_to? :fetch
+          per_page = params.fetch(:per_page, 50)
+          page = params.fetch(:page, 1)
+        else
+          per_page = 50
+          page = 1
+        end
         number_of_pages = items.count < per_page ? 1 : items.count / per_page
 
         body = {


### PR DESCRIPTION
https://github.com/alphagov/gds-api-adapters/commit/c2bb391d9c082ac31ac5b47ae9f074641109a843 prevents the use of RSpec style matcher params in `publishing_api_has_content` such as `hash_including` as [the underlying class doesn't implement a `fetch` method](http://www.rubydoc.info/github/rspec/rspec-mocks/RSpec/Mocks/ArgumentMatchers/HashIncludingMatcher).
So relax the attempt to paginate results to allow for this as [some test suites rely on passing matcher params](https://github.com/alphagov/specialist-publisher-rebuild/blob/fbf2b4a6de62b7be8a5c0ac1f4a7e1c9f9f0a05d/spec/features/searching_and_filtering_cma_cases_spec.rb#L28).