### PR TITLE
Fix publishing api expectations for schema validation

### DIFF
--- a/test/publishing_api_v2_test.rb
+++ b/test/publishing_api_v2_test.rb
@@ -142,7 +142,14 @@ describe GdsApi::PublishingApiV2 do
     describe "optimistic locking" do
       describe "if the content item has not changed since it was requested" do
         before do
-          @content_item = content_item_for_content_id(@content_id, "previous_version" => 3)
+          @content_item = content_item_for_content_id(@content_id,
+            "document_type" => "manual",
+            "schema_name" => "manual",
+            "locale" => "en",
+            "details" => { "body" => [] },
+            "previous_version" => "3"
+          )
+          @content_item.delete("format")
 
           publishing_api
             .given("the content item #{@content_id} is at version 3")
@@ -168,7 +175,14 @@ describe GdsApi::PublishingApiV2 do
 
       describe "if the content item has changed in the meantime" do
         before do
-          @content_item = content_item_for_content_id(@content_id, "previous_version" => 2)
+          @content_item = content_item_for_content_id(@content_id,
+            "document_type" => "manual",
+            "schema_name" => "manual",
+            "locale" => "en",
+            "details" => { "body" => [] },
+            "previous_version" => "2"
+          )
+          @content_item.delete("format")
 
           publishing_api
             .given("the content item #{@content_id} is at version 3")

--- a/test/publishing_api_v2_test.rb
+++ b/test/publishing_api_v2_test.rb
@@ -120,15 +120,12 @@ describe GdsApi::PublishingApiV2 do
           )
           .will_respond_with(
             status: 422,
-            body: {
-              "error" => {
-                "code" => 422,
-                "message" => Pact.term(generate: "Unprocessable entity", matcher:/\S+/),
-                "fields" => {
-                  "base_path" => Pact.each_like("is invalid", :min => 1),
-                },
-              },
-            },
+            body: [
+              {
+                fragment: "#/base_path",
+                failed_attribute: "Pattern"
+              }
+            ],
             headers: {
               "Content-Type" => "application/json; charset=utf-8"
             }
@@ -136,11 +133,9 @@ describe GdsApi::PublishingApiV2 do
       end
 
       it "responds with 422 Unprocessable Entity" do
-        error = assert_raises GdsApi::HTTPClientError do
+        assert_raises GdsApi::HTTPClientError do
           @api_client.put_content(@content_id, @content_item)
         end
-        assert_equal 422, error.code
-        assert_equal "Unprocessable entity", error.error_details["error"]["message"]
       end
     end
 


### PR DESCRIPTION
As a side effect of improving how the Publishing API handles govuk-content-schemas, the validation now takes place when running the pact tests. This is good, but requires changes to the expectations.