### PR TITLE
Generate docs only for documented APIs

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,7 @@
+--no-private
+--markup markdown
+--output-dir docs
+--embed-mixins
+--no-stats
+--readme docs-intro.html
+--api documented

--- a/lib/gds_api/asset_manager.rb
+++ b/lib/gds_api/asset_manager.rb
@@ -1,6 +1,7 @@
 require_relative 'base'
 require_relative 'exceptions'
 
+# @api documented
 class GdsApi::AssetManager < GdsApi::Base
 
   # Creates an asset given a hash with one +file+ attribute

--- a/lib/gds_api/email_alert_api.rb
+++ b/lib/gds_api/email_alert_api.rb
@@ -4,6 +4,7 @@ require_relative 'exceptions'
 # Adapter for the Email Alert API
 #
 # @see https://github.com/alphagov/email-alert-api
+# @api documented
 class GdsApi::EmailAlertApi < GdsApi::Base
 
   # Get or Post subscriber list

--- a/lib/gds_api/publishing_api_v2.rb
+++ b/lib/gds_api/publishing_api_v2.rb
@@ -5,6 +5,7 @@ require_relative 'base'
 # @see https://github.com/alphagov/publishing-api
 # @see https://github.com/alphagov/publishing-api/blob/master/doc/publishing-application-examples.md
 # @see https://github.com/alphagov/publishing-api/blob/master/doc/model.md
+# @api documented
 class GdsApi::PublishingApiV2 < GdsApi::Base
   # Put a content item
   #
@@ -88,8 +89,8 @@ class GdsApi::PublishingApiV2 < GdsApi::Base
   #
   # @param content_id [UUID]
   # @param update_type [String] Either 'major', 'minor' or 'republish'
-  # @param params [Hash]
-  # @option params [String] locale The language, defaults to 'en' in publishing-api.
+  # @param options [Hash]
+  # @option options [String] locale The language, defaults to 'en' in publishing-api.
   #
   # @see https://github.com/alphagov/publishing-api/blob/master/doc/api.md#post-v2contentcontent_idpublish
   def publish(content_id, update_type, options = {})
@@ -142,9 +143,9 @@ class GdsApi::PublishingApiV2 < GdsApi::Base
   #
   # Deletes the draft content item.
   #
-  # @param params [Hash]
-  # @option params [String] locale The language, defaults to 'en' in publishing-api.
-  # @option params [Integer] previous_version used to ensure the request is discarding the latest lock version of the draft
+  # @param options [Hash]
+  # @option options [String] locale The language, defaults to 'en' in publishing-api.
+  # @option options [Integer] previous_version used to ensure the request is discarding the latest lock version of the draft
   #
   # @see https://github.com/alphagov/publishing-api/blob/master/doc/api.md#post-v2contentcontent_iddiscard-draft
   def discard_draft(content_id, options = {})

--- a/lib/gds_api/rummager.rb
+++ b/lib/gds_api/rummager.rb
@@ -2,11 +2,12 @@ require 'gds_api/base'
 require 'rack/utils'
 
 module GdsApi
+  # @api documented
   class Rummager < Base
 
     # Perform a search.
     #
-    # @param query [Hash] A valid search query. See Rummager documentation for options.
+    # @param args [Hash] A valid search query. See Rummager documentation for options.
     #
     # @see https://github.com/alphagov/rummager/blob/master/docs/search-api.md
     def search(args)

--- a/lib/gds_api/support_api.rb
+++ b/lib/gds_api/support_api.rb
@@ -1,5 +1,6 @@
 require_relative 'base'
 
+# @api documented
 class GdsApi::SupportApi < GdsApi::Base
   def create_problem_report(request_details)
     post_json!("#{endpoint}/anonymous-feedback/problem-reports", { :problem_report => request_details })


### PR DESCRIPTION
Most of the classes in this application aren't documented. This means that the documentation isn't really useful for the most part [because it's mega huge and you can't find your thing](http://www.rubydoc.info/gems/gds-api-adapters/index). 

This commit PR a `.yardopts` file that is used by YARD to configure the doc build. The only classes it will document from now on are classes that have at least some documentation.

My hope is that by making the docs smaller they'll be more useful and in turn convinces people to add more docs.

Also solves some warnings for mismatched parameter names in the docs.

Preview: http://www.rubydoc.info/github/alphagov/gds-api-adapters/better-docs/index