### PR TITLE
Update deprecation warnings for configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ GdsApi.configure do |config|
 end
 ```
 
+By default, `always_raise_for_not_found` will be true, so there is no need to
+configure it. By December 1st, 2016 this configuration option will no longer
+exist, defaulting to always raising exceptions for 404s and 410s.
+
 ## Logging
 
 Each HTTP request can be logged as JSON. Example:

--- a/README.md
+++ b/README.md
@@ -18,23 +18,14 @@ Example adapters for frequently used applications:
 
 ## Configuration
 
-We're currently deprecating some behaviour of this gem. You can opt-in to the
-new behaviour now by adding configuration like this:
+From December 1st, 2016 it won't be possible to use the following configuration
+options:
 
-```ruby
-# config/initializers/gds_api_adapters.rb
-GdsApi.configure do |config|
-  # Never return nil when a server responds with 404 or 410.
-  config.always_raise_for_not_found = true
+- `always_raise_for_not_found`
+- `hash_response_for_requests`
 
-  # Return a hash, not an OpenStruct from a request.
-  config.hash_response_for_requests = true
-end
-```
-
-By default, `always_raise_for_not_found` will be true, so there is no need to
-configure it. By December 1st, 2016 this configuration option will no longer
-exist, defaulting to always raising exceptions for 404s and 410s.
+Please remove these configuration options from your client application and
+migrate to the new behaviour as soon as possible.
 
 ## Logging
 

--- a/lib/gds_api/asset_manager.rb
+++ b/lib/gds_api/asset_manager.rb
@@ -31,8 +31,8 @@ class GdsApi::AssetManager < GdsApi::Base
   #
   # @example Upload a file from disk
   #   response = asset_manager.create_asset(file: File.new('image.jpg', 'r'))
-  #   response.id           #=> "http://asset-manager.dev.gov.uk/assets/576bbc52759b74196b000012"
-  #   response.content_type #=> "image/jpeg"
+  #   response['id']           #=> "http://asset-manager.dev.gov.uk/assets/576bbc52759b74196b000012"
+  #   response['content_type'] #=> "image/jpeg"
   # @example Upload a file from a Rails param, (typically a multipart wrapper)
   #    params[:file] #=> #<ActionDispatch::Http::UploadedFile:0x007fc60b43c5c8
   #                      # @content_type="application/foofle",
@@ -42,7 +42,7 @@ class GdsApi::AssetManager < GdsApi::Base
   #    # Though we sent a file with a +content_type+ of 'application/foofle',
   #    # this was ignored
   #    response = asset_manager.create_asset(file: params[:file])
-  #    response.content_type #=> "image/jpeg"
+  #    response['content_type'] #=> "image/jpeg"
   def create_asset(asset)
     post_multipart("#{base_url}/assets", { :asset => asset })
   end

--- a/lib/gds_api/config.rb
+++ b/lib/gds_api/config.rb
@@ -44,9 +44,33 @@ Called from: #{caller[2]}
     # Set to true to make `GdsApi::Response` behave like a simple hash, instead
     # of an OpenStruct. This will prevent nil-errors.
     #
-    # This configuration allows some time to upgrade - you should opt-in to this
-    # behaviour now. We'll change this to default to true on October 1st, 2016
-    # and remove the option entirely on December 1st, 2016.
-    attr_accessor :hash_response_for_requests
+    # Currently defaults to true.
+    #
+    # This configuration will be removed on December 1st, 2016. Please make sure
+    # you upgrade gds-api-adapters to the latest version and avoid configuring
+    # it on your client application.
+    def hash_response_for_requests
+      return true if @hash_response_for_requests.nil?
+
+      @hash_response_for_requests
+    end
+
+    def hash_response_for_requests=(value)
+      warn <<-doc
+
+DEPRECATION NOTICE: Please delete any instances of
+`GdsApi.config.hash_response_for_requests=` from your codebase to make
+sure responses behave like a Hash instead of an OpenStruct.
+
+This configuration option will be be removed. Returning responses that
+behave like a Hash is the default behaviour and it won't be possible to
+opt-out from December 1st, 2016.
+
+Called from: #{caller[2]}
+
+      doc
+
+      @hash_response_for_requests = value
+    end
   end
 end

--- a/lib/gds_api/config.rb
+++ b/lib/gds_api/config.rb
@@ -8,15 +8,38 @@ module GdsApi
   end
 
   class Config
-    # Always raise a `HTTPNotFound` exception when the server returns 404 or
-    # 410. This avoids nil-errors in your code and makes debugging easier.
+    # Always raise an `HTTPNotFound` exception when the server returns 404 or an
+    # `HTTPGone` when the server returns 410. This avoids nil-errors in your
+    # code and makes debugging easier.
     #
-    # Currently defaults to false.
+    # Currently defaults to true.
     #
-    # This configuration allows some time to upgrade - you should opt-in to this
-    # behaviour now. We'll change this to default to true on October 1st, 2016
-    # and remove the option entirely on December 1st, 2016.
-    attr_accessor :always_raise_for_not_found
+    # This configuration will be removed on December 1st, 2016. Please make sure
+    # you upgrade gds-api-adapters to the latest version and avoid configuring
+    # it on your client application.
+    def always_raise_for_not_found
+      return true if @always_raise_for_not_found.nil?
+
+      @always_raise_for_not_found
+    end
+
+    def always_raise_for_not_found=(value)
+      warn <<-doc
+
+DEPRECATION NOTICE: Please delete any instances of
+`GdsApi.config.always_raise_for_not_found=` from your codebase to make
+sure all 404 or 410 responses raise an exception.
+
+This configuration option will be be removed. Raising exceptions is now
+the default behaviour and it won't be possible to opt-out from December
+1st, 2016.
+
+Called from: #{caller[2]}
+
+      doc
+
+      @always_raise_for_not_found = value
+    end
 
     # Set to true to make `GdsApi::Response` behave like a simple hash, instead
     # of an OpenStruct. This will prevent nil-errors.

--- a/lib/gds_api/gov_uk_delivery.rb
+++ b/lib/gds_api/gov_uk_delivery.rb
@@ -22,7 +22,7 @@ class GdsApi::GovUkDelivery < GdsApi::Base
 
   def signup_url(feed_url)
     if response = get_json("#{base_url}/list-url?feed_url=#{CGI.escape(feed_url)}")
-      response.list_url
+      response['list_url']
     end
   end
 

--- a/lib/gds_api/json_client.rb
+++ b/lib/gds_api/json_client.rb
@@ -78,16 +78,6 @@ module GdsApi
       if GdsApi.config.always_raise_for_not_found
         get_raw!(url)
       else
-        warn <<-doc
-          DEPRECATION NOTICE: You are making requests that will potentially
-          return nil. Please set `GdsApi.config.always_raise_for_not_found = true`
-          to make sure all responses with 404 or 410 raise an exception.
-
-          Raising exceptions will be the default behaviour from October 1st, 2016.
-
-          Called from: #{caller[2]}
-        doc
-
         ignoring_missing do
           get_raw!(url)
         end
@@ -105,16 +95,6 @@ module GdsApi
         if GdsApi.config.always_raise_for_not_found
           send (method_name + "!"), url, *args, &block
         else
-          warn <<-doc
-            DEPRECATION NOTICE: You are making requests that will potentially
-            return nil. Please set `GdsApi.config.always_raise_for_not_found = true`
-            to make sure all responses with 404 or 410 raise an exception.
-
-            Raising exceptions will be the default behaviour from October 1st, 2016.
-
-            Called from: #{caller[2]}
-          doc
-
           ignoring_missing do
             send (method_name + "!"), url, *args, &block
           end

--- a/lib/gds_api/part_methods.rb
+++ b/lib/gds_api/part_methods.rb
@@ -1,12 +1,12 @@
 module GdsApi::PartMethods
 
   def part_index(slug)
-    parts.index { |p| p.slug == slug }
+    parsed_content['parts'].index { |p| p['slug'] == slug }
   end
 
   def find_part(slug)
     return nil unless index = part_index(slug)
-    parts[index]
+    parsed_content['parts'][index]
   end
 
   def has_parts?(part)
@@ -14,13 +14,13 @@ module GdsApi::PartMethods
   end
 
   def has_previous_part?(part)
-    index = part_index(part.slug)
+    index = part_index(part['slug'])
     !! (index && index > 0)
   end
 
   def has_next_part?(part)
-    index = part_index(part.slug)
-    !! (index && (index + 1) < parts.length)
+    index = part_index(part['slug'])
+    !! (index && (index + 1) < parsed_content['parts'].length)
   end
 
   def part_after(part)
@@ -33,9 +33,12 @@ module GdsApi::PartMethods
 
 private
   def part_at(part, relative_offset)
-    return nil unless current_index = part_index(part.slug)
+    current_index = part_index(part['slug'])
+    return nil unless current_index
+
     other_index = current_index + relative_offset
-    return nil unless (0 ... parts.length).include?(other_index)
-    parts[other_index]
+    return nil unless (0...parsed_content['parts'].length).cover?(other_index)
+
+    parsed_content['parts'][other_index]
   end
 end

--- a/lib/gds_api/publisher.rb
+++ b/lib/gds_api/publisher.rb
@@ -7,8 +7,8 @@ class GdsApi::Publisher < GdsApi::Base
 
     response = get_json(url_for_slug(slug, options))
     if response
-      container = response.to_ostruct
-      container.extend(GdsApi::PartMethods) if container.parts
+      container = response.dup
+      container.extend(GdsApi::PartMethods) if container['parts']
       convert_updated_date(container)
       container
     else
@@ -39,8 +39,9 @@ class GdsApi::Publisher < GdsApi::Base
 
 private
   def convert_updated_date(container)
-    if container.updated_at && container.updated_at.class == String
-      container.updated_at = Time.parse(container.updated_at)
+    if container['updated_at'] && container['updated_at'].is_a?(String)
+      container.parsed_content['updated_at'] =
+        Time.parse(container['updated_at'])
     end
   end
 

--- a/lib/gds_api/response.rb
+++ b/lib/gds_api/response.rb
@@ -19,7 +19,7 @@ module GdsApi
   # Example:
   #
   #   r = Response.new(response, web_urls_relative_to: "https://www.gov.uk")
-  #   r.results[0].web_url
+  #   r['results'][0]['web_url']
   #   => "/bank-holidays"
   class Response
     extend Forwardable
@@ -71,12 +71,16 @@ module GdsApi
     end
 
     def to_hash
-      @parsed ||= transform_parsed(JSON.parse(@http_response.body))
+      parsed_content
+    end
+
+    def parsed_content
+      @parsed_content ||= transform_parsed(JSON.parse(@http_response.body))
     end
 
     def to_ostruct
       raise NoMethodError if GdsApi.config.hash_response_for_requests
-      @ostruct ||= self.class.build_ostruct_recursively(to_hash)
+      @ostruct ||= self.class.build_ostruct_recursively(parsed_content)
     end
 
     def method_missing(method_sym, *arguments, &block)

--- a/test/asset_manager_test.rb
+++ b/test/asset_manager_test.rb
@@ -29,7 +29,7 @@ describe GdsApi::AssetManager do
 
     response = api.create_asset(:file => file_fixture)
 
-    assert_equal asset_url, response.asset.id
+    assert_equal asset_url, response['asset']['id']
     assert_requested(req)
   end
 
@@ -59,16 +59,16 @@ describe GdsApi::AssetManager do
 
       response = api.update_asset(asset_id, :file => file_fixture)
 
-      assert_equal "#{base_api_url}/assets/#{asset_id}", response.asset.id
+      assert_equal "#{base_api_url}/assets/#{asset_id}", response['asset']['id']
       assert_requested(req)
     end
 
     it "retrieves an asset" do
       asset = api.asset(asset_id)
 
-      assert_equal "photo.jpg", asset.name
-      assert_equal "image/jpeg", asset.content_type
-      assert_equal "http://fooey.gov.uk/media/photo.jpg", asset.file_url
+      assert_equal "photo.jpg", asset['name']
+      assert_equal "image/jpeg", asset['content_type']
+      assert_equal "http://fooey.gov.uk/media/photo.jpg", asset['file_url']
     end
   end
 
@@ -78,7 +78,7 @@ describe GdsApi::AssetManager do
 
     response = api.delete_asset(asset_id)
 
-    assert_equal "#{base_api_url}/assets/#{asset_id}", response.asset.id
+    assert_equal "#{base_api_url}/assets/#{asset_id}", response['asset']['id']
     assert_requested(req)
   end
 end

--- a/test/asset_manager_test.rb
+++ b/test/asset_manager_test.rb
@@ -22,14 +22,6 @@ describe GdsApi::AssetManager do
     }
   }
 
-  before do
-    GdsApi.config.always_raise_for_not_found = true
-  end
-
-  after do
-    GdsApi.config.always_raise_for_not_found = false
-  end
-
   it "creates an asset with a file" do
     req = stub_request(:post, "#{base_api_url}/assets").
       with(:body => %r{Content\-Disposition: form\-data; name="asset\[file\]"; filename="hello\.txt"\r\nContent\-Type: text/plain}).

--- a/test/content_api_test.rb
+++ b/test/content_api_test.rb
@@ -32,10 +32,13 @@ describe GdsApi::ContentApi do
       content_api_has_an_artefact("bank-holidays", artefact_response)
       artefact = @api.artefact("bank-holidays")
 
-      assert_equal "Bank holidays", artefact.title
-      assert_equal "/bank-holidays", artefact.web_url
+      assert_equal "Bank holidays", artefact['title']
+      assert_equal "/bank-holidays", artefact['web_url']
 
-      assert_equal "/browse/cheese", artefact.tags[0].content_with_tag.web_url
+      assert_equal(
+        "/browse/cheese",
+        artefact['tags'][0]['content_with_tag']['web_url']
+      )
     end
 
     it "should use relative URLs for tag listings" do
@@ -44,7 +47,7 @@ describe GdsApi::ContentApi do
 
       assert_equal 3, tags.count
       tags.each do |tag|
-        web_url = tag.content_with_tag.web_url
+        web_url = tag['content_with_tag']['web_url']
         assert web_url.start_with?("/browse/"), web_url
       end
     end
@@ -60,12 +63,15 @@ describe GdsApi::ContentApi do
         artefact_response["web_url"] = "http://www.test.gov.uk/bank-holidays"
         content_api_has_an_artefact("bank-holidays", artefact_response)
 
-        assert_equal "/bank-holidays", @api.artefact("bank-holidays").web_url
+        assert_equal "/bank-holidays", @api.artefact("bank-holidays")['web_url']
 
         clean_api = GdsApi::ContentApi.new(@base_api_url)
         clean_artefact = clean_api.artefact("bank-holidays")
 
-        assert_equal "http://www.test.gov.uk/bank-holidays", clean_artefact.web_url
+        assert_equal(
+          "http://www.test.gov.uk/bank-holidays",
+          clean_artefact['web_url']
+        )
       end
 
       after do
@@ -85,7 +91,10 @@ describe GdsApi::ContentApi do
 
       # Also check attribute access
       first_section = response.first
-      assert_equal "#{@base_api_url}/tags/sections/crime.json", first_section.id
+      assert_equal(
+        "#{@base_api_url}/tags/sections/crime.json",
+        first_section['id']
+      )
     end
 
     def section_page_url(page_parameter)
@@ -134,7 +143,10 @@ describe GdsApi::ContentApi do
 
       sections = @api.sections
       assert_equal 20, sections.with_subsequent_pages.count
-      assert_equal "Section 20", sections.with_subsequent_pages.to_a.last.title
+      assert_equal(
+        "Section 20",
+        sections.with_subsequent_pages.to_a.last['title']
+      )
     end
 
     it "should iterate across three or more pages" do
@@ -144,7 +156,10 @@ describe GdsApi::ContentApi do
 
       sections = @api.sections
       assert_equal 30, sections.with_subsequent_pages.count
-      assert_equal "Section 30", sections.with_subsequent_pages.to_a.last.title
+      assert_equal(
+        "Section 30",
+        sections.with_subsequent_pages.to_a.last['title']
+      )
     end
 
     it "should not load a page multiple times" do
@@ -225,7 +240,10 @@ describe GdsApi::ContentApi do
 
       response = @api.artefacts
       assert_equal 4, response.count
-      assert_equal %w(answer local_transaction place guide), response.map(&:format)
+      assert_equal(
+        %w(answer local_transaction place guide),
+        response.map { |item| item['format'] }
+      )
     end
 
     it "should work with a paginated response" do
@@ -257,7 +275,10 @@ describe GdsApi::ContentApi do
         )
       response = @api.artefacts
       assert_equal 7, response.with_subsequent_pages.count
-      assert_equal "http://www.test.gov.uk/vat2", response.with_subsequent_pages.to_a.last.web_url
+      assert_equal(
+        "http://www.test.gov.uk/vat2",
+        response.with_subsequent_pages.to_a.last['web_url']
+      )
     end
   end
 
@@ -272,8 +293,18 @@ describe GdsApi::ContentApi do
       response = @api.for_need(100123)
 
       assert_equal 3, response.count
-      assert_equal ["http://www.gov.uk/burrito", "http://www.gov.uk/burrito-standard", "http://www.gov.uk/local-burrito-place" ], response.map(&:web_url)
-      assert_equal ["answer", "guide", "transaction" ], response.map(&:format)
+      assert_equal(
+        [
+          "http://www.gov.uk/burrito",
+          "http://www.gov.uk/burrito-standard",
+          "http://www.gov.uk/local-burrito-place"
+        ],
+        response.map { |item| item['web_url'] }
+      )
+      assert_equal(
+        %w(answer guide transaction),
+        response.map { |item| item['format'] }
+      )
     end
   end
 
@@ -288,7 +319,10 @@ describe GdsApi::ContentApi do
 
       # Also check attribute access
       first_section = response.first
-      assert_equal "#{@base_api_url}/tags/authors/justin-thyme.json", first_section.id
+      assert_equal(
+        "#{@base_api_url}/tags/authors/justin-thyme.json",
+        first_section['id']
+      )
     end
 
     it "returns a sorted list of tags of a given type" do
@@ -296,17 +330,29 @@ describe GdsApi::ContentApi do
       response = @api.tags("author", sort: "alphabetical")
 
       first_section = response.first
-      assert_equal "#{@base_api_url}/tags/authors/justin-thyme.json", first_section.id
+      assert_equal(
+        "#{@base_api_url}/tags/authors/justin-thyme.json",
+        first_section['id']
+      )
     end
 
     it "returns draft tags if requested" do
       content_api_has_draft_and_live_tags(type: "specialist", draft: ["draft-tag-1"], live: ["live-tag-1"])
 
       all_tags = @api.tags("specialist", draft: true)
-      assert_equal [["draft-tag-1", "draft"], ["live-tag-1", "live"]].to_set, all_tags.map {|t| [t.slug, t.state] }.to_set
+      assert_equal(
+        [
+          ["draft-tag-1", "draft"],
+          ["live-tag-1", "live"]
+        ].to_set,
+        all_tags.map { |t| [t['slug'], t['state']] }.to_set
+      )
 
       live_tags = @api.tags("specialist")
-      assert_equal [["live-tag-1", "live"]], live_tags.map {|t| [t.slug, t.state] }
+      assert_equal(
+        [["live-tag-1", "live"]],
+        live_tags.map { |t| [t['slug'], t['state']] }
+      )
     end
 
     it "returns a list of root tags of a given type" do
@@ -319,7 +365,10 @@ describe GdsApi::ContentApi do
 
       # Also check attribute access
       first_section = response.first
-      assert_equal "#{@base_api_url}/tags/authors/oliver-sudden.json", first_section.id
+      assert_equal(
+        "#{@base_api_url}/tags/authors/oliver-sudden.json",
+        first_section['id']
+      )
     end
 
     it "returns a list of child tags of a given type" do
@@ -332,7 +381,10 @@ describe GdsApi::ContentApi do
 
       # Also check attribute access
       first_section = response.first
-      assert_equal "#{@base_api_url}/tags/genres/indie%2Findie-rock.json", first_section.id
+      assert_equal(
+        "#{@base_api_url}/tags/genres/indie%2Findie-rock.json",
+        first_section['id']
+      )
     end
 
     it "returns a sorted list of child tags of a given type" do
@@ -340,7 +392,10 @@ describe GdsApi::ContentApi do
       response = @api.child_tags("genre", "indie", sort: "alphabetical")
 
       first_section = response.first
-      assert_equal "#{@base_api_url}/tags/genres/indie%2Findie-rock.json", first_section.id
+      assert_equal(
+        "#{@base_api_url}/tags/genres/indie%2Findie-rock.json",
+        first_section['id']
+      )
     end
 
     it "returns tag information for a section" do
@@ -604,19 +659,37 @@ describe GdsApi::ContentApi do
       content_api_has_licence :licence_identifier => "AB1234", :title => 'Test Licence 3', :slug => 'test-licence-3',
         :licence_short_description => 'A short description'
 
-      results = @api.licences_for_ids([1234, 'AB1234', 'something']).to_ostruct.results
+      results = @api.licences_for_ids([1234, 'AB1234', 'something'])['results']
       assert_equal 2, results.size
-      assert_equal ['1234', 'AB1234'], results.map { |r| r.details.licence_identifier }
-      assert_equal ['Test Licence 1', 'Test Licence 3'], results.map(&:title).sort
-      assert_equal ['http://www.test.gov.uk/test-licence-1', 'http://www.test.gov.uk/test-licence-3'], results.map(&:web_url).sort
-      assert_equal 'A short description', results[0].details.licence_short_description
-      assert_equal 'A short description', results[1].details.licence_short_description
+      assert_equal(
+        %w(1234 AB1234),
+        results.map { |r| r['details']['licence_identifier'] }
+      )
+      assert_equal(
+        ['Test Licence 1', 'Test Licence 3'],
+        results.map { |item| item['title'] }.sort
+      )
+      assert_equal(
+        [
+          'http://www.test.gov.uk/test-licence-1',
+          'http://www.test.gov.uk/test-licence-3'
+        ],
+        results.map { |item| item['web_url'] }.sort
+      )
+      assert_equal(
+        'A short description',
+        results[0]['details']['licence_short_description']
+      )
+      assert_equal(
+        'A short description',
+        results[1]['details']['licence_short_description']
+      )
     end
 
     it "should return empty array with no licences" do
       setup_content_api_licences_stubs
 
-      assert_equal [], @api.licences_for_ids([123,124]).to_ostruct.results
+      assert_equal [], @api.licences_for_ids([123, 124])['results']
     end
 
     it "should raise an error if publisher returns an error" do
@@ -624,7 +697,7 @@ describe GdsApi::ContentApi do
         to_return(:status => [503, "Service temporarily unabailable"])
 
       assert_raises GdsApi::HTTPServerError do
-        @api.licences_for_ids([123,124])
+        @api.licences_for_ids([123, 124])
       end
     end
   end

--- a/test/content_api_test.rb
+++ b/test/content_api_test.rb
@@ -411,14 +411,16 @@ describe GdsApi::ContentApi do
   end
 
   describe "local authorities" do
-    it "should return nil if no local authority found" do
+    it "should raise if no local authority found" do
       stub_request(:get, "#{@base_api_url}/local_authorities/does-not-exist.json").
         with(:headers => GdsApi::JsonClient.default_request_headers).
         to_return(:status => 404,
                   :body => {"_response_info" => {"status" => "ok"}}.to_json,
                   :headers => {})
 
-      assert_nil @api.local_authority("does-not-exist")
+      assert_raises(GdsApi::HTTPNotFound) do
+        @api.local_authority("does-not-exist")
+      end
     end
 
     it "should produce a LocalAuthority hash for an existing snac code" do

--- a/test/content_store_test.rb
+++ b/test/content_store_test.rb
@@ -20,47 +20,35 @@ describe GdsApi::ContentStore do
       assert_equal base_path, response["base_path"]
     end
 
-    it "returns nil if the item doesn't exist" do
+    it "raises if the item doesn't exist" do
       content_store_does_not_have_item("/non-existent")
 
-      assert_nil @api.content_item("/non-existent")
+      assert_raises(GdsApi::HTTPNotFound) do
+        @api.content_item("/non-existent")
+      end
     end
 
-    it "raises if the item doesn't exist and `always_raise_for_not_found` enabled" do
-      GdsApi.configure do |config|
-        config.always_raise_for_not_found = true
-      end
-
+    it "raises if the item doesn't exist" do
       content_store_does_not_have_item("/non-existent")
 
       assert_raises GdsApi::HTTPNotFound do
         @api.content_item("/non-existent")
       end
-
-      GdsApi.configure do |config|
-        config.always_raise_for_not_found = false
-      end
     end
 
-    it "returns nil if the item is gone" do
+    it "raises if the item is gone" do
       content_store_has_gone_item("/it-is-gone")
 
-      assert_nil @api.content_item("/it-is-gone")
+      assert_raises(GdsApi::HTTPGone) do
+        @api.content_item("/it-is-gone")
+      end
     end
 
-    it "raises if the item is gone and `always_raise_for_not_found` enabled" do
-      GdsApi.configure do |config|
-        config.always_raise_for_not_found = true
-      end
-
+    it "raises if the item is gone" do
       content_store_has_gone_item("/it-is-gone")
 
       assert_raises GdsApi::HTTPGone do
         @api.content_item("/it-is-gone")
-      end
-
-      GdsApi.configure do |config|
-        config.always_raise_for_not_found = false
       end
     end
   end

--- a/test/gov_uk_delivery_test.rb
+++ b/test/gov_uk_delivery_test.rb
@@ -43,11 +43,13 @@ describe GdsApi::GovUkDelivery do
     assert_requested stub
   end
 
-  it "returns nil if the API 404s" do
+  it "raises if the API 404s" do
     expected_payload = { feed_url: 'http://example.com/feed'}
     stub = stub_gov_uk_delivery_get_request('list-url', expected_payload).to_return(not_found_hash)
 
-    assert @api.signup_url('http://example.com/feed').nil?
+    assert_raises(GdsApi::HTTPNotFound) do
+      @api.signup_url('http://example.com/feed')
+    end
   end
 
   private

--- a/test/gov_uk_delivery_test.rb
+++ b/test/gov_uk_delivery_test.rb
@@ -36,7 +36,7 @@ describe GdsApi::GovUkDelivery do
   end
 
   it "can get a subscription URL" do
-    expected_payload = { feed_url: 'http://example.com/feed'}
+    expected_payload = { feed_url: 'http://example.com/feed' }
     stub = stub_gov_uk_delivery_get_request('list-url', expected_payload).to_return(created_response_json_hash({list_url: 'thing'}))
 
     assert @api.signup_url('http://example.com/feed')

--- a/test/json_client_test.rb
+++ b/test/json_client_test.rb
@@ -28,6 +28,21 @@ class JsonClientTest < MiniTest::Spec
     {}
   end
 
+  # TODO: When we remove `GdsApi.config.hash_response_for_requests`, this helper
+  # method no longer makes sense and it should be deleted.
+  def with_hash_response_for_requests_disabled
+    @old_hash_response_for_requests = GdsApi.config.hash_response_for_requests
+    GdsApi.configure do |config|
+      config.hash_response_for_requests = false
+    end
+
+    yield
+
+    GdsApi.configure do |config|
+      config.hash_response_for_requests = @old_hash_response_for_requests
+    end
+  end
+
   def test_long_get_requests_timeout
     url = "http://www.example.com/timeout.json"
     stub_request(:get, url).to_timeout
@@ -79,14 +94,14 @@ class JsonClientTest < MiniTest::Spec
 
   def test_should_fetch_and_parse_json_into_response
     url = "http://some.endpoint/some.json"
-    stub_request(:get, url).to_return(:body => "{}", :status => 200)
+    stub_request(:get, url).to_return(body: "{}", status: 200)
     assert_equal GdsApi::Response, @client.get_json(url).class
   end
 
   def test_should_cache_multiple_requests_to_same_url_across_instances
     url = "http://some.endpoint/some.json"
     result = {"foo" => "bar"}
-    stub_request(:get, url).to_return(:body => JSON.dump(result), :status => 200)
+    stub_request(:get, url).to_return(body: JSON.dump(result), status: 200)
     response_a = GdsApi::JsonClient.new.get_json(url)
     response_b = GdsApi::JsonClient.new.get_json(url)
     assert_equal response_a.to_hash, response_b.to_hash
@@ -101,7 +116,7 @@ class JsonClientTest < MiniTest::Spec
     url = "http://some.endpoint/"
     result = {"foo" => "bar"}
     stub_request(:get, %r{\A#{url}}).to_return do |request|
-      {:body => {"url" => request.uri}.to_json, :status => 200}
+      { body: { "url" => request.uri }.to_json, status: 200 }
     end
 
     response_a = GdsApi::JsonClient.new(:cache_size => 5).get_json("#{url}/first.json")
@@ -120,7 +135,7 @@ class JsonClientTest < MiniTest::Spec
   def test_should_cache_requests_for_15_mins_by_default
     url = "http://some.endpoint/some.json"
     result = {"foo" => "bar"}
-    stub_request(:get, url).to_return(:body => JSON.dump(result), :status => 200)#.times(1)
+    stub_request(:get, url).to_return(body: JSON.dump(result), status: 200)
     response_a = GdsApi::JsonClient.new.get_json(url)
     response_b = GdsApi::JsonClient.new.get_json(url)
 
@@ -149,7 +164,7 @@ class JsonClientTest < MiniTest::Spec
 
     url = "http://some.endpoint/some.json"
     result = {"foo" => "bar"}
-    stub_request(:get, url).to_return(:body => JSON.dump(result), :status => 200)#.times(1)
+    stub_request(:get, url).to_return(body: JSON.dump(result), status: 200)
     response_a = GdsApi::JsonClient.new(:cache_ttl => 5 * 60).get_json(url)
     response_b = GdsApi::JsonClient.new.get_json(url)
 
@@ -174,7 +189,7 @@ class JsonClientTest < MiniTest::Spec
   def test_should_allow_disabling_caching
     url = "http://some.endpoint/some.json"
     result = {"foo" => "bar"}
-    stub_request(:get, url).to_return(:body => JSON.dump(result), :status => 200)
+    stub_request(:get, url).to_return(body: JSON.dump(result), status: 200)
 
     client = GdsApi::JsonClient.new(disable_cache: true)
 
@@ -192,9 +207,9 @@ class JsonClientTest < MiniTest::Spec
     url = "http://some.endpoint/some.json"
     result = {"foo" => "bar"}
     stub_request(:get, url).to_return(
-      :body => JSON.dump(result),
-      :status => 200,
-      :headers => { "Expires" => (Time.now + 7 * 60).utc.httpdate }
+      body: JSON.dump(result),
+      status: 200,
+      headers: { "Expires" => (Time.now + 7 * 60).utc.httpdate }
     )
 
     response_a = GdsApi::JsonClient.new.get_json(url)
@@ -218,9 +233,9 @@ class JsonClientTest < MiniTest::Spec
     url = "http://some.endpoint/max_age.json"
     result = {"foo" => "bar"}
     stub_request(:get, url).to_return(
-      :body => JSON.dump(result),
-      :status => 200,
-      :headers => { "Cache-Control" => "max-age=420, public" } # 7 minutes
+      body: JSON.dump(result),
+      status: 200,
+      headers: { "Cache-Control" => "max-age=420, public" } # 7 minutes
     )
 
     response_a = GdsApi::JsonClient.new.get_json(url)
@@ -244,9 +259,9 @@ class JsonClientTest < MiniTest::Spec
     url = "http://some.endpoint/no_cache.json"
     result = {"foo" => "bar"}
     stub_request(:get, url).to_return(
-      :body => JSON.dump(result),
-      :status => 200,
-      :headers => { "Cache-Control" => "no-cache, public" }
+      body: JSON.dump(result),
+      status: 200,
+      headers: { "Cache-Control" => "no-cache, public" }
     )
 
     response_a = GdsApi::JsonClient.new.get_json(url)
@@ -263,9 +278,9 @@ class JsonClientTest < MiniTest::Spec
     url = "http://some.endpoint/private.json"
     result = {"foo" => "bar"}
     stub_request(:get, url).to_return(
-      :body => JSON.dump(result),
-      :status => 200,
-      :headers => { "Cache-Control" => "max-age=600, private" }
+      body: JSON.dump(result),
+      status: 200,
+      headers: { "Cache-Control" => "max-age=600, private" }
     )
 
     response_a = GdsApi::JsonClient.new.get_json(url)
@@ -282,9 +297,9 @@ class JsonClientTest < MiniTest::Spec
     url = "http://some.endpoint/private.json"
     result = {"foo" => "bar"}
     stub_request(:get, url).to_return(
-      :body => JSON.dump(result),
-      :status => 200,
-      :headers => { "Cache-Control" => "max-age=600, no-store" }
+      body: JSON.dump(result),
+      status: 200,
+      headers: { "Cache-Control" => "max-age=600, no-store" }
     )
 
     response_a = GdsApi::JsonClient.new.get_json(url)
@@ -301,9 +316,9 @@ class JsonClientTest < MiniTest::Spec
     url = "http://some.endpoint/no_cache_and_max_age.json"
     result = {"foo" => "bar"}
     stub_request(:get, url).to_return(
-      :body => JSON.dump(result),
-      :status => 200,
-      :headers => { "Cache-Control" => "max-age=600, no-cache, public" }
+      body: JSON.dump(result),
+      status: 200,
+      headers: { "Cache-Control" => "max-age=600, no-cache, public" }
     )
 
     response_a = GdsApi::JsonClient.new.get_json(url)
@@ -320,9 +335,9 @@ class JsonClientTest < MiniTest::Spec
     url = "http://some.endpoint/url.json"
     result = {"foo" => "bar"}
     stub_request(:get, url).to_return(
-      :body => JSON.dump(result),
-      :status => 200,
-      :headers => {
+      body: JSON.dump(result),
+      status: 200,
+      headers: {
         "Cache-Control" => "no-cache",
         "Expires" => (Time.now + 7 * 60).utc.httpdate
       }
@@ -342,9 +357,9 @@ class JsonClientTest < MiniTest::Spec
     url = "http://some.endpoint/url.json"
     result = {"foo" => "bar"}
     stub_request(:get, url).to_return(
-      :body => JSON.dump(result),
-      :status => 200,
-      :headers => {
+      body: JSON.dump(result),
+      status: 200,
+      headers: {
         "Cache-Control" => "foo, bar, baz",
         "Expires" => (Time.now + 7 * 60).utc.httpdate
       }
@@ -362,7 +377,7 @@ class JsonClientTest < MiniTest::Spec
 
   def test_get_bang_should_raise_http_not_found_if_404_returned_from_endpoint
     url = "http://some.endpoint/some.json"
-    stub_request(:get, url).to_return(:body => "{}", :status => 404)
+    stub_request(:get, url).to_return(body: "{}", status: 404)
     assert_raises GdsApi::HTTPNotFound do
       @client.get_json!(url)
     end
@@ -370,7 +385,7 @@ class JsonClientTest < MiniTest::Spec
 
   def test_get_bang_should_raise_http_gone_if_410_returned_from_endpoint
     url = "http://some.endpoint/some.json"
-    stub_request(:get, url).to_return(:body => "{}", :status => 410)
+    stub_request(:get, url).to_return(body: "{}", status: 410)
     assert_raises GdsApi::HTTPGone do
       @client.get_json!(url)
     end
@@ -378,7 +393,7 @@ class JsonClientTest < MiniTest::Spec
 
   def test_get_bang_should_raise_http_forbidden_if_403_returned_from_endpoint
     url = "http://some.endpoint/some.json"
-    stub_request(:get, url).to_return(:body => "{}", :status => 403)
+    stub_request(:get, url).to_return(body: "{}", status: 403)
     assert_raises GdsApi::HTTPForbidden do
       @client.get_json!(url)
     end
@@ -392,7 +407,7 @@ class JsonClientTest < MiniTest::Spec
       config.always_raise_for_not_found = false
     end
     url = "http://some.endpoint/some.json"
-    stub_request(:get, url).to_return(:body => "{}", :status => 404)
+    stub_request(:get, url).to_return(body: "{}", status: 404)
 
     assert_nil @client.get_json(url)
   ensure
@@ -409,7 +424,7 @@ class JsonClientTest < MiniTest::Spec
       config.always_raise_for_not_found = false
     end
     url = "http://some.endpoint/some.json"
-    stub_request(:get, url).to_return(:body => "{}", :status => 410)
+    stub_request(:get, url).to_return(body: "{}", status: 410)
     assert_nil @client.get_json(url)
   ensure
     GdsApi.configure do |config|
@@ -419,7 +434,7 @@ class JsonClientTest < MiniTest::Spec
 
   def test_get_should_raise_if_404_returned_from_endpoint
     url = "http://some.endpoint/some.json"
-    stub_request(:get, url).to_return(:body => "{}", :status => 404)
+    stub_request(:get, url).to_return(body: "{}", status: 404)
     assert_raises GdsApi::HTTPNotFound do
       @client.get_json(url)
     end
@@ -427,7 +442,7 @@ class JsonClientTest < MiniTest::Spec
 
   def test_get_should_raise_if_410_returned_from_endpoint
     url = "http://some.endpoint/some.json"
-    stub_request(:get, url).to_return(:body => "{}", :status => 410)
+    stub_request(:get, url).to_return(body: "{}", status: 410)
     assert_raises GdsApi::HTTPGone do
       @client.get_json(url)
     end
@@ -441,7 +456,7 @@ class JsonClientTest < MiniTest::Spec
       config.always_raise_for_not_found = false
     end
     url = "http://some.endpoint/some.json"
-    stub_request(:get, url).to_return(:body => "{}", :status => 404)
+    stub_request(:get, url).to_return(body: "{}", status: 404)
     assert_nil @client.get_raw(url)
   ensure
     GdsApi.configure do |config|
@@ -457,7 +472,7 @@ class JsonClientTest < MiniTest::Spec
       config.always_raise_for_not_found = false
     end
     url = "http://some.endpoint/some.json"
-    stub_request(:get, url).to_return(:body => "{}", :status => 410)
+    stub_request(:get, url).to_return(body: "{}", status: 410)
     assert_nil @client.get_raw(url)
   ensure
     GdsApi.configure do |config|
@@ -467,7 +482,7 @@ class JsonClientTest < MiniTest::Spec
 
   def test_get_raw_should_raise_if_404_returned_from_endpoint
     url = "http://some.endpoint/some.json"
-    stub_request(:get, url).to_return(:body => "{}", :status => 404)
+    stub_request(:get, url).to_return(body: "{}", status: 404)
     assert_raises GdsApi::HTTPNotFound do
       @client.get_raw(url)
     end
@@ -475,7 +490,7 @@ class JsonClientTest < MiniTest::Spec
 
   def test_get_raw_should_be_nil_if_410_returned_from_endpoint
     url = "http://some.endpoint/some.json"
-    stub_request(:get, url).to_return(:body => "{}", :status => 410)
+    stub_request(:get, url).to_return(body: "{}", status: 410)
     assert_raises GdsApi::HTTPGone do
       @client.get_raw(url)
     end
@@ -483,7 +498,7 @@ class JsonClientTest < MiniTest::Spec
 
   def test_get_should_raise_error_if_non_404_non_410_error_code_returned_from_endpoint
     url = "http://some.endpoint/some.json"
-    stub_request(:get, url).to_return(:body => "{}", :status => 500)
+    stub_request(:get, url).to_return(body: "{}", status: 500)
     assert_raises GdsApi::HTTPServerError do
       @client.get_json(url)
     end
@@ -491,7 +506,7 @@ class JsonClientTest < MiniTest::Spec
 
   def test_get_should_raise_conflict_for_409
     url = "http://some.endpoint/some.json"
-    stub_request(:delete, url).to_return(:body => "{}", :status => 409)
+    stub_request(:delete, url).to_return(body: "{}", status: 409)
     assert_raises GdsApi::HTTPConflict do
       @client.delete_json!(url)
     end
@@ -501,60 +516,60 @@ class JsonClientTest < MiniTest::Spec
     url = "http://some.endpoint/some.json"
     new_url = "http://some.endpoint/other.json"
     stub_request(:get, url).to_return(
-      :body => "",
-      :status => 301,
-      :headers => {"Location" => new_url}
+      body: "",
+      status: 301,
+      headers: { "Location" => new_url }
     )
-    stub_request(:get, new_url).to_return(:body => '{"a": 1}', :status => 200)
+    stub_request(:get, new_url).to_return(body: '{"a": 1}', status: 200)
     result = @client.get_json(url)
-    assert_equal 1, result.a
+    assert_equal 1, result['a']
   end
 
   def test_get_should_follow_found_redirect
     url = "http://some.endpoint/some.json"
     new_url = "http://some.endpoint/other.json"
     stub_request(:get, url).to_return(
-      :body => "",
-      :status => 302,
-      :headers => {"Location" => new_url}
+      body: "",
+      status: 302,
+      headers: { "Location" => new_url }
     )
-    stub_request(:get, new_url).to_return(:body => '{"a": 1}', :status => 200)
+    stub_request(:get, new_url).to_return(body: '{"a": 1}', status: 200)
     result = @client.get_json(url)
-    assert_equal 1, result.a
+    assert_equal 1, result['a']
   end
 
   def test_get_should_follow_see_other
     url = "http://some.endpoint/some.json"
     new_url = "http://some.endpoint/other.json"
     stub_request(:get, url).to_return(
-      :body => "",
-      :status => 303,
-      :headers => {"Location" => new_url}
+      body: "",
+      status: 303,
+      headers: { "Location" => new_url }
     )
-    stub_request(:get, new_url).to_return(:body => '{"a": 1}', :status => 200)
+    stub_request(:get, new_url).to_return(body: '{"a": 1}', status: 200)
     result = @client.get_json(url)
-    assert_equal 1, result.a
+    assert_equal 1, result['a']
   end
 
   def test_get_should_follow_temporary_redirect
     url = "http://some.endpoint/some.json"
     new_url = "http://some.endpoint/other.json"
     stub_request(:get, url).to_return(
-      :body => "",
-      :status => 307,
-      :headers => {"Location" => new_url}
+      body: "",
+      status: 307,
+      headers: { "Location" => new_url }
     )
-    stub_request(:get, new_url).to_return(:body => '{"a": 1}', :status => 200)
+    stub_request(:get, new_url).to_return(body: '{"a": 1}', status: 200)
     result = @client.get_json(url)
-    assert_equal 1, result.a
+    assert_equal 1, result['a']
   end
 
   def test_should_handle_infinite_redirects
     url = "http://some.endpoint/some.json"
     redirect = {
-      :body => "",
-      :status => 302,
-      :headers => {"Location" => url}
+      body: "",
+      status: 302,
+      headers: { "Location" => url }
     }
 
     # Theoretically, we could set this up to mock out any number of requests
@@ -574,14 +589,14 @@ class JsonClientTest < MiniTest::Spec
     second_url = "http://some.endpoint/some-other.json"
 
     first_redirect = {
-      :body => "",
-      :status => 302,
-      :headers => {"Location" => second_url}
+      body: "",
+      status: 302,
+      headers: { "Location" => second_url }
     }
     second_redirect = {
-      :body => "",
-      :status => 302,
-      :headers => {"Location" => first_url}
+      body: "",
+      status: 302,
+      headers: { "Location" => first_url }
     }
 
     # See the comment in the above test for an explanation of this
@@ -596,7 +611,7 @@ class JsonClientTest < MiniTest::Spec
 
   def test_post_should_be_raise_if_404_returned_from_endpoint
     url = "http://some.endpoint/some.json"
-    stub_request(:post, url).to_return(:body => "{}", :status => 404)
+    stub_request(:post, url).to_return(body: "{}", status: 404)
     assert_raises(GdsApi::HTTPNotFound) do
       @client.post_json(url, {})
     end
@@ -604,7 +619,7 @@ class JsonClientTest < MiniTest::Spec
 
   def test_post_should_raise_error_if_non_404_error_code_returned_from_endpoint
     url = "http://some.endpoint/some.json"
-    stub_request(:post, url).to_return(:body => "{}", :status => 500)
+    stub_request(:post, url).to_return(body: "{}", status: 500)
     assert_raises GdsApi::HTTPServerError do
       @client.post_json(url, {})
     end
@@ -614,9 +629,9 @@ class JsonClientTest < MiniTest::Spec
     url = "http://some.endpoint/some.json"
     new_url = "http://some.endpoint/other.json"
     stub_request(:post, url).to_return(
-      :body => "",
-      :status => 302,
-      :headers => {"Location" => new_url}
+      body: "",
+      status: 302,
+      headers: { "Location" => new_url }
     )
     assert_raises GdsApi::HTTPErrorResponse do
       @client.post_json(url, {})
@@ -625,7 +640,7 @@ class JsonClientTest < MiniTest::Spec
 
   def test_put_should_be_raise_if_404_returned_from_endpoint
     url = "http://some.endpoint/some.json"
-    stub_request(:put, url).to_return(:body => "{}", :status => 404)
+    stub_request(:put, url).to_return(body: "{}", status: 404)
 
     assert_raises(GdsApi::HTTPNotFound) do
       @client.put_json(url, {})
@@ -634,33 +649,33 @@ class JsonClientTest < MiniTest::Spec
 
   def test_put_should_raise_error_if_non_404_error_code_returned_from_endpoint
     url = "http://some.endpoint/some.json"
-    stub_request(:put, url).to_return(:body => "{}", :status => 500)
+    stub_request(:put, url).to_return(body: "{}", status: 500)
     assert_raises GdsApi::HTTPServerError do
       @client.put_json(url, {})
     end
   end
 
   def empty_response
-    net_http_response = stub(:body => '{}')
+    net_http_response = stub(body: '{}')
     GdsApi::Response.new(net_http_response)
   end
 
   def test_put_json_does_put_with_json_encoded_packet
     url = "http://some.endpoint/some.json"
     payload = {a: 1}
-    stub_request(:put, url).with(body: payload.to_json).to_return(:body => "{}", :status => 200)
+    stub_request(:put, url).with(body: payload.to_json).to_return(body: "{}", status: 200)
     assert_equal({}, @client.put_json(url, payload).to_hash)
   end
 
   def test_does_not_encode_json_if_payload_is_nil
     url = "http://some.endpoint/some.json"
-    stub_request(:put, url).with(body: nil).to_return(:body => "{}", :status => 200)
+    stub_request(:put, url).with(body: nil).to_return(body: "{}", status: 200)
     assert_equal({}, @client.put_json(url, nil).to_hash)
   end
 
   def test_can_build_custom_response_object
     url = "http://some.endpoint/some.json"
-    stub_request(:get, url).to_return(:body => "Hello there!")
+    stub_request(:get, url).to_return(body: "Hello there!")
 
     response = @client.get_json(url) { |http_response| http_response.body }
     assert response.is_a? String
@@ -669,7 +684,7 @@ class JsonClientTest < MiniTest::Spec
 
   def test_raises_on_custom_response_404
     url = "http://some.endpoint/some.json"
-    stub_request(:get, url).to_return(:body => "", :status => 404)
+    stub_request(:get, url).to_return(body: "", status: 404)
 
     assert_raises(GdsApi::HTTPNotFound) do
       @client.get_json(url, &:body)
@@ -678,35 +693,40 @@ class JsonClientTest < MiniTest::Spec
 
   def test_can_build_custom_response_object_in_bang_method
     url = "http://some.endpoint/some.json"
-    stub_request(:get, url).to_return(:body => "Hello there!")
+    stub_request(:get, url).to_return(body: "Hello there!")
 
     response = @client.get_json!(url) { |http_response| http_response.body }
     assert response.is_a? String
     assert_equal "Hello there!", response
   end
 
+  # TODO: When we remove `GdsApi.config.hash_response_for_requests`, this test
+  # no longer makes sense and it should be deleted.
   def test_can_convert_response_to_ostruct
-    url = "http://some.endpoint/some.json"
-    payload = {a: 1}
-    stub_request(:put, url).with(body: payload.to_json).to_return(:body => '{"a":1}', :status => 200)
-    response = @client.put_json(url, payload)
-    assert_equal(OpenStruct.new(a: 1), response.to_ostruct)
+    with_hash_response_for_requests_disabled do
+      url = "http://some.endpoint/some.json"
+      payload = { a: 1 }
+      stub_request(:put, url).with(body: payload.to_json).to_return(body: '{"a":1}', status: 200)
+      response = @client.put_json(url, payload)
+      assert_equal(OpenStruct.new(a: 1), response.to_ostruct)
+    end
   end
 
   def test_can_access_attributes_of_response_directly
     url = "http://some.endpoint/some.json"
-    payload = {a: 1}
-    stub_request(:put, url).with(body: payload.to_json).to_return(:body => '{"a":{"b":2}}', :status => 200)
+    payload = { a: 1 }
+    stub_request(:put, url).with(body: payload.to_json).to_return(body: '{"a":{"b":2}}', status: 200)
     response = @client.put_json(url, payload)
-    assert_equal 2, response.a.b
+    assert_equal 2, response['a']['b']
   end
 
   def test_cant_access_attributes_of_response_directly_if_hash_only
     url = "http://some.endpoint/some.json"
-    payload = {a: 1}
-    stub_request(:put, url).with(body: payload.to_json).to_return(:body => '{"a":{"b":2}}', :status => 200)
+    payload = { a: 1 }
+    stub_request(:put, url).with(body: payload.to_json).to_return(body: '{"a":{"b":2}}', status: 200)
     response = @client.put_json(url, payload)
 
+    @old_hash_response_for_requests = GdsApi.config.hash_response_for_requests
     GdsApi.configure do |config|
       config.hash_response_for_requests = true
     end
@@ -716,28 +736,36 @@ class JsonClientTest < MiniTest::Spec
     end
 
     GdsApi.configure do |config|
-      config.hash_response_for_requests = false
+      config.hash_response_for_requests = @old_hash_response_for_requests
     end
   end
 
+  # TODO: When we remove `GdsApi.config.hash_response_for_requests`, this test
+  # no longer makes sense and it should be deleted.
   def test_accessing_non_existent_attribute_of_response_returns_nil
-    url = "http://some.endpoint/some.json"
-    stub_request(:put, url).to_return(:body => '{"a":1}', :status => 200)
-    response = @client.put_json(url, {})
-    assert_equal nil, response.does_not_exist
+    with_hash_response_for_requests_disabled do
+      url = "http://some.endpoint/some.json"
+      stub_request(:put, url).to_return(body: '{"a":1}', status: 200)
+      response = @client.put_json(url, {})
+      assert_equal nil, response.does_not_exist
+    end
   end
 
+  # TODO: When we remove `GdsApi.config.hash_response_for_requests`, this test
+  # no longer makes sense and it should be deleted.
   def test_response_does_not_claim_to_respond_to_methods_corresponding_to_non_existent_attributes
-    # This mimics the behaviour of OpenStruct
-    url = "http://some.endpoint/some.json"
-    stub_request(:put, url).to_return(:body => '{"a":1}', :status => 200)
-    response = @client.put_json(url, {})
-    assert ! response.respond_to?(:does_not_exist)
+    with_hash_response_for_requests_disabled do
+      # This mimics the behaviour of OpenStruct
+      url = "http://some.endpoint/some.json"
+      stub_request(:put, url).to_return(body: '{"a":1}', status: 200)
+      response = @client.put_json(url, {})
+      assert ! response.respond_to?(:does_not_exist)
+    end
   end
 
   def test_a_response_is_always_considered_present_and_not_blank
     url = "http://some.endpoint/some.json"
-    stub_request(:put, url).to_return(:body => '{"a":1}', :status => 200)
+    stub_request(:put, url).to_return(body: '{"a":1}', status: 200)
     response = @client.put_json(url, {})
     assert ! response.blank?
     assert response.present?
@@ -747,10 +775,10 @@ class JsonClientTest < MiniTest::Spec
     client = GdsApi::JsonClient.new(basic_auth: {user: 'user', password: 'password'})
 
     stub_request(:put, "http://user:password@some.endpoint/some.json").
-      to_return(:body => '{"a":1}', :status => 200)
+      to_return(body: '{"a":1}', status: 200)
 
     response = client.put_json("http://some.endpoint/some.json", {})
-    assert_equal 1, response.a
+    assert_equal 1, response['a']
   end
 
   def test_client_can_use_bearer_token
@@ -759,15 +787,15 @@ class JsonClientTest < MiniTest::Spec
       merge('Authorization' => 'Bearer SOME_BEARER_TOKEN')
 
     stub_request(:put, "http://some.other.endpoint/some.json").
-      with(:headers => expected_headers).
-      to_return(:body => '{"a":2}', :status => 200)
+      with(headers: expected_headers).
+      to_return(body: '{"a":2}', status: 200)
 
     response = client.put_json("http://some.other.endpoint/some.json", {})
-    assert_equal 2, response.a
+    assert_equal 2, response['a']
   end
 
   def test_client_can_set_custom_headers_on_gets
-    stub_request(:get, "http://some.other.endpoint/some.json").to_return(:status => 200)
+    stub_request(:get, "http://some.other.endpoint/some.json").to_return(status: 200)
 
     response = GdsApi::JsonClient.new.get_json("http://some.other.endpoint/some.json",
                                                { "HEADER-A" => "B", "HEADER-C" => "D" })
@@ -779,7 +807,7 @@ class JsonClientTest < MiniTest::Spec
   end
 
   def test_client_can_set_custom_headers_on_posts
-    stub_request(:post, "http://some.other.endpoint/some.json").to_return(:status => 200)
+    stub_request(:post, "http://some.other.endpoint/some.json").to_return(status: 200)
 
     response = GdsApi::JsonClient.new.post_json("http://some.other.endpoint/some.json", {},
                                                 { "HEADER-A" => "B", "HEADER-C" => "D" })
@@ -791,7 +819,7 @@ class JsonClientTest < MiniTest::Spec
   end
 
   def test_client_can_set_custom_headers_on_puts
-    stub_request(:put, "http://some.other.endpoint/some.json").to_return(:status => 200)
+    stub_request(:put, "http://some.other.endpoint/some.json").to_return(status: 200)
 
     response = GdsApi::JsonClient.new.put_json("http://some.other.endpoint/some.json", {},
                                                { "HEADER-A" => "B", "HEADER-C" => "D" })
@@ -803,7 +831,7 @@ class JsonClientTest < MiniTest::Spec
   end
 
   def test_client_can_set_custom_headers_on_deletes
-    stub_request(:delete, "http://some.other.endpoint/some.json").to_return(:status => 200)
+    stub_request(:delete, "http://some.other.endpoint/some.json").to_return(status: 200)
 
     response = GdsApi::JsonClient.new.delete_json("http://some.other.endpoint/some.json",
                                                   { "HEADER-A" => "B", "HEADER-C" => "D" })
@@ -819,7 +847,7 @@ class JsonClientTest < MiniTest::Spec
     GdsApi::GovukHeaders.set_header(:govuk_request_id, "12345")
     GdsApi::GovukHeaders.set_header(:govuk_original_url, "http://example.com")
 
-    stub_request(:get, "http://some.other.endpoint/some.json").to_return(:status => 200)
+    stub_request(:get, "http://some.other.endpoint/some.json").to_return(status: 200)
 
     GdsApi::JsonClient.new.get_json("http://some.other.endpoint/some.json")
 
@@ -831,7 +859,7 @@ class JsonClientTest < MiniTest::Spec
 
   def test_govuk_headers_ignored_in_requests_if_not_present
     GdsApi::GovukHeaders.set_header(:x_govuk_authenticated_user, "")
-    stub_request(:get, "http://some.other.endpoint/some.json").to_return(:status => 200)
+    stub_request(:get, "http://some.other.endpoint/some.json").to_return(status: 200)
 
     GdsApi::JsonClient.new.get_json("http://some.other.endpoint/some.json")
 
@@ -841,7 +869,7 @@ class JsonClientTest < MiniTest::Spec
   end
 
   def test_additional_headers_passed_in_do_not_get_modified
-    stub_request(:get, "http://some.other.endpoint/some.json").to_return(:status => 200)
+    stub_request(:get, "http://some.other.endpoint/some.json").to_return(status: 200)
 
     headers = { 'HEADER-A' => 'A' }
     GdsApi::JsonClient.new.get_json("http://some.other.endpoint/some.json", headers)
@@ -852,7 +880,11 @@ class JsonClientTest < MiniTest::Spec
   def test_client_can_decompress_gzip_responses
     url = "http://some.endpoint/some.json"
     # {"test": "hello"}
-    stub_request(:get, url).to_return(:body => "\u001F\x8B\b\u0000Q\u000F\u0019Q\u0000\u0003\xABVP*I-.Q\xB2RP\xCAH\xCD\xC9\xC9WR\xA8\u0005\u0000\xD1C\u0018\xFE\u0013\u0000\u0000\u0000", :status => 200, :headers => { 'Content-Encoding' => 'gzip' })
+    stub_request(:get, url).to_return(
+      body: "\u001F\x8B\b\u0000Q\u000F\u0019Q\u0000\u0003\xABVP*I-.Q\xB2RP\xCAH\xCD\xC9\xC9WR\xA8\u0005\u0000\xD1C\u0018\xFE\u0013\u0000\u0000\u0000",
+      status: 200,
+      headers: { 'Content-Encoding' => 'gzip' }
+    )
     response = @client.get_json(url)
 
     assert_equal "hello", response["test"]
@@ -861,11 +893,11 @@ class JsonClientTest < MiniTest::Spec
   def test_client_can_post_multipart_responses
     url = "http://some.endpoint/some.json"
     stub_request(:post, url).
-      with(:body => %r{------RubyFormBoundary\w+\r\nContent-Disposition: form-data; name="a"\r\n\r\n123\r\n------RubyFormBoundary\w+--\r\n},
-           :headers => {
+      with(body: %r{------RubyFormBoundary\w+\r\nContent-Disposition: form-data; name="a"\r\n\r\n123\r\n------RubyFormBoundary\w+--\r\n},
+           headers: {
              'Content-Type' => %r{multipart/form-data; boundary=----RubyFormBoundary\w+}
            }).
-      to_return(:body => '{"b": "1"}', :status => 200)
+      to_return(body: '{"b": "1"}', status: 200)
 
     response = @client.post_multipart("http://some.endpoint/some.json", {"a" => "123"})
     assert_equal "1", response["b"]
@@ -873,7 +905,7 @@ class JsonClientTest < MiniTest::Spec
 
   def test_post_multipart_should_raise_exception_if_not_found
     url = "http://some.endpoint/some.json"
-    stub_request(:post, url).to_return(:body => '', :status => 404)
+    stub_request(:post, url).to_return(body: '', status: 404)
 
     assert_raises GdsApi::HTTPNotFound do
       @client.post_multipart("http://some.endpoint/some.json", {"a" => "123"})
@@ -882,7 +914,7 @@ class JsonClientTest < MiniTest::Spec
 
   def test_post_multipart_should_raise_error_responses
     url = "http://some.endpoint/some.json"
-    stub_request(:post, url).to_return(:body => '', :status => 500)
+    stub_request(:post, url).to_return(body: '', status: 500)
 
     assert_raises GdsApi::HTTPServerError do
       @client.post_multipart("http://some.endpoint/some.json", {"a" => "123"})
@@ -893,11 +925,11 @@ class JsonClientTest < MiniTest::Spec
   def test_client_can_put_multipart_responses
     url = "http://some.endpoint/some.json"
     stub_request(:put, url).
-      with(:body => %r{------RubyFormBoundary\w+\r\nContent-Disposition: form-data; name="a"\r\n\r\n123\r\n------RubyFormBoundary\w+--\r\n},
-           :headers => {
+      with(body: %r{------RubyFormBoundary\w+\r\nContent-Disposition: form-data; name="a"\r\n\r\n123\r\n------RubyFormBoundary\w+--\r\n},
+           headers: {
              'Content-Type' => %r{multipart/form-data; boundary=----RubyFormBoundary\w+}
            }).
-      to_return(:body => '{"b": "1"}', :status => 200)
+      to_return(body: '{"b": "1"}', status: 200)
 
     response = @client.put_multipart("http://some.endpoint/some.json", {"a" => "123"})
     assert_equal "1", response["b"]
@@ -905,7 +937,7 @@ class JsonClientTest < MiniTest::Spec
 
   def test_put_multipart_should_raise_exception_if_not_found
     url = "http://some.endpoint/some.json"
-    stub_request(:put, url).to_return(:body => '', :status => 404)
+    stub_request(:put, url).to_return(body: '', status: 404)
 
     assert_raises GdsApi::HTTPNotFound do
       @client.put_multipart("http://some.endpoint/some.json", {"a" => "123"})
@@ -914,7 +946,7 @@ class JsonClientTest < MiniTest::Spec
 
   def test_put_multipart_should_raise_error_responses
     url = "http://some.endpoint/some.json"
-    stub_request(:put, url).to_return(:body => '', :status => 500)
+    stub_request(:put, url).to_return(body: '', status: 500)
 
     assert_raises GdsApi::HTTPServerError do
       @client.put_multipart("http://some.endpoint/some.json", {"a" => "123"})
@@ -935,7 +967,7 @@ class JsonClientTest < MiniTest::Spec
     ENV['GOVUK_APP_NAME'] = "api-tests"
 
     url = "http://some.other.endpoint/some.json"
-    stub_request(:get, url).to_return(:status => 200)
+    stub_request(:get, url).to_return(status: 200)
 
     GdsApi::JsonClient.new.get_json(url)
 

--- a/test/json_client_test.rb
+++ b/test/json_client_test.rb
@@ -384,6 +384,8 @@ class JsonClientTest < MiniTest::Spec
     end
   end
 
+  # TODO: always_raise_for_not_found will be gone by December 1st, 2016. We will
+  # need to remove it from this test.
   def test_get_should_be_nil_if_404_returned_from_endpoint_and_always_raise_for_not_found_is_disabled
     @old_always_raise = GdsApi.config.always_raise_for_not_found
     GdsApi.configure do |config|
@@ -391,6 +393,7 @@ class JsonClientTest < MiniTest::Spec
     end
     url = "http://some.endpoint/some.json"
     stub_request(:get, url).to_return(:body => "{}", :status => 404)
+
     assert_nil @client.get_json(url)
   ensure
     GdsApi.configure do |config|
@@ -398,6 +401,8 @@ class JsonClientTest < MiniTest::Spec
     end
   end
 
+  # TODO: always_raise_for_not_found will be gone by December 1st, 2016. We will
+  # need to remove it from this test.
   def test_get_should_be_nil_if_410_returned_from_endpoint_and_always_raise_for_not_found_is_disabled
     @old_always_raise = GdsApi.config.always_raise_for_not_found
     GdsApi.configure do |config|
@@ -412,38 +417,24 @@ class JsonClientTest < MiniTest::Spec
     end
   end
 
-  def test_get_should_be_nil_if_404_returned_from_endpoint_and_always_raise_for_not_found_is_enabled
-    @old_always_raise = GdsApi.config.always_raise_for_not_found
-    GdsApi.configure do |config|
-      config.always_raise_for_not_found = true
-    end
+  def test_get_should_raise_if_404_returned_from_endpoint
     url = "http://some.endpoint/some.json"
     stub_request(:get, url).to_return(:body => "{}", :status => 404)
     assert_raises GdsApi::HTTPNotFound do
       @client.get_json(url)
     end
-  ensure
-    GdsApi.configure do |config|
-      config.always_raise_for_not_found = @old_always_raise
-    end
   end
 
-  def test_get_should_be_nil_if_410_returned_from_endpoint_and_always_raise_for_not_found_is_enabled
-    @old_always_raise = GdsApi.config.always_raise_for_not_found
-    GdsApi.configure do |config|
-      config.always_raise_for_not_found = true
-    end
+  def test_get_should_raise_if_410_returned_from_endpoint
     url = "http://some.endpoint/some.json"
     stub_request(:get, url).to_return(:body => "{}", :status => 410)
     assert_raises GdsApi::HTTPGone do
       @client.get_json(url)
     end
-  ensure
-    GdsApi.configure do |config|
-      config.always_raise_for_not_found = @old_always_raise
-    end
   end
 
+  # TODO: always_raise_for_not_found will be gone by December 1st, 2016. We will
+  # need to remove it from this test.
   def test_get_raw_should_be_nil_if_404_returned_from_endpoint_and_always_raise_for_not_found_is_disabled
     @old_always_raise = GdsApi.config.always_raise_for_not_found
     GdsApi.configure do |config|
@@ -458,6 +449,8 @@ class JsonClientTest < MiniTest::Spec
     end
   end
 
+  # TODO: always_raise_for_not_found will be gone by December 1st, 2016. We will
+  # need to remove it from this test.
   def test_get_raw_should_be_nil_if_410_returned_from_endpoint_and_always_raise_for_not_found_is_disabled
     @old_always_raise = GdsApi.config.always_raise_for_not_found
     GdsApi.configure do |config|
@@ -472,35 +465,19 @@ class JsonClientTest < MiniTest::Spec
     end
   end
 
-  def test_get_raw_should_be_nil_if_404_returned_from_endpoint_and_always_raise_for_not_found_is_enabled
-    @old_always_raise = GdsApi.config.always_raise_for_not_found
-    GdsApi.configure do |config|
-      config.always_raise_for_not_found = true
-    end
+  def test_get_raw_should_raise_if_404_returned_from_endpoint
     url = "http://some.endpoint/some.json"
     stub_request(:get, url).to_return(:body => "{}", :status => 404)
     assert_raises GdsApi::HTTPNotFound do
       @client.get_raw(url)
     end
-  ensure
-    GdsApi.configure do |config|
-      config.always_raise_for_not_found = @old_always_raise
-    end
   end
 
-  def test_get_raw_should_be_nil_if_410_returned_from_endpoint_and_always_raise_for_not_found_is_enabled
-    @old_always_raise = GdsApi.config.always_raise_for_not_found
-    GdsApi.configure do |config|
-      config.always_raise_for_not_found = true
-    end
+  def test_get_raw_should_be_nil_if_410_returned_from_endpoint
     url = "http://some.endpoint/some.json"
     stub_request(:get, url).to_return(:body => "{}", :status => 410)
     assert_raises GdsApi::HTTPGone do
       @client.get_raw(url)
-    end
-  ensure
-    GdsApi.configure do |config|
-      config.always_raise_for_not_found = @old_always_raise
     end
   end
 
@@ -617,10 +594,12 @@ class JsonClientTest < MiniTest::Spec
     end
   end
 
-  def test_post_should_be_nil_if_404_returned_from_endpoint
+  def test_post_should_be_raise_if_404_returned_from_endpoint
     url = "http://some.endpoint/some.json"
     stub_request(:post, url).to_return(:body => "{}", :status => 404)
-    assert_nil @client.post_json(url, {})
+    assert_raises(GdsApi::HTTPNotFound) do
+      @client.post_json(url, {})
+    end
   end
 
   def test_post_should_raise_error_if_non_404_error_code_returned_from_endpoint
@@ -644,10 +623,13 @@ class JsonClientTest < MiniTest::Spec
     end
   end
 
-  def test_put_should_be_nil_if_404_returned_from_endpoint
+  def test_put_should_be_raise_if_404_returned_from_endpoint
     url = "http://some.endpoint/some.json"
     stub_request(:put, url).to_return(:body => "{}", :status => 404)
-    assert_nil @client.put_json(url, {})
+
+    assert_raises(GdsApi::HTTPNotFound) do
+      @client.put_json(url, {})
+    end
   end
 
   def test_put_should_raise_error_if_non_404_error_code_returned_from_endpoint
@@ -685,12 +667,13 @@ class JsonClientTest < MiniTest::Spec
     assert_equal "Hello there!", response
   end
 
-  def test_responds_with_nil_on_custom_response_404
+  def test_raises_on_custom_response_404
     url = "http://some.endpoint/some.json"
     stub_request(:get, url).to_return(:body => "", :status => 404)
 
-    response = @client.get_json(url) { |http_response| http_response.body }
-    assert_nil response
+    assert_raises(GdsApi::HTTPNotFound) do
+      @client.get_json(url, &:body)
+    end
   end
 
   def test_can_build_custom_response_object_in_bang_method

--- a/test/licence_application_api_test.rb
+++ b/test/licence_application_api_test.rb
@@ -72,10 +72,12 @@ EOS
     assert_nil api.details_for_licence(nil)
   end
 
-  def test_should_return_nil_if_licence_is_unrecognised
+  def test_should_raise_if_licence_is_unrecognised
     licence_does_not_exist('bloop')
 
-    assert_nil api.details_for_licence("bloop")
+    assert_raises(GdsApi::HTTPNotFound) do
+      api.details_for_licence("bloop")
+    end
   end
 
   def test_should_provide_full_licence_details_for_canonical_id
@@ -90,16 +92,20 @@ EOS
     assert_equal expected, api.details_for_licence("590001").to_hash
   end
 
-  def test_should_return_nil_for_bad_snac_code_entry
+  def test_should_raise_for_bad_snac_code_entry
     licence_does_not_exist('590001/bleep')
 
-    assert_nil api.details_for_licence("590001", "bleep")
+    assert_raises(GdsApi::HTTPNotFound) do
+      api.details_for_licence("590001", "bleep")
+    end
   end
 
-  def test_should_return_nil_for_bad_licence_id_and_snac_code
+  def test_should_raise_for_bad_licence_id_and_snac_code
     licence_does_not_exist('bloop/bleep')
 
-    assert_nil api.details_for_licence("bloop", "bleep")
+    assert_raises(GdsApi::HTTPNotFound) do
+      api.details_for_licence("bloop", "bleep")
+    end
   end
 
   def test_should_return_error_message_to_pick_a_relevant_snac_code_for_the_provided_licence_id
@@ -108,7 +114,9 @@ EOS
       to_return(status: 404,
                 body: "{\"error\": \"No authorities found for the licence 590001 and for the snacCode sw10\"}")
 
-    assert_nil api.details_for_licence("590001", "sw10")
+    assert_raises(GdsApi::HTTPNotFound) do
+      api.details_for_licence("590001", "sw10")
+    end
   end
 
   def test_should_return_full_licence_details_with_location_specific_information

--- a/test/list_response_test.rb
+++ b/test/list_response_test.rb
@@ -80,12 +80,27 @@ describe GdsApi::ListResponse do
           ]
         }
       }
-      @p1_response = stub(:body => page_1.to_json, :status => 200, 
-         :headers => {:link => '<http://www.example.com/1>; rel="self", <http://www.example.com/2>; rel="next"'})
-      @p2_response = stub(:body => page_2.to_json, :status => 200, 
-         :headers => {:link => '<http://www.example.com/2>; rel="self", <http://www.example.com/3>; rel="next", <http://www.example.com/1>; rel="previous"'})
-      @p3_response = stub(:body => page_3.to_json, :status => 200, 
-         :headers => {:link => '<http://www.example.com/3>; rel="self", <http://www.example.com/1>; rel="previous"'})
+      @p1_response = stub(
+        body: page_1.to_json,
+        status: 200,
+        headers: {
+          link: '<http://www.example.com/1>; rel="self", <http://www.example.com/2>; rel="next"'
+        }
+      )
+      @p2_response = stub(
+        body: page_2.to_json,
+        status: 200,
+        headers: {
+          link: '<http://www.example.com/2>; rel="self", <http://www.example.com/3>; rel="next", <http://www.example.com/1>; rel="previous"'
+        }
+      )
+      @p3_response = stub(
+        body: page_3.to_json,
+        status: 200,
+        headers: {
+          link: '<http://www.example.com/3>; rel="self", <http://www.example.com/1>; rel="previous"'
+        }
+      )
 
       @client = stub()
       @client.stubs(:get_list!).with("http://www.example.com/1").returns(GdsApi::ListResponse.new(@p1_response, @client))
@@ -97,7 +112,7 @@ describe GdsApi::ListResponse do
       it "should allow accessing the next page" do
         resp = GdsApi::ListResponse.new(@p1_response, @client)
         assert resp.has_next_page?
-        assert_equal %w(foo2 bar2), resp.next_page.results
+        assert_equal %w(foo2 bar2), resp.next_page['results']
       end
 
       it "should return nil with no next page" do
@@ -121,7 +136,7 @@ describe GdsApi::ListResponse do
       it "should allow accessing the previous page" do
         resp = GdsApi::ListResponse.new(@p2_response, @client)
         assert resp.has_previous_page?
-        assert_equal %w(foo1 bar1), resp.previous_page.results
+        assert_equal %w(foo1 bar1), resp.previous_page['results']
       end
 
       it "should return nil with no previous page" do

--- a/test/local_links_manager_api_test.rb
+++ b/test/local_links_manager_api_test.rb
@@ -145,25 +145,28 @@ describe GdsApi::LocalLinksManager do
     end
 
     describe "when making request with invalid required parameters" do
-      it "returns nil when authority_slug is invalid" do
+      it "raises when authority_slug is invalid" do
         local_links_manager_does_not_have_required_objects("hogwarts", 2)
 
-        response = @api.local_link("hogwarts", 2)
-        assert_equal nil, response
+        assert_raises(GdsApi::HTTPNotFound) do
+          @api.local_link("hogwarts", 2)
+        end
       end
 
-      it "returns nil when LGSL is invalid" do
+      it "raises when LGSL is invalid" do
         local_links_manager_does_not_have_required_objects("blackburn", 999)
 
-        response = @api.local_link("blackburn", 999)
-        assert_equal nil, response
+        assert_raises(GdsApi::HTTPNotFound) do
+          @api.local_link("blackburn", 999)
+        end
       end
 
-      it "returns nil when the LGSL and LGIL combination is invalid" do
+      it "raises when the LGSL and LGIL combination is invalid" do
         local_links_manager_does_not_have_required_objects("blackburn", 2, 9)
 
-        response = @api.local_link("blackburn", 2, 9)
-        assert_equal nil, response
+        assert_raises(GdsApi::HTTPNotFound) do
+          @api.local_link("blackburn", 2, 9)
+        end
       end
     end
   end
@@ -223,11 +226,10 @@ describe GdsApi::LocalLinksManager do
     end
 
     describe 'when making a request with invalid required parameters' do
-      it "returns nil when authority_slug is invalid" do
+      it "raises when authority_slug is invalid" do
         local_links_manager_does_not_have_an_authority("hogwarts")
 
-        response = @api.local_authority("hogwarts")
-        assert_equal nil, response
+        assert_raises(GdsApi::HTTPNotFound) { @api.local_authority("hogwarts") }
       end
     end
   end

--- a/test/mapit_test.rb
+++ b/test/mapit_test.rb
@@ -85,7 +85,7 @@ describe GdsApi::Mapit do
     it "should return and empty result for an unknown area type" do
       response = @api.areas_for_type('FOO')
 
-      assert_empty response
+      assert_empty response.parsed_content
     end
   end
 

--- a/test/mapit_test.rb
+++ b/test/mapit_test.rb
@@ -45,10 +45,12 @@ describe GdsApi::Mapit do
       assert_equal "30UN", response.areas.last.codes['ons']
     end
 
-    it "should return nil if a postcode doesn't exist" do
+    it "should raise if a postcode doesn't exist" do
       mapit_does_not_have_a_postcode("SW1A 1AA")
 
-      assert_nil @api.location_for_postcode("SW1A 1AA")
+      assert_raises(GdsApi::HTTPNotFound) do
+        @api.location_for_postcode("SW1A 1AA")
+      end
     end
 
     it "should return 400 for an invalid postcode" do
@@ -109,7 +111,9 @@ describe GdsApi::Mapit do
     end
 
     it "should return 404 for a missing area of a certain code type" do
-      assert_nil @api.area_for_code('govuk_slug', 'neverland')
+      assert_raises(GdsApi::HTTPNotFound) do
+        @api.area_for_code('govuk_slug', 'neverland')
+      end
     end
   end
 end

--- a/test/need_api_test.rb
+++ b/test/need_api_test.rb
@@ -192,9 +192,12 @@ describe GdsApi::NeedApi do
       assert_equal "good things", need_response.benefit
     end
 
-    it "should return nil for a missing need" do
+    it "should raise for a missing need" do
       need_api_has_no_need(100600)
-      assert_nil @api.need(100600)
+
+      assert_raises(GdsApi::HTTPNotFound) do
+        @api.need(100600)
+      end
     end
   end
 

--- a/test/need_api_test.rb
+++ b/test/need_api_test.rb
@@ -38,24 +38,24 @@ describe GdsApi::NeedApi do
       needs = @api.needs_by_id(1,2,3)
 
       assert_equal 3, needs.count
-      assert_equal %w(1 2 3), needs.map(&:id)
-      assert_equal "apply for a primary school place", needs.results[0].goal
-      assert_equal "find out about becoming a British citizen", needs.results[1].goal
-      assert_equal "find out about unemployment benefits", needs.results[2].goal
+      assert_equal %w(1 2 3), needs.map { |need| need['id'] }
+      assert_equal "apply for a primary school place", needs['results'][0]['goal']
+      assert_equal "find out about becoming a British citizen", needs['results'][1]['goal']
+      assert_equal "find out about unemployment benefits", needs['results'][2]['goal']
     end
 
     it "makes the same request regardless of the order of the IDs" do
       needs = @api.needs_by_id(2,1,3)
 
       assert_equal 3, needs.count
-      assert_equal %w(1 2 3), needs.map(&:id)
+      assert_equal %w(1 2 3), needs.map { |need| need['id'] }
     end
 
     it "correctly sorts IDs requested as strings" do
       needs = @api.needs_by_id(%w(02 3 1))
 
       assert_equal 3, needs.count
-      assert_equal %w(1 2 3), needs.map(&:id)
+      assert_equal %w(1 2 3), needs.map { |need| need['id'] }
     end
   end
 
@@ -109,12 +109,30 @@ describe GdsApi::NeedApi do
       assert_requested(req)
       assert_equal 2, needs.count
 
-      assert_equal ["parent", "user"], needs.map(&:role)
-      assert_equal ["apply for a primary school place", "find out about becoming a British citizen"], needs.map(&:goal)
-      assert_equal ["my child can start school", "i can take the correct steps to apply for citizenship"], needs.map(&:benefit)
+      assert_equal %w(parent user), needs.map { |need| need['role'] }
+      assert_equal(
+        [
+          "apply for a primary school place",
+          "find out about becoming a British citizen"
+        ],
+        needs.map { |need| need['goal'] }
+      )
+      assert_equal(
+        [
+          "my child can start school",
+          "i can take the correct steps to apply for citizenship"
+        ],
+        needs.map { |need| need['benefit'] }
+      )
 
-      assert_equal "department-for-education", needs.first.organisations.first.id
-      assert_equal "Department for Education", needs.first.organisations.first.name
+      assert_equal(
+        "department-for-education",
+        needs.first['organisations'].first['id']
+      )
+      assert_equal(
+        "Department for Education",
+        needs.first['organisations'].first['name']
+      )
     end
   end
 
@@ -189,7 +207,7 @@ describe GdsApi::NeedApi do
       need_api_has_need(need)
 
       need_response = @api.need(100500)
-      assert_equal "good things", need_response.benefit
+      assert_equal "good things", need_response['benefit']
     end
 
     it "should raise for a missing need" do

--- a/test/organisations_api_test.rb
+++ b/test/organisations_api_test.rb
@@ -16,8 +16,8 @@ describe GdsApi::Organisations do
       organisations_api_has_organisations(organisation_slugs)
 
       response = @api.organisations
-      assert_equal organisation_slugs, response.map {|r| r.details.slug }
-      assert_equal "Tea Agency", response.results[1].title
+      assert_equal organisation_slugs, response.map { |r| r['details']['slug'] }
+      assert_equal "Tea Agency", response['results'][1]['title']
     end
 
     it "should handle the pagination" do
@@ -25,7 +25,10 @@ describe GdsApi::Organisations do
       organisations_api_has_organisations(organisation_slugs)
 
       response = @api.organisations
-      assert_equal organisation_slugs, response.with_subsequent_pages.map {|r| r.details.slug }
+      assert_equal(
+        organisation_slugs,
+        response.with_subsequent_pages.map { |r| r['details']['slug'] }
+      )
     end
 
     it "should raise error if endpoint 404s" do
@@ -41,7 +44,7 @@ describe GdsApi::Organisations do
       organisations_api_has_organisation('ministry-of-fun')
 
       response = @api.organisation('ministry-of-fun')
-      assert_equal 'Ministry Of Fun', response.title
+      assert_equal 'Ministry Of Fun', response['title']
     end
 
     it "should raise for a non-existent organisation" do

--- a/test/organisations_api_test.rb
+++ b/test/organisations_api_test.rb
@@ -44,10 +44,12 @@ describe GdsApi::Organisations do
       assert_equal 'Ministry Of Fun', response.title
     end
 
-    it "should return nil for a non-existent organisation" do
+    it "should raise for a non-existent organisation" do
       organisations_api_does_not_have_organisation('non-existent')
 
-      assert_nil @api.organisation('non-existent')
+      assert_raises(GdsApi::HTTPNotFound) do
+        @api.organisation('non-existent')
+      end
     end
   end
 end

--- a/test/panopticon_test.rb
+++ b/test/panopticon_test.rb
@@ -55,11 +55,13 @@ describe GdsApi::Panopticon do
     assert_equal 1, api.get_json(url)['a']
   end
 
-  it 'returns nil if the endpoint returns 404' do
+  it 'raises if the endpoint returns 404' do
     url = "#{base_api_endpoint}/some.json"
     stub_request(:get, url).to_return(status: Rack::Utils.status_code(:not_found))
 
-    assert_nil api.get_json(url)
+    assert_raises(GdsApi::HTTPNotFound) do
+      api.get_json(url)
+    end
   end
 
   it 'constructs the correct URL for a slug' do

--- a/test/panopticon_test.rb
+++ b/test/panopticon_test.rb
@@ -39,7 +39,7 @@ describe GdsApi::Panopticon do
     panopticon_has_metadata(basic_artefact)
 
     artefact = api.artefact_for_slug(basic_artefact[:slug])
-    assert_equal 'An artefact', artefact.name
+    assert_equal 'An artefact', artefact['name']
   end
 
   it 'fetches an artefact as a hash given a slug' do
@@ -72,8 +72,14 @@ describe GdsApi::Panopticon do
     panopticon_has_metadata(artefact_with_contact)
 
     artefact = api.artefact_for_slug(artefact_with_contact[:slug])
-    assert_equal 'Department for Environment, Food and Rural Affairs (Defra)', artefact.contact.name
-    assert_equal 'helpline@defra.gsi.gov.uk', artefact.contact.email_address
+    assert_equal(
+      'Department for Environment, Food and Rural Affairs (Defra)',
+      artefact['contact']['name']
+    )
+    assert_equal(
+      'helpline@defra.gsi.gov.uk',
+      artefact['contact']['email_address']
+    )
   end
 
   it 'creates a new artefact' do

--- a/test/publisher_api_test.rb
+++ b/test/publisher_api_test.rb
@@ -59,7 +59,7 @@ describe GdsApi::Publisher do
     publication_exists(basic_answer)
     pub = api.publication_for_slug(basic_answer['slug'])
 
-    assert_equal "Something", pub.body
+    assert_equal "Something", pub['body']
   end
 
   it "should optionally accept an edition id" do
@@ -84,8 +84,8 @@ describe GdsApi::Publisher do
   it "should deserialise parts into whole objects" do
     publication_exists(publication_with_parts)
     pub = api.publication_for_slug(publication_with_parts['slug'])
-    assert_equal 3, pub.parts.size
-    assert_equal "introduction", pub.parts.first.slug
+    assert_equal 3, pub['parts'].size
+    assert_equal "introduction", pub['parts'].first['slug']
   end
 
   it "should have part specific methods for a publication with parts" do
@@ -97,7 +97,7 @@ describe GdsApi::Publisher do
   it "should deserialise updated at as a time" do
     publication_exists(publication_with_parts)
     pub = api.publication_for_slug(publication_with_parts['slug'])
-    assert_equal Time, pub.updated_at.class
+    assert_equal Time, pub['updated_at'].class
   end
 
   it "should be able to retrieve local transaction details" do

--- a/test/publishing_api_v2/get_expanded_links_test.rb
+++ b/test/publishing_api_v2/get_expanded_links_test.rb
@@ -77,9 +77,9 @@ describe GdsApi::PublishingApiV2 do
           status: 404
         )
 
-      response = @api_client.get_expanded_links(@content_id)
-
-      assert_nil response
+      assert_raises(GdsApi::HTTPNotFound) do
+        @api_client.get_expanded_links(@content_id)
+      end
     end
   end
 end

--- a/test/publishing_api_v2/get_links_test.rb
+++ b/test/publishing_api_v2/get_links_test.rb
@@ -77,8 +77,9 @@ describe GdsApi::PublishingApiV2 do
       end
 
       it "responds with 404" do
-        response = @api_client.get_links(@content_id)
-        assert_nil response
+        assert_raises(GdsApi::HTTPNotFound) do
+          @api_client.get_links(@content_id)
+        end
       end
     end
   end

--- a/test/publishing_api_v2/get_links_test.rb
+++ b/test/publishing_api_v2/get_links_test.rb
@@ -33,7 +33,10 @@ describe GdsApi::PublishingApiV2 do
       it "responds with the links" do
         response = @api_client.get_links(@content_id)
         assert_equal 200, response.code
-        assert_equal ["20583132-1619-4c68-af24-77583172c070"], response.links.organisations
+        assert_equal(
+          ["20583132-1619-4c68-af24-77583172c070"],
+          response['links']['organisations']
+        )
       end
     end
 
@@ -58,7 +61,7 @@ describe GdsApi::PublishingApiV2 do
       it "responds with the empty link set" do
         response = @api_client.get_links(@content_id)
         assert_equal 200, response.code
-        assert_equal OpenStruct.new({}), response.links
+        assert_equal({}, response['links'])
       end
     end
 

--- a/test/publishing_api_v2_test.rb
+++ b/test/publishing_api_v2_test.rb
@@ -493,7 +493,9 @@ describe GdsApi::PublishingApiV2 do
       end
 
       it "responds with 404" do
-        assert_nil @api_client.get_content(@content_id)
+        assert_raises(GdsApi::HTTPNotFound) do
+          @api_client.get_content(@content_id)
+        end
       end
     end
   end
@@ -1542,14 +1544,13 @@ describe GdsApi::PublishingApiV2 do
       end
 
       it "404s" do
-        response = @api_client.get_linked_items(
-          @content_id,
-          {
+        assert_raises(GdsApi::HTTPNotFound) do
+          @api_client.get_linked_items(
+            @content_id,
             link_type: "topic",
-            fields: ["content_id", "base_path"],
-          }
-        )
-        assert_nil response
+            fields: %w(content_id base_path),
+          )
+        end
       end
     end
 

--- a/test/publishing_api_v2_test.rb
+++ b/test/publishing_api_v2_test.rb
@@ -953,7 +953,10 @@ describe GdsApi::PublishingApiV2 do
           organisations: ["591436ab-c2ae-416f-a3c5-1901d633fbfb"],
         })
         assert_equal 200, response.code
-        assert_equal ["591436ab-c2ae-416f-a3c5-1901d633fbfb"], response.links.organisations
+        assert_equal(
+          ["591436ab-c2ae-416f-a3c5-1901d633fbfb"],
+          response['links']['organisations']
+        )
       end
     end
 
@@ -991,10 +994,13 @@ describe GdsApi::PublishingApiV2 do
         })
 
         assert_equal 200, response.code
-        assert_equal(OpenStruct.new(
-          topics: ["225df4a8-2945-4e9b-8799-df7424a90b69"],
-          organisations: ["20583132-1619-4c68-af24-77583172c070"],
-        ), response.links)
+        assert_equal(
+          {
+            'topics' => ["225df4a8-2945-4e9b-8799-df7424a90b69"],
+            'organisations' => ["20583132-1619-4c68-af24-77583172c070"],
+          },
+          response['links']
+        )
       end
     end
 
@@ -1029,7 +1035,7 @@ describe GdsApi::PublishingApiV2 do
         })
 
         assert_equal 200, response.code
-        assert_equal OpenStruct.new({}), response.links
+        assert_equal({}, response['links'])
       end
     end
 
@@ -1066,9 +1072,12 @@ describe GdsApi::PublishingApiV2 do
         })
 
         assert_equal 200, response.code
-        assert_equal(OpenStruct.new(
-          organisations: ["591436ab-c2ae-416f-a3c5-1901d633fbfb"],
-        ), response.links)
+        assert_equal(
+          {
+            'organisations' => ["591436ab-c2ae-416f-a3c5-1901d633fbfb"],
+          },
+          response['links']
+        )
       end
     end
 

--- a/test/router_test.rb
+++ b/test/router_test.rb
@@ -17,7 +17,7 @@ describe GdsApi::Router do
 
         response = @api.get_backend("foo")
         assert_equal 200, response.code
-        assert_equal "http://foo.example.com/", response.backend_url
+        assert_equal "http://foo.example.com/", response['backend_url']
 
         assert_requested(req)
       end
@@ -54,7 +54,7 @@ describe GdsApi::Router do
 
         response = @api.add_backend("foo", "http://foo.example.com/")
         assert_equal 201, response.code
-        assert_equal "http://foo.example.com/", response.backend_url
+        assert_equal "http://foo.example.com/", response['backend_url']
 
         assert_requested(req)
       end
@@ -102,7 +102,7 @@ describe GdsApi::Router do
 
         response = @api.delete_backend("foo")
         assert_equal 200, response.code
-        assert_equal "http://foo.example.com/", response.backend_url
+        assert_equal "http://foo.example.com/", response['backend_url']
 
         assert_requested(req)
       end
@@ -156,7 +156,7 @@ describe GdsApi::Router do
 
         response = @api.get_route("/foo")
         assert_equal 200, response.code
-        assert_equal "foo", response.backend_id
+        assert_equal "foo", response['backend_id']
 
         assert_requested(req)
         assert_not_requested(@commit_req)
@@ -200,7 +200,7 @@ describe GdsApi::Router do
 
         response = @api.add_route("/foo", "exact", "foo")
         assert_equal 201, response.code
-        assert_equal "foo", response.backend_id
+        assert_equal "foo", response['backend_id']
 
         assert_requested(req)
         assert_not_requested(@commit_req)
@@ -250,7 +250,7 @@ describe GdsApi::Router do
 
         response = @api.add_redirect_route("/foo", "exact", "/bar")
         assert_equal 201, response.code
-        assert_equal "/bar", response.redirect_to
+        assert_equal "/bar", response['redirect_to']
 
         assert_requested(req)
         assert_not_requested(@commit_req)
@@ -265,7 +265,7 @@ describe GdsApi::Router do
 
         response = @api.add_redirect_route("/foo", "exact", "/bar", "temporary")
         assert_equal 201, response.code
-        assert_equal "/bar", response.redirect_to
+        assert_equal "/bar", response['redirect_to']
 
         assert_requested(req)
         assert_not_requested(@commit_req)
@@ -280,7 +280,7 @@ describe GdsApi::Router do
 
         response = @api.add_redirect_route("/foo", "exact", "/bar", "temporary", :segments_mode => "preserve")
         assert_equal 201, response.code
-        assert_equal "/bar", response.redirect_to
+        assert_equal "/bar", response['redirect_to']
 
         assert_requested(req)
         assert_not_requested(@commit_req)
@@ -330,7 +330,7 @@ describe GdsApi::Router do
 
         response = @api.add_gone_route("/foo", "exact")
         assert_equal 201, response.code
-        assert_equal "/foo", response.incoming_path
+        assert_equal "/foo", response['incoming_path']
 
         assert_requested(req)
         assert_not_requested(@commit_req)
@@ -379,7 +379,7 @@ describe GdsApi::Router do
 
         response = @api.delete_route("/foo")
         assert_equal 200, response.code
-        assert_equal "foo", response.backend_id
+        assert_equal "foo", response['backend_id']
 
         assert_requested(req)
         assert_not_requested(@commit_req)

--- a/test/router_test.rb
+++ b/test/router_test.rb
@@ -22,12 +22,13 @@ describe GdsApi::Router do
         assert_requested(req)
       end
 
-      it "should return nil for a non-existend backend" do
+      it "raises for a non-existend backend" do
         req = WebMock.stub_request(:get, "#{@base_api_url}/backends/foo").
           to_return(:status => 404)
 
-        response = @api.get_backend("foo")
-        assert_nil response
+        assert_raises(GdsApi::HTTPNotFound) do
+          @api.get_backend("foo")
+        end
 
         assert_requested(req)
       end
@@ -36,8 +37,9 @@ describe GdsApi::Router do
         req = WebMock.stub_request(:get, "#{@base_api_url}/backends/foo+bar").
           to_return(:status => 404)
 
-        response = @api.get_backend("foo bar")
-        assert_nil response
+        assert_raises(GdsApi::HTTPNotFound) do
+          @api.get_backend("foo bar")
+        end
 
         assert_requested(req)
       end
@@ -160,13 +162,14 @@ describe GdsApi::Router do
         assert_not_requested(@commit_req)
       end
 
-      it "should return nil if nothing found" do
+      it "should raise if nothing found" do
         req = WebMock.stub_request(:get, "#{@base_api_url}/routes").
           with(:query => {"incoming_path" => "/foo"}).
           to_return(:status => 404)
 
-        response = @api.get_route("/foo")
-        assert_nil response
+        assert_raises(GdsApi::HTTPNotFound) do
+          @api.get_route("/foo")
+        end
 
         assert_requested(req)
         assert_not_requested(@commit_req)
@@ -179,8 +182,9 @@ describe GdsApi::Router do
           with(:query => {"incoming_path" => "/foo bar"}).
           to_return(:status => 404)
 
-        response = @api.get_route("/foo bar")
-        assert_nil response
+        assert_raises(GdsApi::HTTPNotFound) do
+          @api.get_route("/foo bar")
+        end
 
         assert_requested(req)
         assert_not_requested(@commit_req)

--- a/test/rummager_helpers_test.rb
+++ b/test/rummager_helpers_test.rb
@@ -15,6 +15,6 @@ class RummagerHelpersTest < Minitest::Test
     response = rummager_has_no_services_and_info_data_for_organisation
 
     assert_instance_of GdsApi::Response, response
-    assert_equal 0, response.facets.specialist_sectors.total_options
+    assert_equal 0, response['facets']['specialist_sectors']['total_options']
   end
 end

--- a/test/worldwide_api_test.rb
+++ b/test/worldwide_api_test.rb
@@ -16,8 +16,8 @@ describe GdsApi::Worldwide do
       worldwide_api_has_locations(country_slugs)
 
       response = @api.world_locations
-      assert_equal country_slugs, response.map {|r| r.details.slug }
-      assert_equal "Rohan", response.results[2].title
+      assert_equal country_slugs, response.map { |r| r['details']['slug'] }
+      assert_equal "Rohan", response['results'][2]['title']
     end
 
     it "should handle the pagination" do
@@ -25,7 +25,10 @@ describe GdsApi::Worldwide do
       worldwide_api_has_locations(country_slugs)
 
       response = @api.world_locations
-      assert_equal country_slugs, response.with_subsequent_pages.map {|r| r.details.slug }
+      assert_equal(
+        country_slugs,
+        response.with_subsequent_pages.map { |r| r['details']['slug'] }
+      )
     end
 
     it "should raise error if endpoint 404s" do
@@ -41,7 +44,7 @@ describe GdsApi::Worldwide do
       worldwide_api_has_location('rohan')
 
       response = @api.world_location('rohan')
-      assert_equal 'Rohan', response.title
+      assert_equal 'Rohan', response['title']
     end
 
     it "raises for a non-existent location" do
@@ -60,7 +63,13 @@ describe GdsApi::Worldwide do
 
       response = @api.organisations_for_world_location('australia')
       assert response.is_a?(GdsApi::ListResponse)
-      assert_equal ["UK Trade & Investment Australia", "British High Commission Canberra"], response.map(&:title)
+      assert_equal(
+        [
+          "UK Trade & Investment Australia",
+          "British High Commission Canberra"
+        ],
+        response.map { |item| item['title'] }
+      )
     end
 
     it "should raise error on 404" do

--- a/test/worldwide_api_test.rb
+++ b/test/worldwide_api_test.rb
@@ -44,10 +44,12 @@ describe GdsApi::Worldwide do
       assert_equal 'Rohan', response.title
     end
 
-    it "should return nil for a non-existent location" do
+    it "raises for a non-existent location" do
       worldwide_api_does_not_have_location('non-existent')
 
-      assert_nil @api.world_location('non-existent')
+      assert_raises(GdsApi::HTTPNotFound) do
+        @api.world_location('non-existent')
+      end
     end
   end
 


### PR DESCRIPTION
This is a follow up change to commit 4ad659ff0becbc059e19bac07d9bd091dac7f788 and commit 4b1202b64d07ee619f907f7ca36bbc4e5780a7f3

We will be removing `always_raise_for_not_found` and `hash_response_for_requests` by December 2016. This change makes sure both options default to true when not configured and adds deprecation warnings to the setter methods to make sure client applications see it and are able to migrate before we remove them.

Please see commit messages for details on the changes.