### PR TITLE
Allow #dig on Response.

### DIFF
--- a/lib/gds_api/response.rb
+++ b/lib/gds_api/response.rb
@@ -25,7 +25,7 @@ module GdsApi
     extend Forwardable
     include Enumerable
 
-    def_delegators :to_hash, :[], :"<=>", :each
+    def_delegators :to_hash, :[], :"<=>", :each, :dig
 
     def initialize(http_response, options = {})
       @http_response = http_response

--- a/test/response_test.rb
+++ b/test/response_test.rb
@@ -236,6 +236,11 @@ describe GdsApi::Response do
         JSON.expects(:parse).never
         assert_equal "VAT rates", @response["title"]
       end
+
+      it "should allow using dig to access nested keys" do
+        skip unless RUBY_VERSION > "2.3"
+        assert_equal "1870", @response.dig("details", "need_id")
+      end
     end
 
     # TODO: When we remove `GdsApi.config.hash_response_for_requests`, this


### PR DESCRIPTION
This is used in the breadcrumbs navigation helper.