### PR TITLE
Add a rake lint task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -36,6 +36,11 @@ PactBroker::Client::PublicationTask.new("released_version") do | task |
   configure_pact_broker_location(task)
 end
 
+desc "Run the linter against changed files"
+task :lint do
+  sh "bundle exec govuk-lint-ruby --diff --cached --format clang"
+end
+
 require "gem_publisher"
 desc "Publish gem to rubygems.org if necessary"
 task :publish_gem do |t|


### PR DESCRIPTION
Add a rake task to lint changed files. Runs the same govuk-lint-ruby command as in jenkins.sh, but without outputting an HTML version.