### PR TITLE
Add test helper for get_linked_items

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,2 @@
+AllCops:
+  TargetRubyVersion: 2.3

--- a/lib/gds_api/test_helpers/publishing_api_v2.rb
+++ b/lib/gds_api/test_helpers/publishing_api_v2.rb
@@ -358,6 +358,43 @@ module GdsApi
         stub_request(:post, url).to_return(body: lookup_hash.to_json)
       end
 
+      #
+      # Stub calls to the get linked items endpoint
+      #
+      # @param items [Array] The linked items we wish to return
+      # @param params [Hash] A hash of parameters
+      #
+      # @example
+      #
+      #   publishing_api_has_linked_items(
+      #     [ item_1, item_2 ],
+      #     {
+      #       content_id: "51ac4247-fd92-470a-a207-6b852a97f2db",
+      #       link_type: "taxons",
+      #       fields: ["title", "description", "base_path"]
+      #     }
+      #   )
+      #
+      def publishing_api_has_linked_items(items, params = {})
+        content_id = params.fetch(:content_id)
+        link_type = params.fetch(:link_type)
+        fields = params.fetch(:fields, %w(base_path content_id document_type title))
+
+        url = Plek.current.find('publishing-api') + "/v2/linked/#{content_id}"
+
+        request_parmeters = {
+          "fields" => fields,
+          "link_type" => link_type,
+        }
+
+        stub_request(:get, url)
+          .with(query: request_parmeters)
+          .and_return(
+            body: items.to_json,
+            status: 200
+          )
+      end
+
     private
 
       def stub_publishing_api_put(*args)

--- a/test/test_helpers/publishing_api_v2_test.rb
+++ b/test/test_helpers/publishing_api_v2_test.rb
@@ -6,6 +6,32 @@ describe GdsApi::TestHelpers::PublishingApiV2 do
   include GdsApi::TestHelpers::PublishingApiV2
   let(:publishing_api) { GdsApi::PublishingApiV2.new(Plek.current.find("publishing-api")) }
 
+  describe '#publishing_api_has_linked_items' do
+    it "stubs the get linked items api call" do
+      links = [
+        { 'content_id' => 'id-1', 'title' => 'title 1', 'link_type' => 'taxons' },
+        { 'content_id' => 'id-2', 'title' => 'title 2', 'link_type' => 'taxons' },
+      ]
+      publishing_api_has_linked_items(
+        links,
+        content_id: 'content-id',
+        link_type: 'taxons',
+        fields: [:title]
+      )
+
+      api_response = publishing_api.get_linked_items(
+        'content-id',
+        link_type: 'taxons',
+        fields: [:title]
+      )
+
+      assert_equal(
+        api_response.to_hash,
+        links
+      )
+    end
+  end
+
   describe "#publishing_api_has_lookups" do
     it "stubs the lookup for content items" do
       lookup_hash = { "/foo" => "2878337b-bed9-4e7f-85b6-10ed2cbcd504" }


### PR DESCRIPTION
This commit adds a test helper for `get_linked_items` and the corresponding test.