### PR TITLE
Deprecate the bang methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 * Removed deprecated `PublishingApi` endpoints (`put_content_item` and
   `put_draft_content_item`).
 * Removed `ContentStore#incoming_links!`
+* Removed `ContentStore#content_item!`
+* Removed `PublishingApiV2#get_content!`
+* Renamed `Rummager#delete_content!` to `Rummager#delete_content`
+* Renamed `Rummager#get_content!` to `Rummager#get_content`
 
 # 37.5.1
 

--- a/lib/gds_api/content_store.rb
+++ b/lib/gds_api/content_store.rb
@@ -10,13 +10,13 @@ class GdsApi::ContentStore < GdsApi::Base
   end
 
   def content_item(base_path)
-    get_json(content_item_url(base_path))
-  end
-
-  def content_item!(base_path)
     get_json!(content_item_url(base_path))
   rescue GdsApi::HTTPNotFound => e
     raise ItemNotFound.build_from(e)
+  end
+
+  def content_item!(_)
+    raise "`ContentStore#content_item!` is deprecated. Use `ContentStore#content_item` instead"
   end
 
   private

--- a/lib/gds_api/publishing_api_v2.rb
+++ b/lib/gds_api/publishing_api_v2.rb
@@ -19,20 +19,6 @@ class GdsApi::PublishingApiV2 < GdsApi::Base
 
   # Return a content item
   #
-  # Returns nil if the content item doesn't exist.
-  #
-  # @param content_id [UUID]
-  # @param params [Hash]
-  # @option params [String] locale The language, defaults to 'en' in publishing-api.
-  #
-  # @return [GdsApi::Response] a content item
-  # @see https://github.com/alphagov/publishing-api/blob/master/doc/api.md#get-v2contentcontent_id
-  def get_content(content_id, params = {})
-    get_json(content_url(content_id, params))
-  end
-
-  # Return a content item
-  #
   # Raises exception if the item doesn't exist.
   #
   # @param content_id [UUID]
@@ -43,8 +29,13 @@ class GdsApi::PublishingApiV2 < GdsApi::Base
   #
   # @raise [HTTPNotFound] when the content item is not found
   # @see https://github.com/alphagov/publishing-api/blob/master/doc/api.md#get-v2contentcontent_id
-  def get_content!(content_id, params = {})
-    get_json!(content_url(content_id, params))
+  def get_content(content_id, params = {})
+    get_json(content_url(content_id, params))
+  end
+
+  # @private
+  def get_content!(*)
+    raise "`PublishingApiV2#delete_content!` is deprecated. Use `PublishingApiV2#delete_content`"
   end
 
   # Find the content_ids for a list of base_paths.

--- a/lib/gds_api/rummager.rb
+++ b/lib/gds_api/rummager.rb
@@ -50,9 +50,14 @@ module GdsApi
     #
     # @param base_path Base path of the page on GOV.UK.
     # @see https://github.com/alphagov/rummager/blob/master/docs/content-api.md
-    def delete_content!(base_path)
+    def delete_content(base_path)
       request_url = "#{base_url}/content?link=#{base_path}"
       delete_json!(request_url)
+    end
+
+    # @private
+    def delete_content!(*)
+      raise "`Rummager#delete_content!` is deprecated. Use `Rummager#delete_content`"
     end
 
     # Retrieve a content-document from the index.
@@ -63,9 +68,14 @@ module GdsApi
     #
     # @param base_path [String] Base path of the page on GOV.UK.
     # @see https://github.com/alphagov/rummager/blob/master/docs/content-api.md
-    def get_content!(base_path)
+    def get_content(base_path)
       request_url = "#{base_url}/content?link=#{base_path}"
       get_json!(request_url)
+    end
+
+    # @private
+    def get_content!(*)
+      raise "`Rummager#get_content!` is deprecated. Use `Rummager#get_content`"
     end
 
     # Delete a non-content document from the search index.

--- a/test/content_store_test.rb
+++ b/test/content_store_test.rb
@@ -52,26 +52,4 @@ describe GdsApi::ContentStore do
       end
     end
   end
-
-  describe "#content_item!" do
-    it "returns the item" do
-      base_path = "/test-from-content-store"
-      content_store_has_item(base_path)
-
-      response = @api.content_item!(base_path)
-
-      assert_equal base_path, response["base_path"]
-    end
-
-    it "raises if the item doesn't exist" do
-      content_store_does_not_have_item("/non-existent")
-
-      e = assert_raises GdsApi::ContentStore::ItemNotFound do
-        @api.content_item!("/non-existent")
-      end
-
-      assert_equal 404, e.code
-      assert_equal "URL: #{@base_api_url}/content/non-existent\nResponse body:\n\n\nRequest body:", e.message.strip
-    end
-  end
 end

--- a/test/rummager_test.rb
+++ b/test/rummager_test.rb
@@ -135,7 +135,7 @@ describe GdsApi::Rummager do
   it "#delete_content removes a document" do
     request = stub_request(:delete, "http://example.com/content?link=/foo/bar")
 
-    GdsApi::Rummager.new("http://example.com").delete_content!("/foo/bar")
+    GdsApi::Rummager.new("http://example.com").delete_content("/foo/bar")
 
     assert_requested(request)
   end
@@ -143,7 +143,7 @@ describe GdsApi::Rummager do
   it "#get_content Retrieves a document" do
     request = stub_request(:get, "http://example.com/content?link=/foo/bar")
 
-    GdsApi::Rummager.new("http://example.com").get_content!("/foo/bar")
+    GdsApi::Rummager.new("http://example.com").get_content("/foo/bar")
 
     assert_requested(request)
   end


### PR DESCRIPTION
We used to have bang! and non-bang versions of most methods, to indicate whether or not they would raise an error. This was inconsistently implemented, causing some confusion.

Since https://github.com/alphagov/gds-api-adapters/pull/622 this gem always raises for 404s.

This PR removes the bang-versions of the methods in content store, publishing-api and rummager.