### PR TITLE
Release version 36.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 36.2.0
+
+* Add delete_asset method, to support the new delete asset functionality now supported by asset manager.
+* Fix issue where rspec style matchers would cause issues, since they do not implement the fetch method.
+
 # 36.1.0
 
 * Add helpers for the support-api for fetching problem reports and

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '36.1.0'
+  VERSION = '36.2.0'
 end


### PR DESCRIPTION
This version adds support for asset manager's new delete asset functionality, and fixes an issue with tests using rspec matchers