### PR TITLE
Add an API adapter to get content IDs for needs from the Need API

### DIFF
--- a/lib/gds_api/need_api.rb
+++ b/lib/gds_api/need_api.rb
@@ -8,6 +8,10 @@ class GdsApi::NeedApi < GdsApi::Base
     get_list!("#{endpoint}/needs#{query}")
   end
 
+  def content_id(need_id)
+    get_raw("#{endpoint}/needs/#{CGI.escape(need_id.to_s)}/content_id")
+  end
+
   def needs_by_id(*ids)
     ids_string = ids.flatten.map(&:to_i).sort.join(',')
     query = query_string(ids: ids_string)

--- a/lib/gds_api/test_helpers/need_api.rb
+++ b/lib/gds_api/test_helpers/need_api.rb
@@ -68,6 +68,13 @@ module GdsApi
         stub_request(:get, url).to_return(status: 200, body: need.to_json, headers: {})
       end
 
+      def need_api_has_content_id_for_need(need)
+        need_id = need["id"] || need[:id]
+
+        url = NEED_API_ENDPOINT + "/needs/#{need_id}/content_id"
+        stub_request(:get, url).to_return(body: need[:content_id])
+      end
+
       def need_api_has_raw_response_for_page(response, page = nil)
         url = NEED_API_ENDPOINT + "/needs"
         url << "?page=#{page}" unless page.nil?

--- a/test/need_api_test.rb
+++ b/test/need_api_test.rb
@@ -219,6 +219,22 @@ describe GdsApi::NeedApi do
     end
   end
 
+  describe "viewing content_ids for needs" do
+    it "should return the content_id for a need_id" do
+      need = {
+        id: 100700,
+        content_id: "abcdef-12345",
+        role: "need",
+        goal: "needy",
+        benefit: "needless"
+      }
+      need_api_has_content_id_for_need(need)
+
+      need_response = @api.content_id(100700)
+      assert_equal 'abcdef-12345', need_response.body
+    end
+  end
+
   describe "updating needs" do
     it "should send a PUT request" do
       updated_fields = {


### PR DESCRIPTION
- This implements https://github.com/alphagov/govuk_need_api/pull/112 as an API adapter so we can
  use it from Publisher to match up need_ids to content_ids.