### PR TITLE
Add performance platform service feedback helper

### DIFF
--- a/lib/gds_api/performance_platform/data_out.rb
+++ b/lib/gds_api/performance_platform/data_out.rb
@@ -1,0 +1,48 @@
+require_relative '../base'
+
+module GdsApi
+  module PerformancePlatform
+    class DataOut < GdsApi::Base
+      # Fetch all service feedback from the performance platform for a given transaction
+      # page slug.
+      #
+      # Makes a +GET+ request.
+      #
+      # The results are ordered date ascending.
+      #
+      # @param transaction_page_slug [String] The slug for which service feedback is
+      # needed.
+      #
+      # # @example
+      #
+      #  performance_platform_data_out.service_feedback('register-to-vote')
+      #
+      #  #=> {
+      #      "data": [
+      #   {
+      #     "_day_start_at": "2014-06-10T00:00:00+00:00",
+      #     "_hour_start_at": "2014-06-10T00:00:00+00:00",
+      #     "_id": "20140610_register-to-vote",
+      #     "_month_start_at": "2014-06-01T00:00:00+00:00",
+      #     "_quarter_start_at": "2014-04-01T00:00:00+00:00",
+      #     "_timestamp": "2014-06-10T00:00:00+00:00",
+      #     "_updated_at": "2014-06-11T00:30:50.901000+00:00",
+      #     "_week_start_at": "2014-06-09T00:00:00+00:00",
+      #     "comments": 217,
+      #     "period": "day",
+      #     "rating_1": 4,
+      #     "rating_2": 6,
+      #     "rating_3": 7,
+      #     "rating_4": 74,
+      #     "rating_5": 574,
+      #     "slug": "register-to-vote",
+      #     "total": 665
+      #   },
+      #   ...
+      #  }
+      def service_feedback(transaction_page_slug)
+        get_json!("#{endpoint}/data/#{transaction_page_slug}/customer-satisfaction")
+      end
+    end
+  end
+end

--- a/lib/gds_api/test_helpers/performance_platform/data_out.rb
+++ b/lib/gds_api/test_helpers/performance_platform/data_out.rb
@@ -1,0 +1,23 @@
+module GdsApi
+  module TestHelpers
+    module PerformancePlatform
+      module DataOut
+        PP_DATA_OUT_ENDPOINT = "http://www.performance.service.gov.uk".freeze
+
+        def stub_service_feedback(slug, response_body = {})
+          stub_http_request(:get, "#{PP_DATA_OUT_ENDPOINT}/data/#{slug}/customer-satisfaction").
+            to_return(status: 200, body: response_body.to_json)
+        end
+
+        def stub_data_set_not_available(slug)
+          stub_http_request(:get, "#{PP_DATA_OUT_ENDPOINT}/data/#{slug}/customer-satisfaction").
+            to_return(status: 404)
+        end
+
+        def stub_service_not_available
+          stub_request(:any, /#{PP_DATA_OUT_ENDPOINT}\/.*/).to_return(status: 503)
+        end
+      end
+    end
+  end
+end

--- a/test/pp_data_out_test.rb
+++ b/test/pp_data_out_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+require 'gds_api/performance_platform/data_out'
+require 'gds_api/test_helpers/performance_platform/data_out'
+
+describe GdsApi::PerformancePlatform::DataOut do
+  include GdsApi::TestHelpers::PerformancePlatform::DataOut
+
+  before do
+    @base_api_url = GdsApi::TestHelpers::PerformancePlatform::DataOut::PP_DATA_OUT_ENDPOINT
+    @api = GdsApi::PerformancePlatform::DataOut.new(@base_api_url)
+  end
+
+  let(:transaction_slug) { 'register-to-vote' }
+
+  it "calls the service feedback endpoint for a particular slug" do
+    request_details = { "some" => "data" }
+
+    stub_post = stub_service_feedback(transaction_slug, request_details)
+
+    @api.service_feedback(transaction_slug)
+
+    assert_requested(stub_post)
+  end
+end


### PR DESCRIPTION
This can be called to extract service feedback from the performance
platform.

Also:
  - Added associated test helper methods