### PR TITLE
Add discard_draft and unpublish stub any helpers

### DIFF
--- a/lib/gds_api/test_helpers/publishing_api_v2.rb
+++ b/lib/gds_api/test_helpers/publishing_api_v2.rb
@@ -80,6 +80,14 @@ module GdsApi
         stub_request(:post, %r{\A#{PUBLISHING_API_V2_ENDPOINT}/content/.*/publish})
       end
 
+      def stub_any_publishing_api_unpublish
+        stub_request(:post, %r{\A#{PUBLISHING_API_V2_ENDPOINT}/content/.*/unpublish})
+      end
+
+      def stub_any_publishing_api_discard_draft
+        stub_request(:post, %r{\A#{PUBLISHING_API_V2_ENDPOINT}/content/.*/discard-draft})
+      end
+
       def stub_any_publishing_api_call
         stub_request(:any, %r{\A#{PUBLISHING_API_V2_ENDPOINT}})
       end

--- a/test/test_helpers/publishing_api_v2_test.rb
+++ b/test/test_helpers/publishing_api_v2_test.rb
@@ -155,4 +155,20 @@ describe GdsApi::TestHelpers::PublishingApiV2 do
       assert_publishing_api_publish("some-content-id")
     end
   end
+
+  describe "stub_any_publishing_api_unpublish" do
+    it "stubs any unpublish request to the publishing api" do
+      stub_any_publishing_api_unpublish
+      publishing_api.unpublish("some-content-id", type: :gone)
+      assert_publishing_api_unpublish("some-content-id")
+    end
+  end
+
+  describe "stub_any_publishing_api_discard_draft" do
+    it "stubs any discard draft request to the publishing api" do
+      stub_any_publishing_api_discard_draft
+      publishing_api.discard_draft("some-content-id")
+      assert_publishing_api_discard_draft("some-content-id")
+    end
+  end
 end


### PR DESCRIPTION
These methods were missing. I've had to [work around](https://github.com/alphagov/manuals-publisher/commit/43aa6e709364c3e09e60a357e80e8cecca358163#diff-2f8cd6e10c7bf7e49e3e68eabf2cef64R15) the lack of unpublish so felt it should be added in.

- [ ] Once merged - update Manuals Publisher