### PR TITLE
Fix calculation of the number of pages on Publishing API test helper

### DIFF
--- a/lib/gds_api/test_helpers/publishing_api_v2.rb
+++ b/lib/gds_api/test_helpers/publishing_api_v2.rb
@@ -169,6 +169,7 @@ module GdsApi
       #)
       def publishing_api_has_content(items, params = {})
         url = PUBLISHING_API_V2_ENDPOINT + "/content"
+
         if params.respond_to? :fetch
           per_page = params.fetch(:per_page, 50)
           page = params.fetch(:page, 1)
@@ -176,7 +177,13 @@ module GdsApi
           per_page = 50
           page = 1
         end
-        number_of_pages = items.count < per_page ? 1 : items.count / per_page
+
+        number_of_pages =
+          if items.count < per_page
+            1
+          else
+            (items.count / per_page.to_f).ceil
+          end
 
         body = {
           results: items,

--- a/test/test_helpers/publishing_api_v2_test.rb
+++ b/test/test_helpers/publishing_api_v2_test.rb
@@ -52,7 +52,6 @@ describe GdsApi::TestHelpers::PublishingApiV2 do
           { "content_id" => "2878337b-bed9-4e7f-85b6-10ed2cbcd504" },
           { "content_id" => "2878337b-bed9-4e7f-85b6-10ed2cbcd505" },
           { "content_id" => "2878337b-bed9-4e7f-85b6-10ed2cbcd506" },
-          { "content_id" => "2878337b-bed9-4e7f-85b6-10ed2cbcd507" },
         ],
         {
           page: 1,
@@ -62,7 +61,7 @@ describe GdsApi::TestHelpers::PublishingApiV2 do
 
       response = publishing_api.get_content_items({ page: 1, per_page: 2 })
 
-      assert_equal(response['total'], 4)
+      assert_equal(response['total'], 3)
       assert_equal(response['pages'], 2)
       assert_equal(response['current_page'], 1)
     end


### PR DESCRIPTION
For a scenario where there are, for example, 3 items and we want to show 2 per
page, the simple division doesn't work because:

```
[1] pry(main)> 3/2
=> 1
```

In this case, we actually want to round that division up in order to get the
accurate number of pages, which is 2:

```
[2] pry(main)> (3/2.0).ceil
=> 2
```

This commit makes sure we calculate the number of pages correctly.