### PR TITLE
Add helper methods to stub and assert searches

### DIFF
--- a/lib/gds_api/test_helpers/rummager.rb
+++ b/lib/gds_api/test_helpers/rummager.rb
@@ -38,6 +38,18 @@ module GdsApi
         end
       end
 
+      def stub_any_rummager_search
+        stub_request(:get, %r{#{RUMMAGER_ENDPOINT}/search.json})
+      end
+
+      def stub_any_rummager_search_to_return_no_results
+        stub_any_rummager_search.to_return(body: { results: [] }.to_json)
+      end
+
+      def assert_rummager_search(options)
+        assert_requested :get, "#{RUMMAGER_ENDPOINT}/search.json", **options
+      end
+
       def stub_any_rummager_delete(index: nil)
         if index
           stub_request(:delete, %r{#{RUMMAGER_ENDPOINT}/#{index}/documents/.*})


### PR DESCRIPTION
By not definining a default response (`to_return`) as part of the main stubbing method, this allows you to chain off `stub_any_rummager_search` to specify a suitable return value in your application’s tests.

You can use `stub_any_rummager_search_to_return_no_results` when you do not care about what Rummager will return.

Note that using stub_any_rummager_search _without_ chaining a call to `to_return` will probably result in errors as the Rummager class is expecting valid JSON to be returned.