### PR TITLE
Remove `ContentStore#incoming_links!`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 * Removed `GdsApi::Publisher`
 * Removed `GdsApi::ExternalLinkTracker`
-* Remove deprecated `PublishingApi` endpoints (`put_content_item` and
+* Removed deprecated `PublishingApi` endpoints (`put_content_item` and
   `put_draft_content_item`).
+* Removed `ContentStore#incoming_links!`
 
 # 37.5.1
 

--- a/lib/gds_api/content_store.rb
+++ b/lib/gds_api/content_store.rb
@@ -13,13 +13,6 @@ class GdsApi::ContentStore < GdsApi::Base
     get_json(content_item_url(base_path))
   end
 
-  def incoming_links!(base_path, params = {})
-    query = query_string(params)
-    get_json!("#{endpoint}/incoming-links#{base_path}#{query}")
-  rescue GdsApi::HTTPNotFound => e
-    raise ItemNotFound.build_from(e)
-  end
-
   def content_item!(base_path)
     get_json!(content_item_url(base_path))
   rescue GdsApi::HTTPNotFound => e

--- a/test/content_store_test.rb
+++ b/test/content_store_test.rb
@@ -74,25 +74,4 @@ describe GdsApi::ContentStore do
       assert_equal "URL: #{@base_api_url}/content/non-existent\nResponse body:\n\n\nRequest body:", e.message.strip
     end
   end
-
-  describe "#incoming_links!" do
-    it "returns the item" do
-      base_path = "/test-from-content-store?types%5B%5D=a&types%5B%5D=b"
-      content_store_has_incoming_links(base_path, [ { title: "Yolo" }])
-
-      response = @api.incoming_links!('/test-from-content-store', types: [:a, :b])
-
-      assert_equal [ { "title" => "Yolo" } ], response.to_hash
-    end
-
-    it "raises if the item doesn't exist" do
-      content_store_does_not_have_item("/non-existent")
-
-      e = assert_raises GdsApi::ContentStore::ItemNotFound do
-        response = @api.incoming_links!("/non-existent")
-      end
-
-      assert_equal 404, e.code
-    end
-  end
 end


### PR DESCRIPTION
This endpoint has been removed in https://github.com/alphagov/content-store/pull/244.