### PR TITLE
Only return expected number of items from publishing_api_has_content

### DIFF
--- a/lib/gds_api/test_helpers/publishing_api_v2.rb
+++ b/lib/gds_api/test_helpers/publishing_api_v2.rb
@@ -178,6 +178,9 @@ module GdsApi
           page = 1
         end
 
+        start_position = (page-1) * per_page
+        page_items = items.slice(start_position, per_page) || []
+
         number_of_pages =
           if items.count < per_page
             1
@@ -186,7 +189,7 @@ module GdsApi
           end
 
         body = {
-          results: items,
+          results: page_items,
           total: items.count,
           pages: number_of_pages,
           current_page: page

--- a/test/test_helpers/publishing_api_v2_test.rb
+++ b/test/test_helpers/publishing_api_v2_test.rb
@@ -46,12 +46,16 @@ describe GdsApi::TestHelpers::PublishingApiV2 do
       )
     end
 
-    it 'returns pagination results' do
+    it 'returns paginated results' do
+      content_id_1 = "2878337b-bed9-4e7f-85b6-10ed2cbcd504"
+      content_id_2 = "2878337b-bed9-4e7f-85b6-10ed2cbcd505"
+      content_id_3 = "2878337b-bed9-4e7f-85b6-10ed2cbcd506"
+
       publishing_api_has_content(
         [
-          { "content_id" => "2878337b-bed9-4e7f-85b6-10ed2cbcd504" },
-          { "content_id" => "2878337b-bed9-4e7f-85b6-10ed2cbcd505" },
-          { "content_id" => "2878337b-bed9-4e7f-85b6-10ed2cbcd506" },
+          { "content_id" => content_id_1 },
+          { "content_id" => content_id_2 },
+          { "content_id" => content_id_3 },
         ],
         {
           page: 1,
@@ -60,10 +64,36 @@ describe GdsApi::TestHelpers::PublishingApiV2 do
       )
 
       response = publishing_api.get_content_items({ page: 1, per_page: 2 })
+      records = response['results']
 
       assert_equal(response['total'], 3)
       assert_equal(response['pages'], 2)
       assert_equal(response['current_page'], 1)
+
+      assert_equal(records.length, 2)
+      assert_equal(records.first['content_id'], content_id_1)
+      assert_equal(records.last['content_id'], content_id_2)
+    end
+
+    it 'returns an empty list of results for out-of-bound queries' do
+      content_id_1 = "2878337b-bed9-4e7f-85b6-10ed2cbcd504"
+      content_id_2 = "2878337b-bed9-4e7f-85b6-10ed2cbcd505"
+
+      publishing_api_has_content(
+        [
+          { "content_id" => content_id_1 },
+          { "content_id" => content_id_2 },
+        ],
+        {
+          page: 10,
+          per_page: 2
+        }
+      )
+
+      response = publishing_api.get_content_items({ page: 10, per_page: 2 })
+      records = response['results']
+
+      assert_equal(records, [])
     end
   end
 


### PR DESCRIPTION
This change makes sure that we return the expected results based on the
pagination information.

Even though we need to stub the API call with a number of items, this endpoint
should only return the ones belonging to the page requested (taking into account
the number of items per page).

As an example, for a call like:

```
publishing_api_has_content(
  [
    { "content_id" => 'content_id_1' },
    { "content_id" => 'content_id_2' },
    { "content_id" => 'content_id_3' },
  ],
  {
    page: 2,
    per_page: 2
  }
)
```

Where the user is requesting the 2nd page with 2 items per page, the API call
should only return the last entry in that array ('content_id_3'), which is the
only items on the 2nd page.

For out-of-bound queries, we should return an empty array.