### PR TITLE
Remove deprecated v1 endpoints from PublishingApi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Removed `GdsApi::Publisher`
 * Removed `GdsApi::ExternalLinkTracker`
+* Remove deprecated `PublishingApi` endpoints (`put_content_item` and
+  `put_draft_content_item`).
 
 # 37.5.1
 

--- a/lib/gds_api/publishing_api.rb
+++ b/lib/gds_api/publishing_api.rb
@@ -3,14 +3,6 @@ require_relative 'exceptions'
 
 class GdsApi::PublishingApi < GdsApi::Base
 
-  def put_draft_content_item(base_path, payload)
-    put_json!(draft_content_item_url(base_path), payload)
-  end
-
-  def put_content_item(base_path, payload)
-    put_json!(content_item_url(base_path), payload)
-  end
-
   def put_intent(base_path, payload)
     put_json!(intent_url(base_path), payload)
   end
@@ -25,16 +17,7 @@ class GdsApi::PublishingApi < GdsApi::Base
     put_json!(paths_url(base_path), payload)
   end
 
-
   private
-
-  def draft_content_item_url(base_path)
-    "#{endpoint}/draft-content#{base_path}"
-  end
-
-  def content_item_url(base_path)
-    "#{endpoint}/content#{base_path}"
-  end
 
   def intent_url(base_path)
     "#{endpoint}/publish-intent#{base_path}"

--- a/lib/gds_api/test_helpers/publishing_api.rb
+++ b/lib/gds_api/test_helpers/publishing_api.rb
@@ -11,15 +11,6 @@ module GdsApi
 
       PUBLISHING_API_ENDPOINT = Plek.current.find('publishing-api')
 
-      def stub_publishing_api_put_draft_item(base_path, body = content_item_for_publishing_api(base_path))
-        stub_publishing_api_put_item(base_path, body, '/draft-content')
-      end
-
-      def stub_publishing_api_put_item(base_path, body = content_item_for_publishing_api(base_path), resource_path = '/content')
-        url = PUBLISHING_API_ENDPOINT + resource_path + base_path
-        stub_request(:put, url).with(body: body).to_return(status: 200, body: '{}', headers: {"Content-Type" => "application/json; charset=utf-8"})
-      end
-
       def stub_publishing_api_put_intent(base_path, body = intent_for_publishing_api(base_path))
         url = PUBLISHING_API_ENDPOINT + "/publish-intent" + base_path
         body = body.to_json unless body.is_a?(String)
@@ -31,26 +22,8 @@ module GdsApi
         stub_request(:delete, url).to_return(status: 200, body: '{}', headers: {"Content-Type" => "application/json; charset=utf-8"})
       end
 
-      def stub_default_publishing_api_put()
-        stub_request(:put, %r{\A#{PUBLISHING_API_ENDPOINT}/content})
-      end
-
-      def stub_default_publishing_api_put_draft()
-        stub_request(:put, %r{\A#{PUBLISHING_API_ENDPOINT}/draft-content})
-      end
-
       def stub_default_publishing_api_put_intent()
         stub_request(:put, %r{\A#{PUBLISHING_API_ENDPOINT}/publish-intent})
-      end
-
-      def assert_publishing_api_put_item(base_path, attributes_or_matcher = {}, times = 1)
-        url = PUBLISHING_API_ENDPOINT + "/content" + base_path
-        assert_publishing_api_put(url, attributes_or_matcher, times)
-      end
-
-      def assert_publishing_api_put_draft_item(base_path, attributes_or_matcher = {}, times = 1)
-        url = PUBLISHING_API_ENDPOINT + "/draft-content" + base_path
-        assert_publishing_api_put(url, attributes_or_matcher, times)
       end
 
       def assert_publishing_api_put_intent(base_path, attributes_or_matcher = {}, times = 1)

--- a/test/publishing_api_test.rb
+++ b/test/publishing_api_test.rb
@@ -11,64 +11,6 @@ describe GdsApi::PublishingApi do
     @api_client = GdsApi::PublishingApi.new(publishing_api_host)
   end
 
-  describe "#put_content_item" do
-    it "responds with 200 OK if the entry is valid" do
-      base_path = "/test-content-item"
-      content_item = content_item_for_publishing_api(base_path).merge("update_type" => "major")
-
-      publishing_api
-        .given("no content exists")
-        .upon_receiving("a request to create a content item")
-        .with(
-          method: :put,
-          path: "/content#{base_path}",
-          body: content_item,
-          headers: {
-            "Content-Type" => "application/json"
-          },
-        )
-        .will_respond_with(
-          status: 200,
-          body: content_item,
-          headers: {
-            "Content-Type" => "application/json; charset=utf-8"
-          },
-        )
-
-      response = @api_client.put_content_item(base_path, content_item)
-      assert_equal 200, response.code
-    end
-  end
-
-  describe "#put_draft_content_item" do
-    it "responds with 200 OK if the entry is valid" do
-      base_path = "/test-draft-content-item"
-      content_item = content_item_for_publishing_api(base_path).merge("update_type" => "major")
-
-      publishing_api
-        .given("no content exists")
-        .upon_receiving("a request to create a draft content item")
-        .with(
-          method: :put,
-          path: "/draft-content#{base_path}",
-          body: content_item,
-          headers: {
-            "Content-Type" => "application/json"
-          },
-        )
-        .will_respond_with(
-          status: 200,
-          body: content_item,
-          headers: {
-            "Content-Type" => "application/json; charset=utf-8"
-          },
-        )
-
-      response = @api_client.put_draft_content_item(base_path, content_item)
-      assert_equal 200, response.code
-    end
-  end
-
   describe "#put_intent" do
     it "responds with 200 OK if publish intent is valid" do
       base_path = "/test-intent"

--- a/test/test_helpers/publishing_api_test.rb
+++ b/test/test_helpers/publishing_api_test.rb
@@ -7,35 +7,6 @@ describe GdsApi::TestHelpers::PublishingApi do
   let(:base_api_url) { Plek.current.find("publishing-api") }
   let(:publishing_api) { GdsApi::PublishingApi.new(base_api_url) }
 
-  describe "#assert_publishing_api_put_item" do
-    before { stub_default_publishing_api_put }
-    let(:base_path) { "/example" }
-
-    it "matches a put request with any empty attributes by default" do
-      publishing_api.put_content_item(base_path, {})
-      assert_publishing_api_put_item(base_path)
-    end
-
-    it "matches a put request with any arbitrary attributes by default" do
-      random_attributes = Hash[10.times.map {|n| [Random.rand * 1_000_000_000_000, Random.rand * 1_000_000_000_000]}]
-      publishing_api.put_content_item(base_path, random_attributes)
-      assert_publishing_api_put_item(base_path)
-    end
-
-    it "if attributes are specified, matches a request with at least those attributes" do
-      publishing_api.put_content_item(base_path, {"required_attribute" => 1, "extra_attrbibute" => 1})
-      assert_publishing_api_put_item(base_path, {"required_attribute" => 1})
-    end
-
-    it "matches using a custom request matcher" do
-      publishing_api.put_content_item(base_path, {})
-      matcher_was_called = false
-      matcher = ->(request) { matcher_was_called = true; true }
-      assert_publishing_api_put_item(base_path, matcher)
-      assert matcher_was_called, "matcher should have been called"
-    end
-  end
-
   describe '#request_json_matching predicate' do
     describe "nested required attribute" do
       let(:matcher) { request_json_matching({"a" => {"b" => 1}}) }


### PR DESCRIPTION
These are being removed from the API itself so should no longer appear in here either.