### PR TITLE
Fix linting errors

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,2 +1,10 @@
 AllCops:
   TargetRubyVersion: 2.3
+
+# Running autocorrect with this cop enabled breaks the code.
+Performance/RedundantBlockCall:
+  Enabled: false
+
+# This cop sometimes leads to ugly indentation.
+Style/ConditionalAssignment:
+  Enabled: false

--- a/Rakefile
+++ b/Rakefile
@@ -14,23 +14,23 @@ Rake::TestTask.new("test") do |t|
   t.test_files = FileList["test/**/*_test.rb"]
   t.verbose = true
 end
-task :default => :test
+task default: :test
 
 require 'pact_broker/client/tasks'
 
 def configure_pact_broker_location(task)
   task.pact_broker_base_url = ENV.fetch("PACT_BROKER_BASE_URL")
   if ENV['PACT_BROKER_USERNAME']
-    task.pact_broker_basic_auth =  { username: ENV['PACT_BROKER_USERNAME'], password: ENV['PACT_BROKER_PASSWORD']}
+    task.pact_broker_basic_auth = { username: ENV['PACT_BROKER_USERNAME'], password: ENV['PACT_BROKER_PASSWORD'] }
   end
 end
 
-PactBroker::Client::PublicationTask.new("branch") do | task |
+PactBroker::Client::PublicationTask.new("branch") do |task|
   task.consumer_version = ENV.fetch("PACT_TARGET_BRANCH")
   configure_pact_broker_location(task)
 end
 
-PactBroker::Client::PublicationTask.new("released_version") do | task |
+PactBroker::Client::PublicationTask.new("released_version") do |task|
   require 'gds_api/version'
   task.consumer_version = GdsApi::VERSION
   configure_pact_broker_location(task)
@@ -43,7 +43,7 @@ end
 
 require "gem_publisher"
 desc "Publish gem to rubygems.org if necessary"
-task :publish_gem do |t|
+task :publish_gem do |_t|
   gem = GemPublisher.publish_if_updated("gds-api-adapters.gemspec", :rubygems)
   if gem
     puts "Published #{gem}"

--- a/lib/gds_api/asset_manager.rb
+++ b/lib/gds_api/asset_manager.rb
@@ -3,7 +3,6 @@ require_relative 'exceptions'
 
 # @api documented
 class GdsApi::AssetManager < GdsApi::Base
-
   # Creates an asset given a hash with one +file+ attribute
   #
   # Makes a +POST+ request to the asset manager api to create an asset.
@@ -45,7 +44,7 @@ class GdsApi::AssetManager < GdsApi::Base
   #    response = asset_manager.create_asset(file: params[:file])
   #    response['content_type'] #=> "image/jpeg"
   def create_asset(asset)
-    post_multipart("#{base_url}/assets", { :asset => asset })
+    post_multipart("#{base_url}/assets", asset: asset)
   end
 
   # Updates an asset given a hash with one +file+ attribute
@@ -78,7 +77,7 @@ class GdsApi::AssetManager < GdsApi::Base
   #   uuid = '594602dd-75b3-4e6f-b5d1-cacf8c4d4164'
   #   asset_manager.update_asset(uuid, file: File.new('image.jpg', 'r'))
   def update_asset(id, asset)
-    put_multipart("#{base_url}/assets/#{id}", { :asset => asset })
+    put_multipart("#{base_url}/assets/#{id}", asset: asset)
   end
 
   # Fetches an asset given the id
@@ -138,8 +137,9 @@ class GdsApi::AssetManager < GdsApi::Base
     post_json("#{base_url}/assets/#{id}/restore")
   end
 
-  private
-    def base_url
-      endpoint
-    end
+private
+
+  def base_url
+    endpoint
+  end
 end

--- a/lib/gds_api/base.rb
+++ b/lib/gds_api/base.rb
@@ -38,7 +38,7 @@ class GdsApi::Base
     @logger ||= NullLogger.instance
   end
 
-  def initialize(endpoint_url, options={})
+  def initialize(endpoint_url, options = {})
     options[:endpoint_url] = endpoint_url
     raise InvalidAPIURL unless endpoint_url =~ URI::regexp
     base_options = { logger: self.class.logger }
@@ -47,7 +47,7 @@ class GdsApi::Base
     self.endpoint = options[:endpoint_url]
   end
 
-  def url_for_slug(slug, options={})
+  def url_for_slug(slug, options = {})
     "#{base_url}/#{slug}.json#{query_string(options)}"
   end
 
@@ -58,6 +58,7 @@ class GdsApi::Base
   end
 
 private
+
   attr_accessor :endpoint
 
   def query_string(params)
@@ -67,13 +68,13 @@ private
       case value
       when Array
         value.map { |v|
-          "#{CGI.escape(key.to_s+'[]')}=#{CGI.escape(v.to_s)}"
+          "#{CGI.escape(key.to_s + '[]')}=#{CGI.escape(v.to_s)}"
         }
       else
         "#{CGI.escape(key.to_s)}=#{CGI.escape(value.to_s)}"
       end
     }.flatten
 
-    "?#{param_pairs.join("&")}"
+    "?#{param_pairs.join('&')}"
   end
 end

--- a/lib/gds_api/business_support_api.rb
+++ b/lib/gds_api/business_support_api.rb
@@ -3,7 +3,6 @@ require_relative 'exceptions'
 require_relative 'list_response'
 
 class GdsApi::BusinessSupportApi < GdsApi::Base
-
   def schemes(options = {})
     get_list!(url_for_slug('business-support-schemes', options))
   end
@@ -12,7 +11,7 @@ class GdsApi::BusinessSupportApi < GdsApi::Base
     get_json!(url_for_slug("business-support-schemes/#{slug}"))
   end
 
-  private
+private
 
   def base_url
     endpoint

--- a/lib/gds_api/content_api.rb
+++ b/lib/gds_api/content_api.rb
@@ -3,7 +3,6 @@ require_relative 'exceptions'
 require_relative 'list_response'
 
 class GdsApi::ContentApi < GdsApi::Base
-
   def initialize(endpoint_url, options = {})
     # If the `web_urls_relative_to` option is given, the adapter will convert
     # any `web_url` values to relative URLs if they are from the same host.
@@ -26,7 +25,7 @@ class GdsApi::ContentApi < GdsApi::Base
     child_tags("section", parent_tag)
   end
 
-  def tags(tag_type, options={})
+  def tags(tag_type, options = {})
     params = [
       "type=#{CGI.escape(tag_type)}"
     ]
@@ -41,7 +40,7 @@ class GdsApi::ContentApi < GdsApi::Base
     get_list!("#{base_url}/tags.json?type=#{CGI.escape(tag_type)}&root_sections=true")
   end
 
-  def child_tags(tag_type, parent_tag, options={})
+  def child_tags(tag_type, parent_tag, options = {})
     params = [
       "type=#{CGI.escape(tag_type)}",
       "parent_id=#{CGI.escape(parent_tag)}",
@@ -51,7 +50,7 @@ class GdsApi::ContentApi < GdsApi::Base
     get_list!("#{base_url}/tags.json?#{params.join('&')}")
   end
 
-  def tag(tag, tag_type=nil)
+  def tag(tag, tag_type = nil)
     if tag_type.nil?
       raise "Requests for tags without a tag_type are no longer supported. You probably want a tag_type of 'section'. See https://github.com/alphagov/govuk_content_api/blob/f4c0102a1ae4970be6a440707b89798442f768b9/govuk_content_api.rb#L241-L250"
     end
@@ -64,11 +63,11 @@ class GdsApi::ContentApi < GdsApi::Base
     get_list("#{base_url}/for_need/#{CGI.escape(need_id.to_s)}.json")
   end
 
-  def artefact(slug, params={})
+  def artefact(slug, params = {})
     get_json(artefact_url(slug, params))
   end
 
-  def artefact!(slug, params={})
+  def artefact!(slug, params = {})
     get_json!(artefact_url(slug, params))
   end
 
@@ -95,9 +94,9 @@ class GdsApi::ContentApi < GdsApi::Base
 
   def business_support_schemes(facets)
     url = "#{base_url}/business_support_schemes.json"
-    query = facets.map { |k,v| "#{k}=#{v}" }
+    query = facets.map { |k, v| "#{k}=#{v}" }
     if query.any?
-      url += "?#{query.join("&")}"
+      url += "?#{query.join('&')}"
     end
 
     get_json!(url)
@@ -129,25 +128,26 @@ class GdsApi::ContentApi < GdsApi::Base
     super(url, &create_response)
   end
 
-  private
-    def base_url
-      endpoint
+private
+
+  def base_url
+    endpoint
+  end
+
+  def key_for_tag_type(tag_type)
+    tag_type.nil? ? "tag" : CGI.escape(tag_type)
+  end
+
+  def artefact_url(slug, params)
+    url = "#{base_url}/#{CGI.escape(slug)}.json"
+    query = params.map { |k, v| "#{k}=#{v}" }
+    if query.any?
+      url += "?#{query.join('&')}"
     end
 
-    def key_for_tag_type(tag_type)
-      tag_type.nil? ? "tag" : CGI.escape(tag_type)
+    if params[:edition] && ! options.include?(:bearer_token)
+      raise GdsApi::NoBearerToken
     end
-
-    def artefact_url(slug, params)
-      url = "#{base_url}/#{CGI.escape(slug)}.json"
-      query = params.map { |k,v| "#{k}=#{v}" }
-      if query.any?
-        url += "?#{query.join("&")}"
-      end
-
-      if params[:edition] && ! options.include?(:bearer_token)
-        raise GdsApi::NoBearerToken
-      end
-      url
-    end
+    url
+  end
 end

--- a/lib/gds_api/content_store.rb
+++ b/lib/gds_api/content_store.rb
@@ -2,7 +2,6 @@ require_relative 'base'
 require_relative 'exceptions'
 
 class GdsApi::ContentStore < GdsApi::Base
-
   class ItemNotFound < GdsApi::HTTPNotFound
     def self.build_from(http_error)
       new(http_error.code, http_error.message, http_error.error_details)
@@ -19,7 +18,7 @@ class GdsApi::ContentStore < GdsApi::Base
     raise "`ContentStore#content_item!` is deprecated. Use `ContentStore#content_item` instead"
   end
 
-  private
+private
 
   def content_item_url(base_path)
     "#{endpoint}/content#{base_path}"

--- a/lib/gds_api/email_alert_api.rb
+++ b/lib/gds_api/email_alert_api.rb
@@ -6,7 +6,6 @@ require_relative 'exceptions'
 # @see https://github.com/alphagov/email-alert-api
 # @api documented
 class GdsApi::EmailAlertApi < GdsApi::Base
-
   # Get or Post subscriber list
   #
   # @param attributes [Hash] document_type, links, tags used to search existing subscriber lists
@@ -42,7 +41,7 @@ class GdsApi::EmailAlertApi < GdsApi::Base
   # @option start_at [String] Optional GovDelivery bulletin id to page back through notifications
   #
   # @return [Hash] notifications
-  def notifications(start_at=nil)
+  def notifications(start_at = nil)
     url = "#{endpoint}/notifications"
     url += "?start_at=#{start_at}" if start_at
     get_json!(url)

--- a/lib/gds_api/exceptions.rb
+++ b/lib/gds_api/exceptions.rb
@@ -49,10 +49,11 @@ module GdsApi
   class NoBearerToken < BaseError; end
 
   module ExceptionHandling
-    def ignoring(exception_or_exceptions, &block)
+    def ignoring(exception_or_exceptions)
       yield
     rescue *exception_or_exceptions
       # Discard the exception
+      nil
     end
 
     def ignoring_missing(&block)

--- a/lib/gds_api/gov_uk_delivery.rb
+++ b/lib/gds_api/gov_uk_delivery.rb
@@ -3,36 +3,37 @@ require_relative 'exceptions'
 require 'json'
 
 class GdsApi::GovUkDelivery < GdsApi::Base
-
-  def initialize(endpoint_url, options={})
-    super(endpoint_url, options.merge({timeout: 10}))
+  def initialize(endpoint_url, options = {})
+    super(endpoint_url, options.merge(timeout: 10))
   end
 
   def subscribe(email, feed_urls)
-    data = {email: email, feed_urls: feed_urls}
+    data = { email: email, feed_urls: feed_urls }
     url = "#{base_url}/subscriptions"
     post_url(url, data)
   end
 
-  def topic(feed_url, title, description=nil)
-    data = {feed_url: feed_url, title: title, description: description}
+  def topic(feed_url, title, description = nil)
+    data = { feed_url: feed_url, title: title, description: description }
     url = "#{base_url}/lists"
     post_url(url, data)
   end
 
   def signup_url(feed_url)
-    if response = get_json("#{base_url}/list-url?feed_url=#{CGI.escape(feed_url)}")
+    response = get_json("#{base_url}/list-url?feed_url=#{CGI.escape(feed_url)}")
+    if response
       response['list_url']
     end
   end
 
   def notify(feed_urls, subject, body)
-    data = {feed_urls: feed_urls, subject: subject, body: body}
+    data = { feed_urls: feed_urls, subject: subject, body: body }
     url = "#{base_url}/notifications"
     post_url(url, data)
   end
 
 private
+
   def base_url
     endpoint
   end

--- a/lib/gds_api/govuk_headers.rb
+++ b/lib/gds_api/govuk_headers.rb
@@ -6,7 +6,7 @@ module GdsApi
       end
 
       def headers
-        header_data.select {|k, v| !(v.nil? || v.empty?) }
+        header_data.select { |_k, v| !(v.nil? || v.empty?) }
       end
 
       def clear_headers

--- a/lib/gds_api/imminence.rb
+++ b/lib/gds_api/imminence.rb
@@ -1,20 +1,19 @@
 require_relative 'base'
 
 class GdsApi::Imminence < GdsApi::Base
-
   def api_url(type, params)
-    vals = [:limit, :lat, :lng, :postcode].select{ |p| params.include? p }
+    vals = [:limit, :lat, :lng, :postcode].select { |p| params.include? p }
     querystring = URI.encode_www_form vals.map { |p| [p, params[p]] }
     "#{@endpoint}/places/#{type}.json?#{querystring}"
   end
 
-  def places(type, lat, lon, limit=5)
+  def places(type, lat, lon, limit = 5)
     url = api_url(type, lat: lat, lng: lon, limit: limit)
     places = get_json(url) || []
     places.map { |p| self.class.parse_place_hash(p) }
   end
 
-  def places_for_postcode(type, postcode, limit=5)
+  def places_for_postcode(type, postcode, limit = 5)
     url = api_url(type, postcode: postcode, limit: limit)
     places = get_json(url) || []
     places.map { |p| self.class.parse_place_hash(p) }
@@ -41,27 +40,27 @@ class GdsApi::Imminence < GdsApi::Base
     get_json(url)
   end
 
-private
+  # @private
   def self.extract_location_hash(location)
     # Deal with all known location formats:
     #   Old style: [latitude, longitude]; empty array for no location
     #   New style: hash with keys "longitude", "latitude"; nil for no location
     case location
     when Array
-      {"latitude" => location[0], "longitude" => location[1]}
+      { "latitude" => location[0], "longitude" => location[1] }
     when Hash
       location
     when nil
-      {"latitude" => nil, "longitude" => nil}
+      { "latitude" => nil, "longitude" => nil }
     end
   end
 
+  # @private
   def self.extract_address_hash(place_hash)
     address_fields = [
       place_hash["address1"],
       place_hash["address2"]
-    ].reject { |a| a.nil? or a == "" }
-    {"address" => address_fields.map(&:strip).join(", ")}
+    ].reject { |a| a.nil? || a == "" }
+    { "address" => address_fields.map(&:strip).join(", ") }
   end
-
 end

--- a/lib/gds_api/json_client.rb
+++ b/lib/gds_api/json_client.rb
@@ -9,7 +9,6 @@ require 'null_logger'
 
 module GdsApi
   class JsonClient
-
     include GdsApi::ExceptionHandling
 
     # Cache TTL will be overridden for a given request/response by the Expires
@@ -17,7 +16,7 @@ module GdsApi
     #
     # LRUCache doesn't respect a cache size of 0, and instead effectively
     # creates a cache with a size of 1.
-    def self.cache(size=DEFAULT_CACHE_SIZE, ttl=DEFAULT_CACHE_TTL)
+    def self.cache(size = DEFAULT_CACHE_SIZE, ttl = DEFAULT_CACHE_TTL)
       @cache ||= LRUCache.new(max_size: size, ttl: ttl)
     end
 
@@ -28,14 +27,14 @@ module GdsApi
     #   []=(key, value)
     #   store(key, value, expiry_time=nil) - or a Ruby Time object
     #
-    def self.cache=(c)
-      @cache = c
+    class << self
+      attr_writer :cache
     end
 
     attr_accessor :logger, :options, :cache
 
     def initialize(options = {})
-      if options[:disable_timeout] or options[:timeout].to_i < 0
+      if options[:disable_timeout] || options[:timeout].to_i < 0
         raise "It is no longer possible to disable the timeout."
       end
 
@@ -55,7 +54,7 @@ module GdsApi
       {
         'Accept' => 'application/json',
         # GOVUK_APP_NAME is set for all apps by Puppet
-        'User-Agent' => "gds-api-adapters/#{GdsApi::VERSION} (#{ENV["GOVUK_APP_NAME"]})"
+        'User-Agent' => "gds-api-adapters/#{GdsApi::VERSION} (#{ENV['GOVUK_APP_NAME']})"
       }
     end
 
@@ -122,22 +121,19 @@ module GdsApi
     end
 
     def post_multipart(url, params)
-      r = do_raw_request(:post, url, params.merge({
-        :multipart => true
-      }))
+      r = do_raw_request(:post, url, params.merge(multipart: true))
       Response.new(r)
     end
 
     def put_multipart(url, params)
-      r = do_raw_request(:put, url, params.merge({
-        :multipart => true
-      }))
+      r = do_raw_request(:put, url, params.merge(multipart: true))
       Response.new(r)
     end
 
-    private
+  private
+
     def do_raw_request(method, url, params = nil)
-      response = do_request(method, url, params)
+      do_request(method, url, params)
     rescue RestClient::Exception => e
       raise build_specific_http_error(e, url, nil, params)
     end
@@ -149,7 +145,6 @@ module GdsApi
     # create_response: optional block to instantiate a custom response object
     #                  from the Net::HTTPResponse
     def do_json_request(method, url, params = nil, additional_headers = {}, &create_response)
-
       begin
         response = do_request_with_cache(method, url, (params.to_json if params), additional_headers)
       rescue RestClient::Exception => e
@@ -173,7 +168,7 @@ module GdsApi
       if @options[:bearer_token]
         headers = method_params[:headers] || {}
         method_params.merge(headers: headers.merge(
-          {"Authorization" => "Bearer #{@options[:bearer_token]}"}
+          "Authorization" => "Bearer #{@options[:bearer_token]}"
         ))
       elsif @options[:basic_auth]
         method_params.merge(
@@ -250,7 +245,7 @@ module GdsApi
     end
 
     def do_request(method, url, params = nil, additional_headers = {})
-      loggable = {request_uri: url, start_time: Time.now.to_f}
+      loggable = { request_uri: url, start_time: Time.now.to_f }
       start_logging = loggable.merge(action: 'start')
       logger.debug start_logging.to_json
 

--- a/lib/gds_api/licence_application.rb
+++ b/lib/gds_api/licence_application.rb
@@ -10,7 +10,7 @@ class GdsApi::LicenceApplication < GdsApi::Base
     get_json(build_licence_url(id, snac_code))
   end
 
-  private
+private
 
   def build_licence_url(id, snac_code)
     if snac_code

--- a/lib/gds_api/list_response.rb
+++ b/lib/gds_api/list_response.rb
@@ -3,14 +3,12 @@ require "gds_api/response"
 require "link_header"
 
 module GdsApi
-
   # Response class for lists of multiple items.
   #
   # This expects responses to be in a common format, with the list of results
   # contained under the `results` key. The response may also have previous and
   # subsequent pages, indicated by entries in the response's `Link` header.
   class ListResponse < Response
-
     # The ListResponse is instantiated with a reference back to the API client,
     # so it can make requests for the subsequent pages
     def initialize(response, api_client, options = {})
@@ -39,10 +37,8 @@ module GdsApi
       # allow the data to change once it's already been loaded, so long as we
       # retain a reference to any one page in the sequence
       @next_page ||= if has_next_page?
-        @api_client.get_list! page_link("next").href
-      else
-        nil
-      end
+                       @api_client.get_list! page_link("next").href
+                     end
     end
 
     def has_previous_page?
@@ -51,10 +47,10 @@ module GdsApi
 
     def previous_page
       # See the note in `next_page` for why this is memoised
-      @previous_page ||= if has_previous_page?
-        @api_client.get_list! page_link("previous").href
-      else
-        nil
+      @previous_page ||= begin
+        if has_previous_page?
+          @api_client.get_list!(page_link("previous").href)
+        end
       end
     end
 
@@ -86,6 +82,7 @@ module GdsApi
     end
 
   private
+
     def link_header
       @link_header ||= LinkHeader.parse @http_response.headers[:link]
     end

--- a/lib/gds_api/local_links_manager.rb
+++ b/lib/gds_api/local_links_manager.rb
@@ -1,7 +1,7 @@
 require_relative 'base'
 
 class GdsApi::LocalLinksManager < GdsApi::Base
-  def local_link(authority_slug, lgsl, lgil=nil)
+  def local_link(authority_slug, lgsl, lgil = nil)
     url = "#{endpoint}/api/link?authority_slug=#{authority_slug}&lgsl=#{lgsl}"
     url += "&lgil=#{lgil}" if lgil
     get_json(url)

--- a/lib/gds_api/mapit.rb
+++ b/lib/gds_api/mapit.rb
@@ -2,7 +2,6 @@ require_relative 'base'
 require_relative 'exceptions'
 
 class GdsApi::Mapit < GdsApi::Base
-
   def location_for_postcode(postcode)
     response = get_json("#{base_url}/postcode/#{CGI.escape postcode}.json")
     Location.new(response) unless response.nil?
@@ -32,7 +31,7 @@ class GdsApi::Mapit < GdsApi::Base
     end
 
     def areas
-      @response['areas'].map {|i, area| OpenStruct.new(area) }
+      @response['areas'].map { |_i, area| OpenStruct.new(area) }
     end
 
     def postcode
@@ -40,9 +39,9 @@ class GdsApi::Mapit < GdsApi::Base
     end
   end
 
-  private
-    def base_url
-      endpoint
-    end
+private
 
+  def base_url
+    endpoint
+  end
 end

--- a/lib/gds_api/middleware/govuk_header_sniffer.rb
+++ b/lib/gds_api/middleware/govuk_header_sniffer.rb
@@ -12,7 +12,7 @@ module GdsApi
       @app.call(env)
     end
 
-    private
+  private
 
     def readable_name
       @header_name.sub(/^HTTP_/, "").downcase.to_sym

--- a/lib/gds_api/need_api.rb
+++ b/lib/gds_api/need_api.rb
@@ -1,7 +1,6 @@
 require_relative 'base'
 
 class GdsApi::NeedApi < GdsApi::Base
-
   def needs(options = {})
     query = query_string(options)
 

--- a/lib/gds_api/null_cache.rb
+++ b/lib/gds_api/null_cache.rb
@@ -1,13 +1,13 @@
 module GdsApi
   class NullCache
-    def [](k)
+    def [](_k)
       nil
     end
 
     def []=(k, v)
     end
 
-    def store(k, v, expiry_time=nil)
+    def store(k, v, expiry_time = nil)
     end
   end
 end

--- a/lib/gds_api/organisations.rb
+++ b/lib/gds_api/organisations.rb
@@ -1,7 +1,6 @@
 require_relative 'base'
 
 class GdsApi::Organisations < GdsApi::Base
-
   def organisations
     get_list! "#{base_url}/organisations"
   end
@@ -11,6 +10,7 @@ class GdsApi::Organisations < GdsApi::Base
   end
 
 private
+
   def base_url
     "#{endpoint}/api"
   end

--- a/lib/gds_api/panopticon.rb
+++ b/lib/gds_api/panopticon.rb
@@ -3,7 +3,6 @@ require_relative 'panopticon/registerer'
 require_relative 'exceptions'
 
 class GdsApi::Panopticon < GdsApi::Base
-
   include GdsApi::ExceptionHandling
 
   def all
@@ -12,8 +11,8 @@ class GdsApi::Panopticon < GdsApi::Base
     to_ostruct json
   end
 
-  def artefact_for_slug(slug, opts = {})
-    return nil if slug.nil? or slug == ''
+  def artefact_for_slug(slug, _opts = {})
+    return nil if slug.nil? || slug == ''
     get_json(url_for_slug(slug))
   end
 
@@ -65,16 +64,17 @@ class GdsApi::Panopticon < GdsApi::Base
       tag_url(tag_type, tag_id, '/publish'),
       # we don't need to send any more data along with the publish request,
       # but a body is still required, so sending an empty JSON hash instead
-      { }
+      {}
     )
   end
 
 private
+
   def base_url
     "#{endpoint}/artefacts"
   end
 
-  def tag_url(tag_type, tag_id, action='')
+  def tag_url(tag_type, tag_id, action = '')
     "#{endpoint}/tags/#{tag_type}/#{tag_id}#{action}.json"
   end
 end

--- a/lib/gds_api/publishing_api.rb
+++ b/lib/gds_api/publishing_api.rb
@@ -2,7 +2,6 @@ require_relative 'base'
 require_relative 'exceptions'
 
 class GdsApi::PublishingApi < GdsApi::Base
-
   def put_intent(base_path, payload)
     put_json!(intent_url(base_path), payload)
   end
@@ -17,7 +16,7 @@ class GdsApi::PublishingApi < GdsApi::Base
     put_json!(paths_url(base_path), payload)
   end
 
-  private
+private
 
   def intent_url(base_path)
     "#{endpoint}/publish-intent#{base_path}"

--- a/lib/gds_api/publishing_api/special_route_publisher.rb
+++ b/lib/gds_api/publishing_api/special_route_publisher.rb
@@ -12,7 +12,8 @@ module GdsApi
       def publish(options)
         logger.info("Publishing #{options.fetch(:type)} route #{options.fetch(:base_path)}, routing to #{options.fetch(:rendering_app)}")
 
-        put_content_response = publishing_api.put_content(options.fetch(:content_id), {
+        put_content_response = publishing_api.put_content(
+          options.fetch(:content_id),
           base_path: options.fetch(:base_path),
           document_type: "special_route",
           schema_name: "special_route",
@@ -26,14 +27,15 @@ module GdsApi
           ],
           publishing_app: options.fetch(:publishing_app),
           rendering_app: options.fetch(:rendering_app),
-          public_updated_at: time.now.iso8601,
-        })
+          public_updated_at: time.now.iso8601)
+
         publishing_api.patch_links(options.fetch(:content_id), links: options[:links]) if options[:links]
         publishing_api.publish(options.fetch(:content_id), 'major')
         put_content_response
       end
 
     private
+
       attr_reader :logger, :publishing_api
 
       def time

--- a/lib/gds_api/response.rb
+++ b/lib/gds_api/response.rb
@@ -5,7 +5,6 @@ require 'rack/cache'
 require_relative 'core-ext/openstruct'
 
 module GdsApi
-
   # This wraps an HTTP response with a JSON body, and presents this as
   # an object that has the read behaviour of both a Hash and an OpenStruct
   #
@@ -79,6 +78,7 @@ module GdsApi
     end
 
     def present?; true; end
+
     def blank?; false; end
 
   private

--- a/lib/gds_api/router.rb
+++ b/lib/gds_api/router.rb
@@ -1,7 +1,6 @@
 require_relative 'base'
 
 class GdsApi::Router < GdsApi::Base
-
   ### Backends
 
   def get_backend(id)
@@ -9,7 +8,7 @@ class GdsApi::Router < GdsApi::Base
   end
 
   def add_backend(id, url)
-    put_json!("#{endpoint}/backends/#{CGI.escape(id)}", :backend => {:backend_url => url})
+    put_json!("#{endpoint}/backends/#{CGI.escape(id)}", backend: { backend_url: url })
   end
 
   def delete_backend(id)
@@ -26,20 +25,30 @@ class GdsApi::Router < GdsApi::Base
   end
 
   def add_route(path, type, backend_id, options = {})
-    response = put_json!("#{endpoint}/routes", :route => {:incoming_path => path, :route_type => type, :handler => "backend", :backend_id => backend_id})
+    response = put_json!("#{endpoint}/routes", route: { incoming_path: path, route_type: type, handler: "backend", backend_id: backend_id })
     commit_routes if options[:commit]
     response
   end
 
   def add_redirect_route(path, type, destination, redirect_type = "permanent", options = {})
-    response = put_json!("#{endpoint}/routes", :route => {:incoming_path => path, :route_type => type, :handler => "redirect",
-              :redirect_to => destination, :redirect_type => redirect_type, :segments_mode => options[:segments_mode]})
+    response = put_json!(
+      "#{endpoint}/routes",
+      route: {
+        incoming_path: path,
+        route_type: type,
+        handler: "redirect",
+        redirect_to: destination,
+        redirect_type: redirect_type,
+        segments_mode: options[:segments_mode]
+      }
+    )
+
     commit_routes if options[:commit]
     response
   end
 
   def add_gone_route(path, type, options = {})
-    response = put_json!("#{endpoint}/routes", :route => {:incoming_path => path, :route_type => type, :handler => "gone"})
+    response = put_json!("#{endpoint}/routes", route: { incoming_path: path, route_type: type, handler: "gone" })
     commit_routes if options[:commit]
     response
   end

--- a/lib/gds_api/rummager.rb
+++ b/lib/gds_api/rummager.rb
@@ -4,7 +4,6 @@ require 'rack/utils'
 module GdsApi
   # @api documented
   class Rummager < Base
-
     # Perform a search.
     #
     # @param args [Hash] A valid search query. See Rummager documentation for options.

--- a/lib/gds_api/support.rb
+++ b/lib/gds_api/support.rb
@@ -2,30 +2,31 @@ require_relative 'base'
 
 class GdsApi::Support < GdsApi::Base
   def create_foi_request(request_details)
-    post_json!("#{base_url}/foi_requests", { :foi_request => request_details })
+    post_json!("#{base_url}/foi_requests", foi_request: request_details)
   end
 
   def create_problem_report(request_details)
-    post_json!("#{base_url}/anonymous_feedback/problem_reports", { :problem_report => request_details })
+    post_json!("#{base_url}/anonymous_feedback/problem_reports", problem_report: request_details)
   end
 
   def create_named_contact(request_details)
-    post_json!("#{base_url}/named_contacts", { :named_contact => request_details })
+    post_json!("#{base_url}/named_contacts", named_contact: request_details)
   end
 
   def create_anonymous_long_form_contact(request_details)
-    post_json!("#{base_url}/anonymous_feedback/long_form_contacts", { :long_form_contact => request_details })
+    post_json!("#{base_url}/anonymous_feedback/long_form_contacts", long_form_contact: request_details)
   end
 
   def create_service_feedback(request_details)
-    post_json!("#{base_url}/anonymous_feedback/service_feedback", { :service_feedback => request_details })
+    post_json!("#{base_url}/anonymous_feedback/service_feedback", service_feedback: request_details)
   end
 
   def feedback_url(slug)
     "#{base_url}/anonymous_feedback?path=#{slug}"
   end
 
-  private
+private
+
   def base_url
     endpoint
   end

--- a/lib/gds_api/support_api.rb
+++ b/lib/gds_api/support_api.rb
@@ -3,15 +3,15 @@ require_relative 'base'
 # @api documented
 class GdsApi::SupportApi < GdsApi::Base
   def create_problem_report(request_details)
-    post_json!("#{endpoint}/anonymous-feedback/problem-reports", { :problem_report => request_details })
+    post_json!("#{endpoint}/anonymous-feedback/problem-reports", problem_report: request_details)
   end
 
   def create_service_feedback(request_details)
-    post_json!("#{endpoint}/anonymous-feedback/service-feedback", { :service_feedback => request_details })
+    post_json!("#{endpoint}/anonymous-feedback/service-feedback", service_feedback: request_details)
   end
 
   def create_anonymous_long_form_contact(request_details)
-    post_json!("#{endpoint}/anonymous-feedback/long-form-contacts", { :long_form_contact => request_details })
+    post_json!("#{endpoint}/anonymous-feedback/long-form-contacts", long_form_contact: request_details)
   end
 
   def create_feedback_export_request(request_details)
@@ -137,6 +137,6 @@ class GdsApi::SupportApi < GdsApi::Base
   #
   # #=> { "success" =>  false} (status: 400)
   def mark_reviewed_for_spam(request_details)
-    put_json!("#{endpoint}/anonymous-feedback/problem-reports/mark-reviewed-for-spam", { reviewed_problem_report_ids: request_details })
+    put_json!("#{endpoint}/anonymous-feedback/problem-reports/mark-reviewed-for-spam", reviewed_problem_report_ids: request_details)
   end
 end

--- a/lib/gds_api/test_helpers/asset_manager.rb
+++ b/lib/gds_api/test_helpers/asset_manager.rb
@@ -1,16 +1,13 @@
 module GdsApi
   module TestHelpers
     module AssetManager
-
       ASSET_MANAGER_ENDPOINT = Plek.current.find('asset-manager')
 
       def asset_manager_has_an_asset(id, atts)
-        response = atts.merge({
-          "_response_info" => { "status" => "ok" }
-        })
+        response = atts.merge("_response_info" => { "status" => "ok" })
 
         stub_request(:get, "#{ASSET_MANAGER_ENDPOINT}/assets/#{id}")
-          .to_return(:body => response.to_json, :status => 200)
+          .to_return(body: response.to_json, status: 200)
       end
 
       def asset_manager_does_not_have_an_asset(id)
@@ -19,7 +16,7 @@ module GdsApi
         }
 
         stub_request(:get, "#{ASSET_MANAGER_ENDPOINT}/assets/#{id}")
-          .to_return(:body => response.to_json, :status => 404)
+          .to_return(body: response.to_json, status: 404)
       end
 
       def asset_manager_receives_an_asset(response_url)

--- a/lib/gds_api/test_helpers/business_support_api.rb
+++ b/lib/gds_api/test_helpers/business_support_api.rb
@@ -13,11 +13,11 @@ module GdsApi
         setup_business_support_stubs(BUSINESS_SUPPORT_API_ENDPOINT, 'business-support-schemes')
       end
 
-      def business_support_api_has_scheme(scheme, facets={})
+      def business_support_api_has_scheme(scheme, facets = {})
         api_has_business_support(scheme, facets)
       end
 
-      def business_support_api_has_schemes(schemes, facets={})
+      def business_support_api_has_schemes(schemes, facets = {})
         schemes.each do |scheme|
           business_support_api_has_scheme(scheme, facets)
         end
@@ -25,8 +25,8 @@ module GdsApi
 
       def business_support_api_has_a_scheme(slug, scheme)
         title = scheme.delete(:title)
-        stub_request(:get, %r{\A#{BUSINESS_SUPPORT_API_ENDPOINT}/business-support-schemes/#{slug}\.json}).to_return do |request|
-          {:body => response_base.merge(:format => 'business_support', :title => title, :details => scheme).to_json}
+        stub_request(:get, %r{\A#{BUSINESS_SUPPORT_API_ENDPOINT}/business-support-schemes/#{slug}\.json}).to_return do |_request|
+          { body: response_base.merge(format: 'business_support', title: title, details: scheme).to_json }
         end
       end
     end

--- a/lib/gds_api/test_helpers/business_support_helper.rb
+++ b/lib/gds_api/test_helpers/business_support_helper.rb
@@ -15,28 +15,29 @@ module GdsApi
           else
             results = @stubbed_business_supports
           end
-          {:body => plural_response_base.merge("results" => results, "total" => results.size).to_json}
+          { body: plural_response_base.merge("results" => results, "total" => results.size).to_json }
         end
-
       end
 
-      def api_has_business_support(business_support, facets={})
+      def api_has_business_support(business_support, facets = {})
         facets = sanitise_facets(facets)
+
         if business_support.is_a?(Symbol)
-          bs_with_facets = facets.merge(:title => business_support)
+          bs_with_facets = facets.merge(title: business_support)
         else
           bs_with_facets = facets.merge(business_support)
         end
+
         @stubbed_business_supports << bs_with_facets unless @stubbed_business_supports.include?(bs_with_facets)
       end
 
-      private
+    private
 
       def stubs_for_facets(facets)
         @stubbed_business_supports.select do |bs|
           facet_matches = 0
-          facets.each do |k,v|
-            if bs[k] and (v & bs[k]).any?
+          facets.each do |k, v|
+            if bs[k] && (v & bs[k]).any?
               facet_matches += 1
             end
           end
@@ -45,7 +46,7 @@ module GdsApi
       end
 
       def sanitise_facets(facets)
-        Hash[facets.map{ |k, v|
+        Hash[facets.map { |k, v|
           v = v.split(',') if v.is_a?(String)
           [k.to_sym, v]
         }]

--- a/lib/gds_api/test_helpers/common_responses.rb
+++ b/lib/gds_api/test_helpers/common_responses.rb
@@ -3,16 +3,16 @@ module GdsApi
     module CommonResponses
       def titleize_slug(slug, options = {})
         if options[:title_case]
-          slug.gsub("-", " ").gsub(/\b./) {|m| m.upcase }
+          slug.tr("-", " ").gsub(/\b./, &:upcase)
         else
-          slug.gsub("-", " ").capitalize
+          slug.tr("-", " ").capitalize
         end
       end
 
       # expects a slug like "ministry-of-funk"
       # returns an acronym like "MOF"
       def acronymize_slug(slug)
-        initials = slug.gsub(/\b\w+/) {|m| m[0] }.gsub("-", "")
+        initials = slug.gsub(/\b\w+/) { |m| m[0] }.delete("-")
         initials.upcase
       end
 
@@ -27,15 +27,13 @@ module GdsApi
 
       def plural_response_base
         response_base.merge(
-          {
-            "description" => "Tags!",
-            "total" => 100,
-            "start_index" => 1,
-            "page_size" => 100,
-            "current_page" => 1,
-            "pages" => 1,
-            "results" => []
-          }
+          "description" => "Tags!",
+          "total" => 100,
+          "start_index" => 1,
+          "page_size" => 100,
+          "current_page" => 1,
+          "pages" => 1,
+          "results" => []
         )
       end
     end

--- a/lib/gds_api/test_helpers/content_api/artefact_stub.rb
+++ b/lib/gds_api/test_helpers/content_api/artefact_stub.rb
@@ -16,7 +16,7 @@ module GdsApi
           @response_body = artefact_for_slug(slug)
           @response_status = 200
         end
-        
+
         def with_query_parameters(hash)
           @query_parameters = hash
           self
@@ -38,19 +38,20 @@ module GdsApi
               .with(query: hash_including(comparable_query_params))
               .to_return(status: @response_status, body: @response_body.to_json)
         end
-        
-        private
-          def url_without_query
-            "#{CONTENT_API_ENDPOINT}/#{CGI.escape(slug)}.json"
-          end
 
-          # Ensure that all keys and values are strings 
-          # because Webmock doesn't handle symbols
-          def comparable_query_params
-            @query_parameters.each_with_object({}) do |(k,v),hash| 
-              hash[k.to_s] = v.nil? ? v : v.to_s
-            end
+      private
+
+        def url_without_query
+          "#{CONTENT_API_ENDPOINT}/#{CGI.escape(slug)}.json"
+        end
+
+        # Ensure that all keys and values are strings
+        # because Webmock doesn't handle symbols
+        def comparable_query_params
+          @query_parameters.each_with_object({}) do |(k, v), hash|
+            hash[k.to_s] = v.nil? ? v : v.to_s
           end
+        end
       end
     end
   end

--- a/lib/gds_api/test_helpers/content_item_helpers.rb
+++ b/lib/gds_api/test_helpers/content_item_helpers.rb
@@ -2,7 +2,6 @@
 module GdsApi
   module TestHelpers
     module ContentItemHelpers
-
       def content_item_for_base_path(base_path)
         {
           "title" => titleize_base_path(base_path),
@@ -33,7 +32,7 @@ module GdsApi
 
       def titleize_base_path(base_path, options = {})
         if options[:title_case]
-          base_path.gsub("-", " ").gsub(/\b./) {|m| m.upcase }
+          base_path.tr("-", " ").gsub(/\b./, &:upcase)
         else
           base_path.gsub(%r{[-/]}, " ").strip.capitalize
         end

--- a/lib/gds_api/test_helpers/content_store.rb
+++ b/lib/gds_api/test_helpers/content_store.rb
@@ -15,7 +15,7 @@ module GdsApi
       #             will include "public"
       #   :draft    will point to the draft content store if set to true
 
-      def content_store_endpoint(draft=false)
+      def content_store_endpoint(draft = false)
         draft ? Plek.current.find('draft-content-store') : Plek.current.find('content-store')
       end
 
@@ -79,11 +79,11 @@ module GdsApi
       end
 
       def content_store_isnt_available
-        stub_request(:any, /#{content_store_endpoint}\/.*/).to_return(:status => 503)
+        stub_request(:any, /#{content_store_endpoint}\/.*/).to_return(status: 503)
       end
 
       def content_item_for_base_path(base_path)
-        super.merge({ "base_path" => base_path })
+        super.merge("base_path" => base_path)
       end
 
       def content_store_has_incoming_links(base_path, links)

--- a/lib/gds_api/test_helpers/email_alert_api.rb
+++ b/lib/gds_api/test_helpers/email_alert_api.rb
@@ -9,8 +9,8 @@ module GdsApi
       def email_alert_api_has_subscriber_list(attributes)
         stub_request(:get, subscriber_lists_url(attributes))
           .to_return(
-            :status => 200,
-            :body => get_subscriber_list_response(attributes).to_json,
+            status: 200,
+            body: get_subscriber_list_response(attributes).to_json,
           )
       end
 
@@ -22,15 +22,15 @@ module GdsApi
       def email_alert_api_creates_subscriber_list(attributes)
         stub_request(:post, subscriber_lists_url)
           .to_return(
-            :status => 201,
-            :body => get_subscriber_list_response(attributes).to_json,
+            status: 201,
+            body: get_subscriber_list_response(attributes).to_json,
           )
       end
 
       def email_alert_api_refuses_to_create_subscriber_list
         stub_request(:post, subscriber_lists_url)
           .to_return(
-            :status => 422,
+            status: 422,
           )
       end
 
@@ -48,8 +48,8 @@ module GdsApi
       def email_alert_api_accepts_alert
         stub_request(:post, notifications_url)
           .to_return(
-            :status => 202,
-            :body => {}.to_json,
+            status: 202,
+            body: {}.to_json,
           )
       end
 
@@ -67,14 +67,12 @@ module GdsApi
             payload = JSON.parse(request.body)
             payload.select { |k, _| attributes.key?(k) } == attributes
           end
-        else
-          matcher = nil
         end
 
         assert_requested(:post, notifications_url, times: 1, &matcher)
       end
 
-      def email_alert_api_has_notifications(notifications, start_at=nil)
+      def email_alert_api_has_notifications(notifications, start_at = nil)
         url = notifications_url
         url += "?start_at=#{start_at}" if start_at
         url_regexp = Regexp.new("^#{Regexp.escape(url)}$")

--- a/lib/gds_api/test_helpers/gov_uk_delivery.rb
+++ b/lib/gds_api/test_helpers/gov_uk_delivery.rb
@@ -3,7 +3,6 @@ require 'json'
 module GdsApi
   module TestHelpers
     module GovUkDelivery
-
       GOVUK_DELIVERY_ENDPOINT = Plek.current.find('govuk-delivery')
 
       def stub_gov_uk_delivery_post_request(method, params_hash)

--- a/lib/gds_api/test_helpers/imminence.rb
+++ b/lib/gds_api/test_helpers/imminence.rb
@@ -14,13 +14,13 @@ module GdsApi
 
       def imminence_has_areas_for_postcode(postcode, areas)
         results = {
-          "_response_info" => {"status" => "ok"},
+          "_response_info" => { "status" => "ok" },
           "total" => areas.size, "startIndex" => 1, "pageSize" => areas.size,
           "currentPage" => 1, "pages" => 1, "results" => areas
         }
 
         stub_request(:get, %r{\A#{IMMINENCE_API_ENDPOINT}/areas/#{postcode}\.json}).
-          to_return(:body => results.to_json)
+          to_return(body: results.to_json)
       end
 
       def imminence_has_places_for_postcode(places, slug, postcode, limit)
@@ -30,8 +30,8 @@ module GdsApi
 
       def stub_imminence_places_request(slug, query_hash, return_data, status_code = 200)
         stub_request(:get, "#{IMMINENCE_API_ENDPOINT}/places/#{slug}.json").
-        with(:query => query_hash).
-        to_return(:status => status_code, :body => return_data.to_json, :headers => {})
+        with(query: query_hash).
+        to_return(status: status_code, body: return_data.to_json, headers: {})
       end
     end
   end

--- a/lib/gds_api/test_helpers/intent_helpers.rb
+++ b/lib/gds_api/test_helpers/intent_helpers.rb
@@ -1,7 +1,6 @@
 module GdsApi
   module TestHelpers
     module IntentHelpers
-
       def intent_for_base_path(base_path)
         {
           "base_path" => base_path,
@@ -11,4 +10,3 @@ module GdsApi
     end
   end
 end
-

--- a/lib/gds_api/test_helpers/local_links_manager.rb
+++ b/lib/gds_api/test_helpers/local_links_manager.rb
@@ -3,7 +3,6 @@ require 'gds_api/test_helpers/json_client_helper'
 module GdsApi
   module TestHelpers
     module LocalLinksManager
-
       LOCAL_LINKS_MANAGER_ENDPOINT = Plek.current.find('local-links-manager')
 
       def local_links_manager_has_a_link(authority_slug:, lgsl:, lgil:, url:)
@@ -22,7 +21,7 @@ module GdsApi
         }
 
         stub_request(:get, "#{LOCAL_LINKS_MANAGER_ENDPOINT}/api/link")
-          .with(query: {authority_slug: authority_slug, lgsl: lgsl, lgil: lgil})
+          .with(query: { authority_slug: authority_slug, lgsl: lgsl, lgil: lgil })
           .to_return(body: response.to_json, status: 200)
       end
 
@@ -37,7 +36,7 @@ module GdsApi
         }
 
         stub_request(:get, "#{LOCAL_LINKS_MANAGER_ENDPOINT}/api/link")
-          .with(query: {authority_slug: authority_slug, lgsl: lgsl, lgil: lgil})
+          .with(query: { authority_slug: authority_slug, lgsl: lgsl, lgil: lgil })
           .to_return(body: response.to_json, status: 200)
       end
 
@@ -52,7 +51,7 @@ module GdsApi
         }
 
         stub_request(:get, "#{LOCAL_LINKS_MANAGER_ENDPOINT}/api/link")
-          .with(query: {authority_slug: authority_slug, lgsl: lgsl, lgil: lgil})
+          .with(query: { authority_slug: authority_slug, lgsl: lgsl, lgil: lgil })
           .to_return(body: response.to_json, status: 200)
       end
 
@@ -72,7 +71,7 @@ module GdsApi
         }
 
         stub_request(:get, "#{LOCAL_LINKS_MANAGER_ENDPOINT}/api/link")
-          .with(query: {authority_slug: authority_slug, lgsl: lgsl})
+          .with(query: { authority_slug: authority_slug, lgsl: lgsl })
           .to_return(body: response.to_json, status: 200)
       end
 
@@ -87,7 +86,7 @@ module GdsApi
         }
 
         stub_request(:get, "#{LOCAL_LINKS_MANAGER_ENDPOINT}/api/link")
-          .with(query: {authority_slug: authority_slug, lgsl: lgsl})
+          .with(query: { authority_slug: authority_slug, lgsl: lgsl })
           .to_return(body: response.to_json, status: 200)
       end
 
@@ -100,9 +99,9 @@ module GdsApi
           .to_return(body: {}.to_json, status: 400)
       end
 
-      def local_links_manager_does_not_have_required_objects(authority_slug, lgsl, lgil=nil)
+      def local_links_manager_does_not_have_required_objects(authority_slug, lgsl, lgil = nil)
         params = { authority_slug: authority_slug, lgsl: lgsl }
-        params.merge!(lgil: lgil) if lgil
+        params[:lgil] = lgil if lgil
 
         stub_request(:get, "#{LOCAL_LINKS_MANAGER_ENDPOINT}/api/link")
           .with(query: params)
@@ -121,7 +120,7 @@ module GdsApi
         }
 
         stub_request(:get, "#{LOCAL_LINKS_MANAGER_ENDPOINT}/api/local-authority")
-          .with(query: {authority_slug: authority_slug})
+          .with(query: { authority_slug: authority_slug })
           .to_return(body: response.to_json, status: 200)
       end
 
@@ -142,19 +141,19 @@ module GdsApi
         }
 
         stub_request(:get, "#{LOCAL_LINKS_MANAGER_ENDPOINT}/api/local-authority")
-          .with(query: {authority_slug: district_slug})
+          .with(query: { authority_slug: district_slug })
           .to_return(body: response.to_json, status: 200)
       end
 
       def local_links_manager_request_without_local_authority_slug
         stub_request(:get, "#{LOCAL_LINKS_MANAGER_ENDPOINT}/api/local-authority")
-        .with(query: {authority_slug: ''})
+        .with(query: { authority_slug: '' })
         .to_return(body: {}.to_json, status: 400)
       end
 
       def local_links_manager_does_not_have_an_authority(authority_slug)
         stub_request(:get, "#{LOCAL_LINKS_MANAGER_ENDPOINT}/api/local-authority")
-        .with(query: {authority_slug: authority_slug})
+        .with(query: { authority_slug: authority_slug })
         .to_return(body: {}.to_json, status: 404)
       end
 
@@ -170,7 +169,7 @@ module GdsApi
         }
 
         stub_request(:get, "#{LOCAL_LINKS_MANAGER_ENDPOINT}/api/local-authority")
-          .with(query: {authority_slug: authority_slug})
+          .with(query: { authority_slug: authority_slug })
           .to_return(body: response.to_json, status: 200)
       end
     end

--- a/lib/gds_api/test_helpers/mapit.rb
+++ b/lib/gds_api/test_helpers/mapit.rb
@@ -1,7 +1,6 @@
 module GdsApi
   module TestHelpers
     module Mapit
-
       MAPIT_ENDPOINT = Plek.current.find('mapit')
 
       def mapit_has_a_postcode(postcode, coords)
@@ -11,10 +10,10 @@ module GdsApi
           "postcode"  => postcode
         }
 
-        stub_request(:get, "#{MAPIT_ENDPOINT}/postcode/" + postcode.gsub(' ','+') + ".json")
-          .to_return(:body => response.to_json, :status => 200)
+        stub_request(:get, "#{MAPIT_ENDPOINT}/postcode/" + postcode.tr(' ', '+') + ".json")
+          .to_return(body: response.to_json, status: 200)
         stub_request(:get, "#{MAPIT_ENDPOINT}/postcode/partial/" + postcode.split(' ').first + ".json")
-          .to_return(:body => response.to_json, :status => 200)
+          .to_return(body: response.to_json, status: 200)
       end
 
       def mapit_has_a_postcode_and_areas(postcode, coords, areas)
@@ -36,40 +35,40 @@ module GdsApi
           }]
         }]
 
-        stub_request(:get, "#{MAPIT_ENDPOINT}/postcode/" + postcode.gsub(' ','+') + ".json")
-          .to_return(:body => response.merge({'areas' => area_response}).to_json, :status => 200)
+        stub_request(:get, "#{MAPIT_ENDPOINT}/postcode/" + postcode.tr(' ', '+') + ".json")
+          .to_return(body: response.merge('areas' => area_response).to_json, status: 200)
         stub_request(:get, "#{MAPIT_ENDPOINT}/postcode/partial/" + postcode.split(' ').first + ".json")
-          .to_return(:body => response.to_json, :status => 200)
+          .to_return(body: response.to_json, status: 200)
       end
 
       def mapit_does_not_have_a_postcode(postcode)
-        stub_request(:get, "#{MAPIT_ENDPOINT}/postcode/" + postcode.gsub(' ','+') + ".json")
-          .to_return(:body => { "code" => 404, "error" => "No Postcode matches the given query." }.to_json, :status => 404)
+        stub_request(:get, "#{MAPIT_ENDPOINT}/postcode/" + postcode.tr(' ', '+') + ".json")
+          .to_return(body: { "code" => 404, "error" => "No Postcode matches the given query." }.to_json, status: 404)
       end
 
       def mapit_does_not_have_a_bad_postcode(postcode)
-        stub_request(:get, "#{MAPIT_ENDPOINT}/postcode/" + postcode.gsub(' ','+') + ".json")
-          .to_return(:body => { "code" => 400, "error" => "Postcode '#{postcode}' is not valid." }.to_json, :status => 400)
+        stub_request(:get, "#{MAPIT_ENDPOINT}/postcode/" + postcode.tr(' ', '+') + ".json")
+          .to_return(body: { "code" => 400, "error" => "Postcode '#{postcode}' is not valid." }.to_json, status: 400)
       end
 
       def mapit_has_areas(area_type, areas)
         stub_request(:get, "#{MAPIT_ENDPOINT}/areas/" + area_type + ".json")
-          .to_return(:body => areas.to_json, :status => 200)
+          .to_return(body: areas.to_json, status: 200)
       end
 
       def mapit_does_not_have_areas(area_type)
         stub_request(:get, "#{MAPIT_ENDPOINT}/areas/" + area_type + ".json")
-          .to_return(:body => [].to_json, :status => 200)
+          .to_return(body: [].to_json, status: 200)
       end
 
       def mapit_has_area_for_code(code_type, code, area)
         stub_request(:get, "#{MAPIT_ENDPOINT}/code/#{code_type}/#{code}.json")
-          .to_return(:body => area.to_json, :status => 200)
+          .to_return(body: area.to_json, status: 200)
       end
 
       def mapit_does_not_have_area_for_code(code_type, code)
         stub_request(:get, "#{MAPIT_ENDPOINT}/code/#{code_type}/#{code}.json")
-        .to_return(:body => { "code" => 404, "error" => "No areas were found that matched code #{code_type} = #{code}." }.to_json, :status => 404)
+        .to_return(body: { "code" => 404, "error" => "No areas were found that matched code #{code_type} = #{code}." }.to_json, status: 404)
       end
     end
   end

--- a/lib/gds_api/test_helpers/need_api.rb
+++ b/lib/gds_api/test_helpers/need_api.rb
@@ -51,7 +51,7 @@ module GdsApi
       end
 
       def need_api_has_need_ids(needs)
-        ids = needs.map {|need| (need["id"] || need[:id]).to_i }.sort.join(',')
+        ids = needs.map { |need| (need["id"] || need[:id]).to_i }.sort.join(',')
         url = NEED_API_ENDPOINT + "/needs?ids=#{ids}"
 
         body = response_base.merge(
@@ -85,7 +85,7 @@ module GdsApi
       def need_api_has_no_need(need_id)
         url = NEED_API_ENDPOINT + "/needs/#{need_id}"
         not_found_body = {
-          "_response_info" => {"status" => "not_found"},
+          "_response_info" => { "status" => "not_found" },
           "error" => "No need exists with this ID"
         }
         stub_request(:get, url).to_return(
@@ -97,8 +97,8 @@ module GdsApi
 
       def stub_create_note(note_details = nil)
         post_stub = stub_request(:post, NEED_API_ENDPOINT + "/notes")
-        post_stub.with(:body => note_details.to_json) unless note_details.nil?
-        post_stub.to_return(:status => 201)
+        post_stub.with(body: note_details.to_json) unless note_details.nil?
+        post_stub.to_return(status: 201)
       end
     end
   end

--- a/lib/gds_api/test_helpers/organisations.rb
+++ b/lib/gds_api/test_helpers/organisations.rb
@@ -34,43 +34,41 @@ module GdsApi
         end
 
         pages.each_with_index do |page, i|
-          page_details = plural_response_base.merge({
-            "results" => page,
+          page_details = plural_response_base.merge("results" => page,
             "total" => organisation_bodies.size,
             "pages" => pages.size,
             "current_page" => i + 1,
             "page_size" => 20,
-            "start_index" => i * 20 + 1,
-          })
+            "start_index" => i * 20 + 1)
 
-          links = {:self => "#{ORGANISATIONS_API_ENDPOINT}/api/organisations?page=#{i + 1}" }
-          links[:next] = "#{ORGANISATIONS_API_ENDPOINT}/api/organisations?page=#{i + 2}" if pages[i+1]
+          links = { self: "#{ORGANISATIONS_API_ENDPOINT}/api/organisations?page=#{i + 1}" }
+          links[:next] = "#{ORGANISATIONS_API_ENDPOINT}/api/organisations?page=#{i + 2}" if pages[i + 1]
           links[:previous] = "#{ORGANISATIONS_API_ENDPOINT}/api/organisations?page=#{i}" unless i == 0
           page_details["_response_info"]["links"] = []
           link_headers = []
           links.each do |rel, href|
-            page_details["_response_info"]["links"] << {"rel" => rel, "href" => href}
+            page_details["_response_info"]["links"] << { "rel" => rel, "href" => href }
             link_headers << "<#{href}>; rel=\"#{rel}\""
           end
 
           stub_request(:get, links[:self]).
-            to_return(:status => 200, :body => page_details.to_json, :headers => {"Link" => link_headers.join(", ")})
+            to_return(status: 200, body: page_details.to_json, headers: { "Link" => link_headers.join(", ") })
           if i == 0
             # First page exists at URL with and without page param
             stub_request(:get, links[:self].sub(/\?page=1/, '')).
-              to_return(:status => 200, :body => page_details.to_json, :headers => {"Link" => link_headers.join(", ")})
+              to_return(status: 200, body: page_details.to_json, headers: { "Link" => link_headers.join(", ") })
           end
         end
       end
 
-      def organisations_api_has_organisation(organisation_slug, details=nil)
+      def organisations_api_has_organisation(organisation_slug, details = nil)
         details ||= organisation_for_slug(organisation_slug)
         stub_request(:get, "#{ORGANISATIONS_API_ENDPOINT}/api/organisations/#{organisation_slug}").
-          to_return(:status => 200, :body => details.to_json)
+          to_return(status: 200, body: details.to_json)
       end
 
       def organisations_api_does_not_have_organisation(organisation_slug)
-        stub_request(:get, "#{ORGANISATIONS_API_ENDPOINT}/api/organisations/#{organisation_slug}").to_return(:status => 404)
+        stub_request(:get, "#{ORGANISATIONS_API_ENDPOINT}/api/organisations/#{organisation_slug}").to_return(status: 404)
       end
 
       def organisation_for_slug(slug)
@@ -81,17 +79,17 @@ module GdsApi
       #
       # if the slug contains 'ministry' the format will be set to 'Ministerial department'
       # otherwise it will be set to 'Executive agency'
-      def organisation_details_for_slug(slug, content_id=SecureRandom.uuid)
+      def organisation_details_for_slug(slug, content_id = SecureRandom.uuid)
         {
           "id" => "#{ORGANISATIONS_API_ENDPOINT}/api/organisations/#{slug}",
-          "title" => titleize_slug(slug, :title_case => true),
+          "title" => titleize_slug(slug, title_case: true),
           "format" => (slug =~ /ministry/ ? "Ministerial department" : "Executive agency"),
           "updated_at" => "2013-03-25T13:06:42+00:00",
           "web_url" => "#{PUBLIC_HOST}/government/organisations/#{slug}",
           "details" => {
             "slug" => slug,
             "abbreviation" => acronymize_slug(slug),
-            "logo_formatted_name" => titleize_slug(slug, :title_case => true),
+            "logo_formatted_name" => titleize_slug(slug, title_case: true),
             "organisation_brand_colour_class_name" => slug,
             "organisation_logo_type_class_name" => (slug =~ /ministry/ ? "single-identity" : "eo"),
             "closed_at" => nil,

--- a/lib/gds_api/test_helpers/panopticon.rb
+++ b/lib/gds_api/test_helpers/panopticon.rb
@@ -23,20 +23,20 @@ module GdsApi
         urls << "#{PANOPTICON_ENDPOINT}/artefacts/#{metadata['id']}.json" if metadata['id']
         urls << "#{PANOPTICON_ENDPOINT}/artefacts/#{metadata['slug']}.json" if metadata['slug']
 
-        urls.each { |url| stub_request(:get, url).to_return(:status => 200, :body => json, :headers => {}) }
+        urls.each { |url| stub_request(:get, url).to_return(status: 200, body: json, headers: {}) }
 
-        return urls.first
+        urls.first
       end
 
       def panopticon_has_no_metadata_for(slug)
         url = "#{PANOPTICON_ENDPOINT}/artefacts/#{slug}.json"
-        stub_request(:get, url).to_return(:status => 404, :body => "", :headers => {})
+        stub_request(:get, url).to_return(status: 404, body: "", headers: {})
       end
 
       def stub_panopticon_default_artefact
         stub_request(:get, %r{\A#{PANOPTICON_ENDPOINT}/artefacts}).to_return { |request|
           # return a response with only a slug, and set that slug to match the requested artefact slug
-          {:body => JSON.dump("slug" => request.uri.path.split('/').last.chomp('.json'))}
+          { body: JSON.dump("slug" => request.uri.path.split('/').last.chomp('.json')) }
         }
       end
 
@@ -45,10 +45,10 @@ module GdsApi
 
         if request_details
           request_details = request_details.to_json unless custom_matcher
-          stub.with(:body => request_details) 
+          stub.with(body: request_details)
         end
 
-        stub.to_return(:status => 201)
+        stub.to_return(status: 201)
       end
 
       def stub_panopticon_tag_creation(attributes)

--- a/lib/gds_api/test_helpers/performance_platform/data_in.rb
+++ b/lib/gds_api/test_helpers/performance_platform/data_in.rb
@@ -2,42 +2,42 @@ module GdsApi
   module TestHelpers
     module PerformancePlatform
       module DataIn
-        PP_DATA_IN_ENDPOINT = "http://www.performance.dev.gov.uk"
+        PP_DATA_IN_ENDPOINT = "http://www.performance.dev.gov.uk".freeze
 
         def stub_service_feedback_day_aggregate_submission(slug, request_body = nil)
           post_stub = stub_http_request(:post, "#{PP_DATA_IN_ENDPOINT}/data/#{slug}/customer-satisfaction")
           post_stub.with(body: request_body) unless request_body.nil?
-          post_stub.to_return(:status => 200)
+          post_stub.to_return(status: 200)
         end
 
         def stub_corporate_content_problem_report_count_submission(submissions = nil)
           post_stub = stub_http_request(:post, "#{PP_DATA_IN_ENDPOINT}/data/gov-uk-content/feedback-count")
           post_stub.with(body: submissions.to_json) unless submissions.nil?
-          post_stub.to_return(:status => 200)
+          post_stub.to_return(status: 200)
         end
 
         def stub_corporate_content_urls_with_the_most_problem_reports_submission(submissions = nil)
           post_stub = stub_http_request(:post, "#{PP_DATA_IN_ENDPOINT}/data/gov-uk-content/top-urls")
           post_stub.with(body: submissions.to_json) unless submissions.nil?
-          post_stub.to_return(:status => 200)
+          post_stub.to_return(status: 200)
         end
 
         def stub_problem_report_daily_totals_submission(submissions = nil)
           post_stub = stub_http_request(:post, "#{PP_DATA_IN_ENDPOINT}/data/govuk-info/page-contacts")
           post_stub.with(body: submissions.to_json) unless submissions.nil?
-          post_stub.to_return(:status => 200)
+          post_stub.to_return(status: 200)
         end
 
         def stub_service_feedback_bucket_unavailable_for(slug)
-          stub_request(:post, "#{PP_DATA_IN_ENDPOINT}/data/#{slug}/customer-satisfaction").to_return(:status => 404)
+          stub_request(:post, "#{PP_DATA_IN_ENDPOINT}/data/#{slug}/customer-satisfaction").to_return(status: 404)
         end
 
         def stub_pp_isnt_available
-          stub_request(:post, /#{PP_DATA_IN_ENDPOINT}\/.*/).to_return(:status => 503)
+          stub_request(:post, /#{PP_DATA_IN_ENDPOINT}\/.*/).to_return(status: 503)
         end
 
         def stub_pp_dataset_unavailable
-          stub_request(:any, /#{PP_DATA_IN_ENDPOINT}/).to_return(:status => 404)
+          stub_request(:any, /#{PP_DATA_IN_ENDPOINT}/).to_return(status: 404)
         end
       end
     end

--- a/lib/gds_api/test_helpers/publishing_api.rb
+++ b/lib/gds_api/test_helpers/publishing_api.rb
@@ -14,15 +14,15 @@ module GdsApi
       def stub_publishing_api_put_intent(base_path, body = intent_for_publishing_api(base_path))
         url = PUBLISHING_API_ENDPOINT + "/publish-intent" + base_path
         body = body.to_json unless body.is_a?(String)
-        stub_request(:put, url).with(body: body).to_return(status: 200, body: '{}', headers: {"Content-Type" => "application/json; charset=utf-8"})
+        stub_request(:put, url).with(body: body).to_return(status: 200, body: '{}', headers: { "Content-Type" => "application/json; charset=utf-8" })
       end
 
       def stub_publishing_api_destroy_intent(base_path)
         url = PUBLISHING_API_ENDPOINT + "/publish-intent" + base_path
-        stub_request(:delete, url).to_return(status: 200, body: '{}', headers: {"Content-Type" => "application/json; charset=utf-8"})
+        stub_request(:delete, url).to_return(status: 200, body: '{}', headers: { "Content-Type" => "application/json; charset=utf-8" })
       end
 
-      def stub_default_publishing_api_put_intent()
+      def stub_default_publishing_api_put_intent
         stub_request(:put, %r{\A#{PUBLISHING_API_ENDPOINT}/publish-intent})
       end
 
@@ -60,43 +60,42 @@ module GdsApi
       end
 
       def publishing_api_isnt_available
-        stub_request(:any, /#{PUBLISHING_API_ENDPOINT}\/.*/).to_return(:status => 503)
+        stub_request(:any, /#{PUBLISHING_API_ENDPOINT}\/.*/).to_return(status: 503)
       end
 
       def stub_default_publishing_api_path_reservation
         stub_request(:put, %r[\A#{PUBLISHING_API_ENDPOINT}/paths/]).to_return { |request|
-           base_path = request.uri.path.sub(%r{\A/paths/}, "")
-           { :status => 200,  :headers => {:content_type => "application/json"},
-             :body => publishing_api_path_data_for(base_path).to_json }
+          base_path = request.uri.path.sub(%r{\A/paths/}, "")
+          { status: 200, headers: { content_type: "application/json" },
+            body: publishing_api_path_data_for(base_path).to_json }
         }
       end
 
       def publishing_api_has_path_reservation_for(path, publishing_app)
         data = publishing_api_path_data_for(path, "publishing_app" => publishing_app)
-        error_data = data.merge({
-          "errors" => {"path" => ["is already reserved by the #{publishing_app} application"]},
-        })
+        error_data = data.merge("errors" => { "path" => ["is already reserved by the #{publishing_app} application"] })
 
         stub_request(:put, "#{PUBLISHING_API_ENDPOINT}/paths#{path}").
-                  to_return(:status => 422, :body => error_data.to_json,
-                            :headers => {:content_type => "application/json"})
+                  to_return(status: 422, body: error_data.to_json,
+                            headers: { content_type: "application/json" })
 
         stub_request(:put, "#{PUBLISHING_API_ENDPOINT}/paths#{path}").
-          with(:body => {"publishing_app" => publishing_app}).
-          to_return(:status => 200,
-                    :headers => {:content_type => "application/json"},
-                    :body => data.to_json)
+          with(body: { "publishing_app" => publishing_app }).
+          to_return(status: 200,
+                    headers: { content_type: "application/json" },
+                    body: data.to_json)
       end
 
       def publishing_api_returns_path_reservation_validation_error_for(path, error_details = nil)
-        error_details ||= {"base" => ["computer says no"]}
+        error_details ||= { "base" => ["computer says no"] }
         error_data = publishing_api_path_data_for(path).merge("errors" => error_details)
 
         stub_request(:put, "#{PUBLISHING_API_ENDPOINT}/paths#{path}").
-          to_return(:status => 422, :body => error_data.to_json, :headers => {:content_type => "application/json"})
+          to_return(status: 422, body: error_data.to_json, headers: { content_type: "application/json" })
       end
 
     private
+
       def values_match_recursively(expected_value, actual_value)
         case expected_value
         when Hash
@@ -116,11 +115,11 @@ module GdsApi
         end
       end
 
-      def content_item_for_publishing_api(base_path, publishing_app="publisher")
+      def content_item_for_publishing_api(base_path, publishing_app = "publisher")
         content_item_for_base_path(base_path).merge("publishing_app" => publishing_app)
       end
 
-      def intent_for_publishing_api(base_path, publishing_app="publisher")
+      def intent_for_publishing_api(base_path, publishing_app = "publisher")
         intent_for_base_path(base_path).merge("publishing_app" => publishing_app)
       end
 

--- a/lib/gds_api/test_helpers/publishing_api_v2.rb
+++ b/lib/gds_api/test_helpers/publishing_api_v2.rb
@@ -35,7 +35,7 @@ module GdsApi
         response = {
           status: 200,
           body: '{}',
-          headers: {"Content-Type" => "application/json; charset=utf-8"}
+          headers: { "Content-Type" => "application/json; charset=utf-8" }
         }.merge(response_hash)
         stub_request(:post, url).with(body: body).to_return(response)
       end
@@ -45,14 +45,14 @@ module GdsApi
         response = {
           status: 200,
           body: '{}',
-          headers: {"Content-Type" => "application/json; charset=utf-8"}
+          headers: { "Content-Type" => "application/json; charset=utf-8" }
         }.merge(response_hash)
         stub_request(:post, url).with(params).to_return(response)
       end
 
       def stub_publishing_api_discard_draft(content_id)
         url = PUBLISHING_API_V2_ENDPOINT + "/content/#{content_id}/discard-draft"
-        stub_request(:post, url).to_return(status: 200, headers: {"Content-Type" => "application/json; charset=utf-8"})
+        stub_request(:post, url).to_return(status: 200, headers: { "Content-Type" => "application/json; charset=utf-8" })
       end
 
       def stub_publishing_api_put_content_links_and_publish(body, content_id = nil, publish_body = nil)
@@ -94,7 +94,7 @@ module GdsApi
 
       def stub_any_publishing_api_call_to_return_not_found
         stub_request(:any, %r{\A#{PUBLISHING_API_V2_ENDPOINT}})
-          .to_return(status: 404, headers: {"Content-Type" => "application/json; charset=utf-8"})
+          .to_return(status: 404, headers: { "Content-Type" => "application/json; charset=utf-8" })
       end
 
       def publishing_api_isnt_available
@@ -186,7 +186,7 @@ module GdsApi
           page = 1
         end
 
-        start_position = (page-1) * per_page
+        start_position = (page - 1) * per_page
         page_items = items.slice(start_position, per_page) || []
 
         number_of_pages =
@@ -221,12 +221,12 @@ module GdsApi
 
         url = PUBLISHING_API_V2_ENDPOINT + "/content?document_type=#{format}#{query_params.join('')}"
 
-        stub_request(:get, url).to_return(:status => 200, :body => { results: body }.to_json, :headers => {})
+        stub_request(:get, url).to_return(status: 200, body: { results: body }.to_json, headers: {})
       end
 
       def publishing_api_has_linkables(linkables, document_type:)
         url = PUBLISHING_API_V2_ENDPOINT + "/linkables?document_type=#{document_type}"
-        stub_request(:get, url).to_return(:status => 200, :body => linkables.to_json, :headers => {})
+        stub_request(:get, url).to_return(status: 200, body: linkables.to_json, headers: {})
       end
 
       def publishing_api_has_item(item)
@@ -240,7 +240,7 @@ module GdsApi
         url = PUBLISHING_API_V2_ENDPOINT + "/content/" + content_id
         calls = -1
 
-        stub_request(:get, url).to_return do |request|
+        stub_request(:get, url).to_return do |_request|
           calls += 1
           item = items[calls] || items.last
 
@@ -414,7 +414,7 @@ module GdsApi
       end
 
       def stub_publishing_api_postlike_call(method, content_id, body, resource_path, override_response_hash = {})
-        response_hash = {status: 200, body: '{}', headers: {"Content-Type" => "application/json; charset=utf-8"}}
+        response_hash = { status: 200, body: '{}', headers: { "Content-Type" => "application/json; charset=utf-8" } }
         response_hash.merge!(override_response_hash)
         response_hash[:body] = response_hash[:body].to_json if response_hash[:body].is_a?(Hash)
         url = PUBLISHING_API_V2_ENDPOINT + resource_path + "/" + content_id
@@ -422,7 +422,7 @@ module GdsApi
       end
 
       def deep_stringify_keys(hash)
-        deep_transform_keys(hash) { |key| key.to_s }
+        deep_transform_keys(hash, &:to_s)
       end
 
       def deep_transform_keys(object, &block)
@@ -432,7 +432,7 @@ module GdsApi
             result[yield(key)] = deep_transform_keys(value, &block)
           end
         when Array
-          object.map{ |item| deep_transform_keys(item, &block) }
+          object.map { |item| deep_transform_keys(item, &block) }
         else
           object
         end

--- a/lib/gds_api/test_helpers/router.rb
+++ b/lib/gds_api/test_helpers/router.rb
@@ -12,10 +12,10 @@ module GdsApi
       end
 
       def stub_router_backend_registration(backend_id, backend_url)
-        backend = { "backend" => { "backend_url" => backend_url }}
+        backend = { "backend" => { "backend_url" => backend_url } }
         stub_http_request(:put, "#{ROUTER_API_ENDPOINT}/backends/#{backend_id}")
-            .with(:body => backend.to_json)
-            .to_return(:status => 201)
+            .with(body: backend.to_json)
+            .to_return(status: 201)
       end
 
       def stub_route_registration(path, type, backend_id)
@@ -66,8 +66,8 @@ module GdsApi
 
       def stub_route_put(route)
         stub_http_request(:put, "#{ROUTER_API_ENDPOINT}/routes")
-            .with(:body => route.to_json)
-            .to_return(:status => 201)
+            .with(body: route.to_json)
+            .to_return(status: 201)
       end
     end
   end

--- a/lib/gds_api/test_helpers/rummager.rb
+++ b/lib/gds_api/test_helpers/rummager.rb
@@ -100,7 +100,7 @@ module GdsApi
         run_example_query
       end
 
-      def rummager_has_specialist_sector_organisations(sub_sector)
+      def rummager_has_specialist_sector_organisations(_sub_sector)
         stub_request_for(sub_sector_organisations_results)
         run_example_query
       end
@@ -111,9 +111,9 @@ module GdsApi
       end
 
       def rummager_has_policies_for_every_type(options = {})
-        if count = options[:count]
-          stub_request(:get, %r{/search.json.*count=#{count}.*})
-            .to_return(body: first_n_results(new_policies_results, n: count))
+        if options[:count]
+          stub_request(:get, %r{/search.json.*count=#{options[:count]}.*})
+            .to_return(body: first_n_results(new_policies_results, n: options[:count]))
         else
           stub_request(:get, %r{/search.json})
             .to_return(body: new_policies_results)
@@ -121,6 +121,7 @@ module GdsApi
       end
 
     private
+
       def stub_request_for(result_set)
         stub_request(:get, /example.com\/search/).to_return(body: result_set)
       end

--- a/lib/gds_api/test_helpers/support.rb
+++ b/lib/gds_api/test_helpers/support.rb
@@ -5,36 +5,36 @@ module GdsApi
 
       def stub_support_foi_request_creation(request_details = nil)
         post_stub = stub_http_request(:post, "#{SUPPORT_ENDPOINT}/foi_requests")
-        post_stub.with(:body => {"foi_request" => request_details}) unless request_details.nil?
-        post_stub.to_return(:status => 201)
+        post_stub.with(body: { "foi_request" => request_details }) unless request_details.nil?
+        post_stub.to_return(status: 201)
       end
 
       def stub_support_problem_report_creation(request_details = nil)
         post_stub = stub_http_request(:post, "#{SUPPORT_ENDPOINT}/anonymous_feedback/problem_reports")
-        post_stub.with(:body => { problem_report: request_details }) unless request_details.nil?
-        post_stub.to_return(:status => 201)
+        post_stub.with(body: { problem_report: request_details }) unless request_details.nil?
+        post_stub.to_return(status: 201)
       end
 
       def stub_support_named_contact_creation(request_details = nil)
         post_stub = stub_http_request(:post, "#{SUPPORT_ENDPOINT}/named_contacts")
-        post_stub.with(:body => { named_contact: request_details }) unless request_details.nil?
-        post_stub.to_return(:status => 201)
+        post_stub.with(body: { named_contact: request_details }) unless request_details.nil?
+        post_stub.to_return(status: 201)
       end
 
       def stub_support_long_form_anonymous_contact_creation(request_details = nil)
         post_stub = stub_http_request(:post, "#{SUPPORT_ENDPOINT}/anonymous_feedback/long_form_contacts")
-        post_stub.with(:body => { long_form_contact: request_details }) unless request_details.nil?
-        post_stub.to_return(:status => 201)
+        post_stub.with(body: { long_form_contact: request_details }) unless request_details.nil?
+        post_stub.to_return(status: 201)
       end
 
       def stub_support_service_feedback_creation(feedback_details = nil)
         post_stub = stub_http_request(:post, "#{SUPPORT_ENDPOINT}/anonymous_feedback/service_feedback")
-        post_stub.with(:body => { service_feedback: feedback_details }) unless feedback_details.nil?
-        post_stub.to_return(:status => 201)
+        post_stub.with(body: { service_feedback: feedback_details }) unless feedback_details.nil?
+        post_stub.to_return(status: 201)
       end
 
       def support_isnt_available
-        stub_request(:post, /#{SUPPORT_ENDPOINT}\/.*/).to_return(:status => 503)
+        stub_request(:post, /#{SUPPORT_ENDPOINT}\/.*/).to_return(status: 503)
       end
     end
   end

--- a/lib/gds_api/test_helpers/support_api.rb
+++ b/lib/gds_api/test_helpers/support_api.rb
@@ -8,38 +8,38 @@ module GdsApi
 
       def stub_support_api_problem_report_creation(request_details = nil)
         post_stub = stub_http_request(:post, "#{SUPPORT_API_ENDPOINT}/anonymous-feedback/problem-reports")
-        post_stub.with(:body => { problem_report: request_details }) unless request_details.nil?
-        post_stub.to_return(:status => 202)
+        post_stub.with(body: { problem_report: request_details }) unless request_details.nil?
+        post_stub.to_return(status: 202)
       end
 
       def stub_support_api_service_feedback_creation(feedback_details = nil)
         post_stub = stub_http_request(:post, "#{SUPPORT_API_ENDPOINT}/anonymous-feedback/service-feedback")
-        post_stub.with(:body => { service_feedback: feedback_details }) unless feedback_details.nil?
-        post_stub.to_return(:status => 201)
+        post_stub.with(body: { service_feedback: feedback_details }) unless feedback_details.nil?
+        post_stub.to_return(status: 201)
       end
 
       def stub_support_long_form_anonymous_contact_creation(request_details = nil)
         post_stub = stub_http_request(:post, "#{SUPPORT_API_ENDPOINT}/anonymous-feedback/long-form-contacts")
-        post_stub.with(:body => { long_form_contact: request_details }) unless request_details.nil?
-        post_stub.to_return(:status => 202)
+        post_stub.with(body: { long_form_contact: request_details }) unless request_details.nil?
+        post_stub.to_return(status: 202)
       end
 
       def stub_support_feedback_export_request_creation(request_details = nil)
         post_stub = stub_http_request(:post, "#{SUPPORT_API_ENDPOINT}/anonymous-feedback/export-requests")
-        post_stub.with(:body => { export_request: request_details }) unless request_details.nil?
-        post_stub.to_return(:status => 202)
+        post_stub.with(body: { export_request: request_details }) unless request_details.nil?
+        post_stub.to_return(status: 202)
       end
 
       def stub_support_global_export_request_creation(request_details = nil)
         post_stub = stub_http_request(:post, "#{SUPPORT_API_ENDPOINT}/anonymous-feedback/global-export-requests")
-        post_stub.with(:body => { global_export_request: request_details }) unless request_details.nil?
-        post_stub.to_return(:status => 202)
+        post_stub.with(body: { global_export_request: request_details }) unless request_details.nil?
+        post_stub.to_return(status: 202)
       end
 
       def stub_create_page_improvement(params)
         post_stub = stub_http_request(:post, "#{SUPPORT_API_ENDPOINT}/page-improvements")
-        post_stub.with(:body => params)
-        post_stub.to_return(:status => 201)
+        post_stub.with(body: params)
+        post_stub.to_return(status: 201)
       end
 
       def stub_problem_report_daily_totals_for(date, expected_results = nil)
@@ -58,12 +58,12 @@ module GdsApi
 
       def stub_support_mark_reviewed_for_spam(request_details = nil, response_body = {})
         post_stub = stub_http_request(:put, "#{SUPPORT_API_ENDPOINT}/anonymous-feedback/problem-reports/mark-reviewed-for-spam")
-        post_stub.with(:body => { reviewed_problem_report_ids: request_details}) unless request_details.nil?
+        post_stub.with(body: { reviewed_problem_report_ids: request_details }) unless request_details.nil?
         post_stub.to_return(status: 200, body: response_body.to_json)
       end
 
       def support_api_isnt_available
-        stub_request(:post, /#{SUPPORT_API_ENDPOINT}\/.*/).to_return(:status => 503)
+        stub_request(:post, /#{SUPPORT_API_ENDPOINT}\/.*/).to_return(status: 503)
       end
 
       def stub_anonymous_feedback(params, response_body = {})

--- a/lib/gds_api/test_helpers/whitehall_admin_api.rb
+++ b/lib/gds_api/test_helpers/whitehall_admin_api.rb
@@ -1,7 +1,7 @@
 module GdsApi
   module TestHelpers
     module WhitehallAdminApi
-      WHITEHALL_ADMIN_API_ENDPOINT = "#{Plek.current.find("whitehall-admin")}/government/admin/api"
+      WHITEHALL_ADMIN_API_ENDPOINT = "#{Plek.current.find('whitehall-admin')}/government/admin/api".freeze
 
       def stub_all_whitehall_admin_api_requests
         stub_request(:any, %r|^#{WHITEHALL_ADMIN_API_ENDPOINT}|)

--- a/lib/gds_api/test_helpers/worldwide.rb
+++ b/lib/gds_api/test_helpers/worldwide.rb
@@ -14,38 +14,36 @@ module GdsApi
       # This also sets up the individual endpoints for each slug
       # by calling worldwide_api_has_location below
       def worldwide_api_has_locations(location_slugs)
-        location_slugs.each {|s| worldwide_api_has_location(s) }
+        location_slugs.each { |s| worldwide_api_has_location(s) }
         pages = []
         location_slugs.each_slice(20) do |slugs|
-          pages << slugs.map {|s| world_location_details_for_slug(s) }
+          pages << slugs.map { |s| world_location_details_for_slug(s) }
         end
 
         pages.each_with_index do |page, i|
-          page_details = plural_response_base.merge({
-            "results" => page,
+          page_details = plural_response_base.merge("results" => page,
             "total" => location_slugs.size,
             "pages" => pages.size,
             "current_page" => i + 1,
             "page_size" => 20,
-            "start_index" => i * 20 + 1,
-          })
+            "start_index" => i * 20 + 1)
 
-          links = {:self => "#{WORLDWIDE_API_ENDPOINT}/api/world-locations?page=#{i + 1}" }
-          links[:next] = "#{WORLDWIDE_API_ENDPOINT}/api/world-locations?page=#{i + 2}" if pages[i+1]
+          links = { self: "#{WORLDWIDE_API_ENDPOINT}/api/world-locations?page=#{i + 1}" }
+          links[:next] = "#{WORLDWIDE_API_ENDPOINT}/api/world-locations?page=#{i + 2}" if pages[i + 1]
           links[:previous] = "#{WORLDWIDE_API_ENDPOINT}/api/world-locations?page=#{i}" unless i == 0
           page_details["_response_info"]["links"] = []
           link_headers = []
           links.each do |rel, href|
-            page_details["_response_info"]["links"] << {"rel" => rel, "href" => href}
+            page_details["_response_info"]["links"] << { "rel" => rel, "href" => href }
             link_headers << "<#{href}>; rel=\"#{rel}\""
           end
 
           stub_request(:get, links[:self]).
-            to_return(:status => 200, :body => page_details.to_json, :headers => {"Link" => link_headers.join(", ")})
+            to_return(status: 200, body: page_details.to_json, headers: { "Link" => link_headers.join(", ") })
           if i == 0
             # First page exists at URL with and without page param
             stub_request(:get, links[:self].sub(/\?page=1/, '')).
-              to_return(:status => 200, :body => page_details.to_json, :headers => {"Link" => link_headers.join(", ")})
+              to_return(status: 200, body: page_details.to_json, headers: { "Link" => link_headers.join(", ") })
           end
         end
       end
@@ -61,28 +59,28 @@ module GdsApi
         )
       end
 
-      def worldwide_api_has_location(location_slug, details=nil)
+      def worldwide_api_has_location(location_slug, details = nil)
         details ||= world_location_for_slug(location_slug)
         stub_request(:get, "#{WORLDWIDE_API_ENDPOINT}/api/world-locations/#{location_slug}").
-          to_return(:status => 200, :body => details.to_json)
+          to_return(status: 200, body: details.to_json)
       end
 
       def worldwide_api_does_not_have_location(location_slug)
-        stub_request(:get, "#{WORLDWIDE_API_ENDPOINT}/api/world-locations/#{location_slug}").to_return(:status => 404)
+        stub_request(:get, "#{WORLDWIDE_API_ENDPOINT}/api/world-locations/#{location_slug}").to_return(status: 404)
       end
 
       def worldwide_api_has_organisations_for_location(location_slug, json_or_hash)
         json = json_or_hash.is_a?(Hash) ? json_or_hash.to_json : json_or_hash
         url = "#{WORLDWIDE_API_ENDPOINT}/api/world-locations/#{location_slug}/organisations"
         stub_request(:get, url).
-          to_return(:status => 200, :body => json, :headers => {"Link" => "<#{url}; rel\"self\""})
+          to_return(status: 200, body: json, headers: { "Link" => "<#{url}; rel\"self\"" })
       end
 
       def worldwide_api_has_no_organisations_for_location(location_slug)
-        details = {"results" => [], "total" => 0, "_response_info" => { "status" => "ok" } }
+        details = { "results" => [], "total" => 0, "_response_info" => { "status" => "ok" } }
         url = "#{WORLDWIDE_API_ENDPOINT}/api/world-locations/#{location_slug}/organisations"
         stub_request(:get, url).
-          to_return(:status => 200, :body => details.to_json, :headers => {"Link" => "<#{url}; rel\"self\""})
+          to_return(status: 200, body: details.to_json, headers: { "Link" => "<#{url}; rel\"self\"" })
       end
 
       def world_location_for_slug(slug)
@@ -96,7 +94,7 @@ module GdsApi
       def world_location_details_for_slug(slug)
         {
           "id" => "https://www.gov.uk/api/world-locations/#{slug}",
-          "title" => titleize_slug(slug, :title_case => true),
+          "title" => titleize_slug(slug, title_case: true),
           "format" => (slug =~ /(delegation|mission)/ ? "International delegation" : "World location"),
           "updated_at" => "2013-03-25T13:06:42+00:00",
           "web_url" => "https://www.gov.uk/government/world/#{slug}",
@@ -110,7 +108,6 @@ module GdsApi
           },
         }
       end
-
     end
   end
 end

--- a/lib/gds_api/worldwide.rb
+++ b/lib/gds_api/worldwide.rb
@@ -1,7 +1,6 @@
 require_relative 'base'
 
 class GdsApi::Worldwide < GdsApi::Base
-
   def world_locations
     get_list! "#{base_url}/world-locations"
   end
@@ -15,6 +14,7 @@ class GdsApi::Worldwide < GdsApi::Base
   end
 
 private
+
   def base_url
     "#{endpoint}/api"
   end

--- a/test/asset_manager_test.rb
+++ b/test/asset_manager_test.rb
@@ -24,10 +24,10 @@ describe GdsApi::AssetManager do
 
   it "creates an asset with a file" do
     req = stub_request(:post, "#{base_api_url}/assets").
-      with(:body => %r{Content\-Disposition: form\-data; name="asset\[file\]"; filename="hello\.txt"\r\nContent\-Type: text/plain}).
-      to_return(:body => JSON.dump(asset_manager_response), :status => 201)
+      with(body: %r{Content\-Disposition: form\-data; name="asset\[file\]"; filename="hello\.txt"\r\nContent\-Type: text/plain}).
+      to_return(body: JSON.dump(asset_manager_response), status: 201)
 
-    response = api.create_asset(:file => file_fixture)
+    response = api.create_asset(file: file_fixture)
 
     assert_equal asset_url, response['asset']['id']
     assert_requested(req)
@@ -55,9 +55,9 @@ describe GdsApi::AssetManager do
 
     it "updates an asset with a file" do
       req = stub_request(:put, "#{base_api_url}/assets/test-id").
-        to_return(:body => JSON.dump(asset_manager_response), :status => 200)
+        to_return(body: JSON.dump(asset_manager_response), status: 200)
 
-      response = api.update_asset(asset_id, :file => file_fixture)
+      response = api.update_asset(asset_id, file: file_fixture)
 
       assert_equal "#{base_api_url}/assets/#{asset_id}", response['asset']['id']
       assert_requested(req)
@@ -74,7 +74,7 @@ describe GdsApi::AssetManager do
 
   it "deletes an asset for the given id" do
     req = stub_request(:delete, "#{base_api_url}/assets/#{asset_id}").
-      to_return(:body => JSON.dump(asset_manager_response), :status => 200)
+      to_return(body: JSON.dump(asset_manager_response), status: 200)
 
     response = api.delete_asset(asset_id)
 

--- a/test/business_support_api_test.rb
+++ b/test/business_support_api_test.rb
@@ -15,27 +15,26 @@ describe GdsApi::BusinessSupportApi do
     it "should return all schemes when called with no facets" do
       business_support_api_has_schemes([:scheme1, :scheme2, :scheme3])
       response = @api.schemes
-      assert_equal [{"title" => "scheme1"}, {"title" => "scheme2"}, {"title" => "scheme3"}], response['results']
+      assert_equal [{ "title" => "scheme1" }, { "title" => "scheme2" }, { "title" => "scheme3" }], response['results']
     end
-    it "should return schemes for applicable facets"  do
-      business_support_api_has_scheme(:scottish_manufacturing, {locations: 'scotland', sectors: 'manufacturing', support_types: 'grant,loan'})
-      response = @api.schemes({locations: 'scotland', sectors: 'manufacturing', support_types: 'grant,loan'})
+    it "should return schemes for applicable facets" do
+      business_support_api_has_scheme(:scottish_manufacturing, locations: 'scotland', sectors: 'manufacturing', support_types: 'grant,loan')
+      response = @api.schemes(locations: 'scotland', sectors: 'manufacturing', support_types: 'grant,loan')
       assert_equal 1, response["results"].size
       assert_equal "scottish_manufacturing", response["results"].first["title"]
     end
     it "should return an empty result when facets are not applicable" do
-      business_support_api_has_scheme(:super_secret, {locations: 'the moon', sectors: 'espionage'})
-      response = @api.schemes({locations: 'earth', sectors: 'espionage'})
+      business_support_api_has_scheme(:super_secret, locations: 'the moon', sectors: 'espionage')
+      response = @api.schemes(locations: 'earth', sectors: 'espionage')
       assert_empty response["results"]
     end
   end
 
   describe "finding a scheme by slug" do
     it "should give the scheme details" do
-      business_support_api_has_a_scheme('superbiz-wunderfundz', {
-        :title => 'Superbiz wunderfundz',
-        :short_description => 'Wunderfundz for your superbiz',
-        :body => 'Do you run or work for a Superbiz? Well we have the Wunderfundz.'})
+      business_support_api_has_a_scheme('superbiz-wunderfundz', title: 'Superbiz wunderfundz',
+        short_description: 'Wunderfundz for your superbiz',
+        body: 'Do you run or work for a Superbiz? Well we have the Wunderfundz.')
       response = @api.scheme('superbiz-wunderfundz')
       assert_equal 'business_support', response['format']
       assert_equal 'Superbiz wunderfundz', response['title']

--- a/test/content_api_test.rb
+++ b/test/content_api_test.rb
@@ -132,7 +132,7 @@ describe GdsApi::ContentApi do
       stub_request(:get, url).to_return(
         status: 200,
         body: body.to_json,
-        headers: {"Link" => links.join(",")}
+        headers: { "Link" => links.join(",") }
       )
     end
 
@@ -192,7 +192,7 @@ describe GdsApi::ContentApi do
     end
 
     it "should be able to fetch unpublished editions when authenticated" do
-      api = GdsApi::ContentApi.new(@base_api_url, { bearer_token: 'MY_BEARER_TOKEN' })
+      api = GdsApi::ContentApi.new(@base_api_url, bearer_token: 'MY_BEARER_TOKEN')
       content_api_has_unpublished_artefact("devolution-uk", 3)
       response = api.artefact("devolution-uk", edition: 3)
       assert_equal "#{@base_api_url}/devolution-uk.json", response["id"]
@@ -227,14 +227,14 @@ describe GdsApi::ContentApi do
 
     it "should return a listresponse for the artefacts" do
       WebMock.stub_request(:get, @artefacts_endpoint).
-        to_return(:body => {
-          "_response_info" => {"status" => "ok"},
+        to_return(body: {
+          "_response_info" => { "status" => "ok" },
           "total" => 4,
           "results" => [
-            {"format" => "answer", "web_url" => "http://www.test.gov.uk/foo"},
-            {"format" => "local_transaction", "web_url" => "http://www.test.gov.uk/bar/baz"},
-            {"format" => "place", "web_url" => "http://www.test.gov.uk/somewhere"},
-            {"format" => "guide", "web_url" => "http://www.test.gov.uk/vat"},
+            { "format" => "answer", "web_url" => "http://www.test.gov.uk/foo" },
+            { "format" => "local_transaction", "web_url" => "http://www.test.gov.uk/bar/baz" },
+            { "format" => "place", "web_url" => "http://www.test.gov.uk/somewhere" },
+            { "format" => "guide", "web_url" => "http://www.test.gov.uk/vat" },
           ]
         }.to_json)
 
@@ -249,27 +249,27 @@ describe GdsApi::ContentApi do
     it "should work with a paginated response" do
       WebMock.stub_request(:get, @artefacts_endpoint).
         to_return(
-          :body => {
-            "_response_info" => {"status" => "ok"},
+          body: {
+            "_response_info" => { "status" => "ok" },
             "total" => 4,
             "results" => [
-              {"format" => "answer", "web_url" => "http://www.test.gov.uk/foo"},
-              {"format" => "local_transaction", "web_url" => "http://www.test.gov.uk/bar/baz"},
-              {"format" => "place", "web_url" => "http://www.test.gov.uk/somewhere"},
-              {"format" => "guide", "web_url" => "http://www.test.gov.uk/vat"},
+              { "format" => "answer", "web_url" => "http://www.test.gov.uk/foo" },
+              { "format" => "local_transaction", "web_url" => "http://www.test.gov.uk/bar/baz" },
+              { "format" => "place", "web_url" => "http://www.test.gov.uk/somewhere" },
+              { "format" => "guide", "web_url" => "http://www.test.gov.uk/vat" },
             ]
           }.to_json,
-          :headers => {"Link" => "<#{@artefacts_endpoint}?page=2>; rel=\"next\""}
+          headers: { "Link" => "<#{@artefacts_endpoint}?page=2>; rel=\"next\"" }
         )
       WebMock.stub_request(:get, "#{@artefacts_endpoint}?page=2").
         to_return(
-          :body => {
-            "_response_info" => {"status" => "ok"},
+          body: {
+            "_response_info" => { "status" => "ok" },
             "total" => 3,
             "results" => [
-              {"format" => "answer", "web_url" => "http://www.test.gov.uk/foo2"},
-              {"format" => "local_transaction", "web_url" => "http://www.test.gov.uk/bar/baz2"},
-              {"format" => "guide", "web_url" => "http://www.test.gov.uk/vat2"},
+              { "format" => "answer", "web_url" => "http://www.test.gov.uk/foo2" },
+              { "format" => "local_transaction", "web_url" => "http://www.test.gov.uk/bar/baz2" },
+              { "format" => "guide", "web_url" => "http://www.test.gov.uk/vat2" },
             ]
           }.to_json
         )
@@ -425,28 +425,26 @@ describe GdsApi::ContentApi do
 
   describe "licence" do
     it "should return an artefact with licence for a snac code" do
-      response = content_api_has_an_artefact_with_snac_code("licence-example", '1234', {
-        "title" => "Licence Example",
+      content_api_has_an_artefact_with_snac_code("licence-example", '1234', "title" => "Licence Example",
         "slug" => "licence-example",
         "details" => {
           "licence" => {
             "location_specific" => false,
-            "availability" => [ "England", "Wales" ],
-            "authorities" => [ ]
+            "availability" => %w(England Wales),
+            "authorities" => []
           }
-        }
-      })
+        })
       response = @api.artefact('licence-example', snac: '1234')
 
       assert_equal "Licence Example", response["title"]
-      assert_equal [ "England", "Wales" ], response["details"]["licence"]["availability"]
+      assert_equal %w(England Wales), response["details"]["licence"]["availability"]
     end
 
     it "should escape snac code when searching for licence" do
       stub_request(:get, "#{@base_api_url}/licence-example.json?snac=snacks%21").
-        to_return(:status => 200,
-                  :body => {"test" => "ing"}.to_json,
-                  :headers => {})
+        to_return(status: 200,
+                  body: { "test" => "ing" }.to_json,
+                  headers: {})
 
       @api.artefact("licence-example", snac: "snacks!")
 
@@ -458,7 +456,7 @@ describe GdsApi::ContentApi do
       url = "#{@base_api_url}/licence-example.json?snac=1234&edition=1"
       stub_request(:get, url).to_return(status: 200, body: body.to_json)
 
-      api = GdsApi::ContentApi.new(@base_api_url, { bearer_token: 'MY_BEARER_TOKEN' })
+      api = GdsApi::ContentApi.new(@base_api_url, bearer_token: 'MY_BEARER_TOKEN')
       response = api.artefact('licence-example', snac: '1234', edition: '1')
 
       assert_equal "Licence example", response["title"]
@@ -468,10 +466,10 @@ describe GdsApi::ContentApi do
   describe "local authorities" do
     it "should raise if no local authority found" do
       stub_request(:get, "#{@base_api_url}/local_authorities/does-not-exist.json").
-        with(:headers => GdsApi::JsonClient.default_request_headers).
-        to_return(:status => 404,
-                  :body => {"_response_info" => {"status" => "ok"}}.to_json,
-                  :headers => {})
+        with(headers: GdsApi::JsonClient.default_request_headers).
+        to_return(status: 404,
+                  body: { "_response_info" => { "status" => "ok" } }.to_json,
+                  headers: {})
 
       assert_raises(GdsApi::HTTPNotFound) do
         @api.local_authority("does-not-exist")
@@ -483,14 +481,14 @@ describe GdsApi::ContentApi do
         "name" => "Solihull Metropolitan Borough Council",
         "snac_code" => "00CT",
         "id" => "#{@base_api_url}/local_authorities/00CT.json",
-        "_response_info" => {"status" => "ok"}
+        "_response_info" => { "status" => "ok" }
       }
 
       stub_request(:get, "#{@base_api_url}/local_authorities/00CT.json").
-        with(:headers => GdsApi::JsonClient.default_request_headers).
-        to_return(:status => 200,
-                  :body => body_response.to_json,
-                  :headers => {})
+        with(headers: GdsApi::JsonClient.default_request_headers).
+        to_return(status: 200,
+                  body: body_response.to_json,
+                  headers: {})
 
       response = @api.local_authority("00CT").to_hash
 
@@ -499,17 +497,17 @@ describe GdsApi::ContentApi do
 
     it "should return an empty result set if name not found" do
       body_response = {
-        "_response_info" => {"status" => "ok"},
+        "_response_info" => { "status" => "ok" },
         "description" => "Local Authorities",
         "total" => 0,
         "results" => []
       }.to_json
 
       stub_request(:get, "#{@base_api_url}/local_authorities.json?name=Swansalona").
-        with(:headers => GdsApi::JsonClient.default_request_headers).
-        to_return(:status => 200,
-                  :body => body_response,
-                  :headers => {})
+        with(headers: GdsApi::JsonClient.default_request_headers).
+        to_return(status: 200,
+                  body: body_response,
+                  headers: {})
 
       response = @api.local_authorities_by_name("Swansalona")
 
@@ -519,17 +517,17 @@ describe GdsApi::ContentApi do
 
     it "should return an empty result set if snac code not found" do
       body_response = {
-        "_response_info" => {"status" => "ok"},
+        "_response_info" => { "status" => "ok" },
         "description" => "Local Authorities",
         "total" => 0,
         "results" => []
       }.to_json
 
       stub_request(:get, "#{@base_api_url}/local_authorities.json?snac_code=SNACKS").
-        with(:headers => GdsApi::JsonClient.default_request_headers).
-        to_return(:status => 200,
-                  :body => body_response,
-                  :headers => {})
+        with(headers: GdsApi::JsonClient.default_request_headers).
+        to_return(status: 200,
+                  body: body_response,
+                  headers: {})
 
       response = @api.local_authorities_by_snac_code("SNACKS")
 
@@ -539,7 +537,7 @@ describe GdsApi::ContentApi do
 
     it "should have an array of results for a name search" do
       body_response = {
-        "_response_info" => {"status" => "ok"},
+        "_response_info" => { "status" => "ok" },
         "description" => "Local Authorities",
         "total" => 2,
         "results" => [{
@@ -555,10 +553,10 @@ describe GdsApi::ContentApi do
       }.to_json
 
       stub_request(:get, "#{@base_api_url}/local_authorities.json?name=Swans").
-        with(:headers => GdsApi::JsonClient.default_request_headers).
-        to_return(:status => 200,
-                  :body => body_response,
-                  :headers => {})
+        with(headers: GdsApi::JsonClient.default_request_headers).
+        to_return(status: 200,
+                  body: body_response,
+                  headers: {})
 
       response = @api.local_authorities_by_name("Swans")
 
@@ -568,9 +566,9 @@ describe GdsApi::ContentApi do
 
     it "should escape snac code when calling unique a local authority" do
       stub_request(:get, "#{@base_api_url}/local_authorities/escape%21.json").
-        to_return(:status => 200,
-                  :body => {"test" => "ing"}.to_json,
-                  :headers => {})
+        to_return(status: 200,
+                  body: { "test" => "ing" }.to_json,
+                  headers: {})
 
       @api.local_authority("escape!")
 
@@ -579,9 +577,9 @@ describe GdsApi::ContentApi do
 
     it "should escape name when searching for local authorities" do
       stub_request(:get, "#{@base_api_url}/local_authorities.json?name=name%21").
-        to_return(:status => 200,
-                  :body => {"test" => "ing"}.to_json,
-                  :headers => {})
+        to_return(status: 200,
+                  body: { "test" => "ing" }.to_json,
+                  headers: {})
 
       @api.local_authorities_by_name("name!")
 
@@ -590,9 +588,9 @@ describe GdsApi::ContentApi do
 
     it "should escape snac code when searching for local authorities" do
       stub_request(:get, "#{@base_api_url}/local_authorities.json?snac_code=snacks%21").
-        to_return(:status => 200,
-                  :body => {"test" => "ing"}.to_json,
-                  :headers => {})
+        to_return(status: 200,
+                  body: { "test" => "ing" }.to_json,
+                  headers: {})
 
       @api.local_authorities_by_snac_code("snacks!")
 
@@ -603,29 +601,29 @@ describe GdsApi::ContentApi do
   describe "business support schemes" do
     it "should query content_api for business_support_schemes" do
       stub_request(:get, %r{\A#{@base_api_url}/business_support_schemes.json}).
-        to_return(:status => 200, :body => {"foo" => "bar"}.to_json)
+        to_return(status: 200, body: { "foo" => "bar" }.to_json)
 
-      response = @api.business_support_schemes(:drink => "coffee")
+      response = @api.business_support_schemes(drink: "coffee")
 
-      assert_equal({"foo" => "bar"}, response.to_hash)
-      assert_requested :get, "#{@base_api_url}/business_support_schemes.json?drink=coffee", :times => 1
+      assert_equal({ "foo" => "bar" }, response.to_hash)
+      assert_requested :get, "#{@base_api_url}/business_support_schemes.json?drink=coffee", times: 1
     end
 
     it "should raise an error if content_api returns 404" do
       stub_request(:get, %r{\A#{@base_api_url}/business_support_schemes.json}).
-        to_return(:status => 404, :body => "Not Found")
+        to_return(status: 404, body: "Not Found")
 
       assert_raises GdsApi::HTTPNotFound do
-        @api.business_support_schemes(['foo', 'bar'])
+        @api.business_support_schemes(%w(foo bar))
       end
     end
 
     it "should raise an error if content_api returns a 50x error" do
       stub_request(:get, %r{\A#{@base_api_url}/business_support_schemes.json}).
-        to_return(:status => 503, :body => "Gateway timeout")
+        to_return(status: 503, body: "Gateway timeout")
 
       assert_raises GdsApi::HTTPServerError do
-        @api.business_support_schemes(['foo', 'bar'])
+        @api.business_support_schemes(%w(foo bar))
       end
     end
 
@@ -633,13 +631,13 @@ describe GdsApi::ContentApi do
       it "should have representative test helpers" do
         setup_content_api_business_support_schemes_stubs
         s1 = { "title" => "Scheme 1", "format" => "business_support" }
-        content_api_has_business_support_scheme(s1, :locations => "england", :sectors => "farming")
+        content_api_has_business_support_scheme(s1, locations: "england", sectors: "farming")
         s2 = { "title" => "Scheme 2", "format" => "business_support" }
-        content_api_has_business_support_scheme(s2, :sectors => "farming")
+        content_api_has_business_support_scheme(s2, sectors: "farming")
         s3 = { "title" => "Scheme 3", "format" => "business_support" }
-        content_api_has_business_support_scheme(s3, :locations => "england", :sectors => "farming")
+        content_api_has_business_support_scheme(s3, locations: "england", sectors: "farming")
 
-        response = @api.business_support_schemes(:locations => "england", :sectors => "farming").to_hash
+        response = @api.business_support_schemes(locations: "england", sectors: "farming").to_hash
 
         assert_equal 2, response["total"]
         assert_equal s1["title"], response["results"].first["title"]
@@ -652,12 +650,12 @@ describe GdsApi::ContentApi do
     it "should get licence details" do
       setup_content_api_licences_stubs
 
-      content_api_has_licence :licence_identifier => "1234", :title => 'Test Licence 1', :slug => 'test-licence-1',
-        :licence_short_description => 'A short description'
-      content_api_has_licence :licence_identifier => "1235", :title => 'Test Licence 2', :slug => 'test-licence-2',
-        :licence_short_description => 'A short description'
-      content_api_has_licence :licence_identifier => "AB1234", :title => 'Test Licence 3', :slug => 'test-licence-3',
-        :licence_short_description => 'A short description'
+      content_api_has_licence licence_identifier: "1234", title: 'Test Licence 1', slug: 'test-licence-1',
+        licence_short_description: 'A short description'
+      content_api_has_licence licence_identifier: "1235", title: 'Test Licence 2', slug: 'test-licence-2',
+        licence_short_description: 'A short description'
+      content_api_has_licence licence_identifier: "AB1234", title: 'Test Licence 3', slug: 'test-licence-3',
+        licence_short_description: 'A short description'
 
       results = @api.licences_for_ids([1234, 'AB1234', 'something'])['results']
       assert_equal 2, results.size
@@ -694,7 +692,7 @@ describe GdsApi::ContentApi do
 
     it "should raise an error if publisher returns an error" do
       stub_request(:get, %r[\A#{@base_api_url}/licences]).
-        to_return(:status => [503, "Service temporarily unabailable"])
+        to_return(status: [503, "Service temporarily unabailable"])
 
       assert_raises GdsApi::HTTPServerError do
         @api.licences_for_ids([123, 124])

--- a/test/email_alert_api_test.rb
+++ b/test/email_alert_api_test.rb
@@ -162,7 +162,7 @@ describe GdsApi::EmailAlertApi do
   describe "notifications" do
     it "retrieves notifications" do
       stubbed_request = email_alert_api_has_notifications([
-        {"subject" => "Foo"}, {"subject" => "Bar"}
+        { "subject" => "Foo" }, { "subject" => "Bar" }
       ])
       api_client.notifications
       assert_requested(stubbed_request)
@@ -170,7 +170,7 @@ describe GdsApi::EmailAlertApi do
 
     it "uses the start_at param if present" do
       stubbed_request = email_alert_api_has_notifications([
-        {"subject" => "Foo"}, {"subject" => "Bar"}
+        { "subject" => "Foo" }, { "subject" => "Bar" }
       ], "101AA")
       api_client.notifications("101AA")
       assert_requested(stubbed_request)
@@ -179,9 +179,7 @@ describe GdsApi::EmailAlertApi do
 
   describe "notification" do
     before do
-      @stubbed_request = email_alert_api_has_notification({
-        "web_service_bulletin" => { "to_param" => "10001001" }
-      })
+      @stubbed_request = email_alert_api_has_notification("web_service_bulletin" => { "to_param" => "10001001" })
     end
     it "retrieves a notification by id" do
       api_client.notification("10001001")

--- a/test/gds_api_base_test.rb
+++ b/test/gds_api_base_test.rb
@@ -3,7 +3,6 @@ require 'gds_api/base'
 require 'uri'
 
 class GdsApiBaseTest < Minitest::Test
-
   class ConcreteApi < GdsApi::Base
     def base_url
       endpoint
@@ -33,7 +32,7 @@ class GdsApiBaseTest < Minitest::Test
     u = URI.parse(url)
     assert_equal "b%5B%5D=123", u.query
 
-    url = api.url_for_slug("slug", "b" => ['123', '456'])
+    url = api.url_for_slug("slug", "b" => %w(123 456))
     u = URI.parse(url)
     assert_equal "b%5B%5D=123&b%5B%5D=456", u.query
   end
@@ -41,30 +40,30 @@ class GdsApiBaseTest < Minitest::Test
   def test_should_not_add_a_question_mark_if_there_are_no_parameters
     api = ConcreteApi.new('http://foo')
     url = api.url_for_slug("slug")
-    refute_match /\?/, url
+    refute_match(/\?/, url)
   end
 
   def test_should_use_endpoint_in_url
     api = ConcreteApi.new("http://foobarbaz")
     url = api.url_for_slug("slug")
     u = URI.parse(url)
-    assert_match /foobarbaz$/, u.host
+    assert_match(/foobarbaz$/, u.host)
   end
 
   def test_should_accept_options_as_second_arg
-    api = ConcreteApi.new("http://foo", {foo: "bar"})
+    api = ConcreteApi.new("http://foo", foo: "bar")
     assert_equal "bar", api.options[:foo]
   end
 
   def test_setting_cache_size_from_options
     GdsApi::JsonClient.cache = false
-    api = ConcreteApi.new("https://foo", {cache_size: 2})
+    api = ConcreteApi.new("https://foo", cache_size: 2)
     assert_equal 2, api.client.cache.max_size
   end
 
   def test_setting_cache_size_from_default_options
     GdsApi::JsonClient.cache = false
-    GdsApi::Base.default_options = {cache_size: 4}
+    GdsApi::Base.default_options = { cache_size: 4 }
     api = ConcreteApi.new("http://bar")
     assert_equal 4, api.client.cache.max_size
   end
@@ -83,10 +82,10 @@ class GdsApiBaseTest < Minitest::Test
     assert api.client.cache.is_a? GdsApi::NullCache
   end
 
-  def test_should_barf_if_not_given_valid_URL
-    proc do
+  def test_should_barf_if_not_given_valid_url
+    assert_raises GdsApi::Base::InvalidAPIURL do
       ConcreteApi.new('invalid-url')
-    end.must_raise GdsApi::Base::InvalidAPIURL
+    end
   end
 
   def test_should_set_json_client_logger_to_own_logger_by_default

--- a/test/gov_uk_delivery_test.rb
+++ b/test/gov_uk_delivery_test.rb
@@ -3,7 +3,6 @@ require 'gds_api/gov_uk_delivery'
 require 'gds_api/test_helpers/gov_uk_delivery'
 
 describe GdsApi::GovUkDelivery do
-
   include GdsApi::TestHelpers::GovUkDelivery
 
   before do
@@ -28,7 +27,7 @@ describe GdsApi::GovUkDelivery do
   end
 
   it "can post a notification" do
-    expected_payload = { feed_urls: ['http://example.com/feed'], subject: 'Test', body: '<p>Something</p>'}
+    expected_payload = { feed_urls: ['http://example.com/feed'], subject: 'Test', body: '<p>Something</p>' }
     stub = stub_gov_uk_delivery_post_request('notifications', expected_payload).to_return(created_response_hash)
 
     assert @api.notify(['http://example.com/feed'], 'Test', '<p>Something</p>')
@@ -37,15 +36,15 @@ describe GdsApi::GovUkDelivery do
 
   it "can get a subscription URL" do
     expected_payload = { feed_url: 'http://example.com/feed' }
-    stub = stub_gov_uk_delivery_get_request('list-url', expected_payload).to_return(created_response_json_hash({list_url: 'thing'}))
+    stub = stub_gov_uk_delivery_get_request('list-url', expected_payload).to_return(created_response_json_hash(list_url: 'thing'))
 
     assert @api.signup_url('http://example.com/feed')
     assert_requested stub
   end
 
   it "raises if the API 404s" do
-    expected_payload = { feed_url: 'http://example.com/feed'}
-    stub = stub_gov_uk_delivery_get_request('list-url', expected_payload).to_return(not_found_hash)
+    expected_payload = { feed_url: 'http://example.com/feed' }
+    stub_gov_uk_delivery_get_request('list-url', expected_payload).to_return(not_found_hash)
 
     assert_raises(GdsApi::HTTPNotFound) do
       @api.signup_url('http://example.com/feed')
@@ -65,5 +64,4 @@ describe GdsApi::GovUkDelivery do
   def created_response_json_hash(data)
     { body: data.to_json, status: 201 }
   end
-
 end

--- a/test/imminence_api_test.rb
+++ b/test/imminence_api_test.rb
@@ -2,8 +2,7 @@ require "test_helper"
 require "gds_api/imminence"
 
 class ImminenceApiTest < Minitest::Test
-
-  ROOT = "https://imminence.test.alphagov.co.uk"
+  ROOT = "https://imminence.test.alphagov.co.uk".freeze
   LATITUDE = 52.1327584352089
   LONGITUDE = -0.4702813074674147
 
@@ -87,7 +86,7 @@ class ImminenceApiTest < Minitest::Test
     c = api_client
     url = "#{ROOT}/places/wibble.json?limit=5&lat=52&lng=0"
     place_info = dummy_place.merge(
-      "location" => {"longitude" => LONGITUDE, "latitude" => LATITUDE}
+      "location" => { "longitude" => LONGITUDE, "latitude" => LATITUDE }
     )
     c.expects(:get_json).with(url).returns([place_info])
     places = c.places("wibble", 52, 0)
@@ -139,7 +138,7 @@ EOS
 
     stub_request(:get, "#{ROOT}/places/test.kml").
       with(headers: GdsApi::JsonClient.default_request_headers).
-      to_return(status: 200, body: kml_body )
+      to_return(status: 200, body: kml_body)
 
     response_body = api_client.places_kml("test")
     assert_equal kml_body, response_body
@@ -151,14 +150,14 @@ EOS
       { "id" => 66, "type" => "EUR", "name" => "London", "country_name" => "England" }
     ]
     results = {
-      "_response_info" => {"status" => "ok"},
+      "_response_info" => { "status" => "ok" },
       "total" => areas.size, "startIndex" => 1, "pageSize" => areas.size,
       "currentPage" => 1, "pages" => 1, "results" => areas
     }
 
     stub_request(:get, "#{ROOT}/areas/WC2B%206SE.json").
       with(headers: GdsApi::JsonClient.default_request_headers).
-      to_return(status: 200, body: results.to_json )
+      to_return(status: 200, body: results.to_json)
 
     response = api_client.areas_for_postcode("WC2B 6SE")
 
@@ -175,14 +174,14 @@ EOS
       { "id" => 665, "type" => "EUR", "name" => "London", "country_name" => "England" }
     ]
     results = {
-      "_response_info" => {"status" => "ok"},
+      "_response_info" => { "status" => "ok" },
       "total" => areas.size, "startIndex" => 1, "pageSize" => areas.size,
       "currentPage" => 1, "pages" => 1, "results" => areas
     }
 
     stub_request(:get, "#{ROOT}/areas/EUR.json").
       with(headers: GdsApi::JsonClient.default_request_headers).
-      to_return(status: 200, body: results.to_json )
+      to_return(status: 200, body: results.to_json)
 
     response = api_client.areas_for_type("EUR")
 
@@ -194,5 +193,4 @@ EOS
     assert_equal 122, areas_from_response.first["id"]
     assert_equal 665, areas_from_response.last["id"]
   end
-
 end

--- a/test/json_client_test.rb
+++ b/test/json_client_test.rb
@@ -85,7 +85,7 @@ class JsonClientTest < MiniTest::Spec
 
   def test_should_cache_multiple_requests_to_same_url_across_instances
     url = "http://some.endpoint/some.json"
-    result = {"foo" => "bar"}
+    result = { "foo" => "bar" }
     stub_request(:get, url).to_return(body: JSON.dump(result), status: 200)
     response_a = GdsApi::JsonClient.new.get_json(url)
     response_b = GdsApi::JsonClient.new.get_json(url)
@@ -99,12 +99,12 @@ class JsonClientTest < MiniTest::Spec
     GdsApi::JsonClient.cache = nil
 
     url = "http://some.endpoint/"
-    result = {"foo" => "bar"}
+
     stub_request(:get, %r{\A#{url}}).to_return do |request|
       { body: { "url" => request.uri }.to_json, status: 200 }
     end
 
-    response_a = GdsApi::JsonClient.new(:cache_size => 5).get_json("#{url}/first.json")
+    response_a = GdsApi::JsonClient.new(cache_size: 5).get_json("#{url}/first.json")
     response_b = GdsApi::JsonClient.new.get_json("#{url}/second.json")
     4.times { |n| GdsApi::JsonClient.new.get_json("#{url}/#{n}.json") }
 
@@ -119,7 +119,7 @@ class JsonClientTest < MiniTest::Spec
 
   def test_should_cache_requests_for_15_mins_by_default
     url = "http://some.endpoint/some.json"
-    result = {"foo" => "bar"}
+    result = { "foo" => "bar" }
     stub_request(:get, url).to_return(body: JSON.dump(result), status: 200)
     response_a = GdsApi::JsonClient.new.get_json(url)
     response_b = GdsApi::JsonClient.new.get_json(url)
@@ -127,14 +127,14 @@ class JsonClientTest < MiniTest::Spec
     assert_requested :get, url, times: 1
     assert_equal response_a.to_hash, response_b.to_hash
 
-    Timecop.travel( 15 * 60 - 30) do # now + 14 mins 30 secs
+    Timecop.travel(15 * 60 - 30) do # now + 14 mins 30 secs
       response_c = GdsApi::JsonClient.new.get_json(url)
 
       assert_requested :get, url, times: 1
       assert_equal response_a.to_hash, response_c.to_hash
     end
 
-    Timecop.travel( 15 * 60 + 30) do # now + 15 mins 30 secs
+    Timecop.travel(15 * 60 + 30) do # now + 15 mins 30 secs
       response_d = GdsApi::JsonClient.new.get_json(url)
 
       assert_requested :get, url, times: 2
@@ -148,22 +148,22 @@ class JsonClientTest < MiniTest::Spec
     GdsApi::JsonClient.cache = nil
 
     url = "http://some.endpoint/some.json"
-    result = {"foo" => "bar"}
+    result = { "foo" => "bar" }
     stub_request(:get, url).to_return(body: JSON.dump(result), status: 200)
-    response_a = GdsApi::JsonClient.new(:cache_ttl => 5 * 60).get_json(url)
+    response_a = GdsApi::JsonClient.new(cache_ttl: 5 * 60).get_json(url)
     response_b = GdsApi::JsonClient.new.get_json(url)
 
     assert_requested :get, url, times: 1
     assert_equal response_a.to_hash, response_b.to_hash
 
-    Timecop.travel( 5 * 60 - 30) do # now + 4 mins 30 secs
+    Timecop.travel(5 * 60 - 30) do # now + 4 mins 30 secs
       response_c = GdsApi::JsonClient.new.get_json(url)
 
       assert_requested :get, url, times: 1
       assert_equal response_a.to_hash, response_c.to_hash
     end
 
-    Timecop.travel( 5 * 60 + 30) do # now + 5 mins 30 secs
+    Timecop.travel(5 * 60 + 30) do # now + 5 mins 30 secs
       response_d = GdsApi::JsonClient.new.get_json(url)
 
       assert_requested :get, url, times: 2
@@ -173,7 +173,7 @@ class JsonClientTest < MiniTest::Spec
 
   def test_should_allow_disabling_caching
     url = "http://some.endpoint/some.json"
-    result = {"foo" => "bar"}
+    result = { "foo" => "bar" }
     stub_request(:get, url).to_return(body: JSON.dump(result), status: 200)
 
     client = GdsApi::JsonClient.new(disable_cache: true)
@@ -190,7 +190,7 @@ class JsonClientTest < MiniTest::Spec
 
   def test_should_respect_expiry_headers
     url = "http://some.endpoint/some.json"
-    result = {"foo" => "bar"}
+    result = { "foo" => "bar" }
     stub_request(:get, url).to_return(
       body: JSON.dump(result),
       status: 200,
@@ -199,14 +199,14 @@ class JsonClientTest < MiniTest::Spec
 
     response_a = GdsApi::JsonClient.new.get_json(url)
 
-    Timecop.travel( 7 * 60 - 30) do # now + 6 mins 30 secs
+    Timecop.travel(7 * 60 - 30) do # now + 6 mins 30 secs
       response_b = GdsApi::JsonClient.new.get_json(url)
 
       assert_requested :get, url, times: 1
       assert_equal response_a.to_hash, response_b.to_hash
     end
 
-    Timecop.travel( 7 * 60 + 30) do # now + 7 mins 30 secs
+    Timecop.travel(7 * 60 + 30) do # now + 7 mins 30 secs
       response_c = GdsApi::JsonClient.new.get_json(url)
 
       assert_requested :get, url, times: 2
@@ -216,7 +216,7 @@ class JsonClientTest < MiniTest::Spec
 
   def test_should_respect_cache_control_headers_with_max_age
     url = "http://some.endpoint/max_age.json"
-    result = {"foo" => "bar"}
+    result = { "foo" => "bar" }
     stub_request(:get, url).to_return(
       body: JSON.dump(result),
       status: 200,
@@ -225,14 +225,14 @@ class JsonClientTest < MiniTest::Spec
 
     response_a = GdsApi::JsonClient.new.get_json(url)
 
-    Timecop.travel( 7 * 60 - 30) do # now + 6 mins 30 secs
+    Timecop.travel(7 * 60 - 30) do # now + 6 mins 30 secs
       response_b = GdsApi::JsonClient.new.get_json(url)
 
       assert_requested :get, url, times: 1
       assert_equal response_a.to_hash, response_b.to_hash
     end
 
-    Timecop.travel( 7 * 60 + 30) do # now + 7 mins 30 secs
+    Timecop.travel(7 * 60 + 30) do # now + 7 mins 30 secs
       response_c = GdsApi::JsonClient.new.get_json(url)
 
       assert_requested :get, url, times: 2
@@ -242,7 +242,7 @@ class JsonClientTest < MiniTest::Spec
 
   def test_should_respect_cache_control_headers_with_no_cache
     url = "http://some.endpoint/no_cache.json"
-    result = {"foo" => "bar"}
+    result = { "foo" => "bar" }
     stub_request(:get, url).to_return(
       body: JSON.dump(result),
       status: 200,
@@ -251,7 +251,7 @@ class JsonClientTest < MiniTest::Spec
 
     response_a = GdsApi::JsonClient.new.get_json(url)
 
-    Timecop.travel( 7 * 60 - 30) do # now + 6 mins 30 secs
+    Timecop.travel(7 * 60 - 30) do # now + 6 mins 30 secs
       response_b = GdsApi::JsonClient.new.get_json(url)
 
       assert_requested :get, url, times: 2
@@ -261,7 +261,7 @@ class JsonClientTest < MiniTest::Spec
 
   def test_does_not_cache_responses_with_cache_control_private
     url = "http://some.endpoint/private.json"
-    result = {"foo" => "bar"}
+    result = { "foo" => "bar" }
     stub_request(:get, url).to_return(
       body: JSON.dump(result),
       status: 200,
@@ -270,7 +270,7 @@ class JsonClientTest < MiniTest::Spec
 
     response_a = GdsApi::JsonClient.new.get_json(url)
 
-    Timecop.travel( 7 * 60 - 30) do # now + 6 mins 30 secs
+    Timecop.travel(7 * 60 - 30) do # now + 6 mins 30 secs
       response_b = GdsApi::JsonClient.new.get_json(url)
 
       assert_requested :get, url, times: 2
@@ -280,7 +280,7 @@ class JsonClientTest < MiniTest::Spec
 
   def test_does_not_cache_responses_with_cache_control_no_store
     url = "http://some.endpoint/private.json"
-    result = {"foo" => "bar"}
+    result = { "foo" => "bar" }
     stub_request(:get, url).to_return(
       body: JSON.dump(result),
       status: 200,
@@ -289,7 +289,7 @@ class JsonClientTest < MiniTest::Spec
 
     response_a = GdsApi::JsonClient.new.get_json(url)
 
-    Timecop.travel( 7 * 60 - 30) do # now + 6 mins 30 secs
+    Timecop.travel(7 * 60 - 30) do # now + 6 mins 30 secs
       response_b = GdsApi::JsonClient.new.get_json(url)
 
       assert_requested :get, url, times: 2
@@ -299,7 +299,7 @@ class JsonClientTest < MiniTest::Spec
 
   def test_should_respect_cache_control_headers_with_no_cache_and_max_age
     url = "http://some.endpoint/no_cache_and_max_age.json"
-    result = {"foo" => "bar"}
+    result = { "foo" => "bar" }
     stub_request(:get, url).to_return(
       body: JSON.dump(result),
       status: 200,
@@ -308,7 +308,7 @@ class JsonClientTest < MiniTest::Spec
 
     response_a = GdsApi::JsonClient.new.get_json(url)
 
-    Timecop.travel( 7 * 60 - 30) do # now + 6 mins 30 secs
+    Timecop.travel(7 * 60 - 30) do # now + 6 mins 30 secs
       response_b = GdsApi::JsonClient.new.get_json(url)
 
       assert_requested :get, url, times: 2
@@ -318,7 +318,7 @@ class JsonClientTest < MiniTest::Spec
 
   def test_should_use_cache_control_headers_over_expires_headers
     url = "http://some.endpoint/url.json"
-    result = {"foo" => "bar"}
+    result = { "foo" => "bar" }
     stub_request(:get, url).to_return(
       body: JSON.dump(result),
       status: 200,
@@ -330,7 +330,7 @@ class JsonClientTest < MiniTest::Spec
 
     response_a = GdsApi::JsonClient.new.get_json(url)
 
-    Timecop.travel( 7 * 60 - 30) do # now + 6 mins 30 secs
+    Timecop.travel(7 * 60 - 30) do # now + 6 mins 30 secs
       response_b = GdsApi::JsonClient.new.get_json(url)
 
       assert_requested :get, url, times: 2
@@ -340,7 +340,7 @@ class JsonClientTest < MiniTest::Spec
 
   def test_should_fallback_to_expires_headers_if_cache_control_is_malformed
     url = "http://some.endpoint/url.json"
-    result = {"foo" => "bar"}
+    result = { "foo" => "bar" }
     stub_request(:get, url).to_return(
       body: JSON.dump(result),
       status: 200,
@@ -352,7 +352,7 @@ class JsonClientTest < MiniTest::Spec
 
     response_a = GdsApi::JsonClient.new.get_json(url)
 
-    Timecop.travel( 7 * 60 - 30) do # now + 6 mins 30 secs
+    Timecop.travel(7 * 60 - 30) do # now + 6 mins 30 secs
       response_b = GdsApi::JsonClient.new.get_json(url)
 
       assert_requested :get, url, times: 1
@@ -496,7 +496,7 @@ class JsonClientTest < MiniTest::Spec
     # with a redirect to the same URL, but we'd risk getting the test code into
     # an infinite loop if the code didn't do what it was supposed to. The
     # failure response block aborts the test if we have too many requests.
-    failure = lambda { |request| flunk("Request called too many times") }
+    failure = lambda { |_request| flunk("Request called too many times") }
     stub_request(:get, url).to_return(redirect).times(11).then.to_return(failure)
 
     assert_raises GdsApi::HTTPErrorResponse do
@@ -520,7 +520,7 @@ class JsonClientTest < MiniTest::Spec
     }
 
     # See the comment in the above test for an explanation of this
-    failure = lambda { |request| flunk("Request called too many times") }
+    failure = lambda { |_request| flunk("Request called too many times") }
     stub_request(:get, first_url).to_return(first_redirect).times(6).then.to_return(failure)
     stub_request(:get, second_url).to_return(second_redirect).times(6).then.to_return(failure)
 
@@ -582,7 +582,7 @@ class JsonClientTest < MiniTest::Spec
 
   def test_put_json_does_put_with_json_encoded_packet
     url = "http://some.endpoint/some.json"
-    payload = {a: 1}
+    payload = { a: 1 }
     stub_request(:put, url).with(body: payload.to_json).to_return(body: "{}", status: 200)
     assert_equal({}, @client.put_json(url, payload).to_hash)
   end
@@ -597,7 +597,7 @@ class JsonClientTest < MiniTest::Spec
     url = "http://some.endpoint/some.json"
     stub_request(:get, url).to_return(body: "Hello there!")
 
-    response = @client.get_json(url) { |http_response| http_response.body }
+    response = @client.get_json(url, &:body)
     assert response.is_a? String
     assert_equal "Hello there!", response
   end
@@ -615,7 +615,7 @@ class JsonClientTest < MiniTest::Spec
     url = "http://some.endpoint/some.json"
     stub_request(:get, url).to_return(body: "Hello there!")
 
-    response = @client.get_json!(url) { |http_response| http_response.body }
+    response = @client.get_json!(url, &:body)
     assert response.is_a? String
     assert_equal "Hello there!", response
   end
@@ -637,7 +637,7 @@ class JsonClientTest < MiniTest::Spec
   end
 
   def test_client_can_use_basic_auth
-    client = GdsApi::JsonClient.new(basic_auth: {user: 'user', password: 'password'})
+    client = GdsApi::JsonClient.new(basic_auth: { user: 'user', password: 'password' })
 
     stub_request(:put, "http://user:password@some.endpoint/some.json").
       to_return(body: '{"a":1}', status: 200)
@@ -662,11 +662,11 @@ class JsonClientTest < MiniTest::Spec
   def test_client_can_set_custom_headers_on_gets
     stub_request(:get, "http://some.other.endpoint/some.json").to_return(status: 200)
 
-    response = GdsApi::JsonClient.new.get_json("http://some.other.endpoint/some.json",
-                                               { "HEADER-A" => "B", "HEADER-C" => "D" })
+    GdsApi::JsonClient.new.get_json("http://some.other.endpoint/some.json",
+                                               "HEADER-A" => "B", "HEADER-C" => "D")
 
     assert_requested(:get, %r{/some.json}) do |request|
-      headers_with_uppercase_names = Hash[request.headers.collect {|key, value| [key.upcase, value] }]
+      headers_with_uppercase_names = Hash[request.headers.collect { |key, value| [key.upcase, value] }]
       headers_with_uppercase_names["HEADER-A"] == "B" && headers_with_uppercase_names["HEADER-C"] == "D"
     end
   end
@@ -674,11 +674,11 @@ class JsonClientTest < MiniTest::Spec
   def test_client_can_set_custom_headers_on_posts
     stub_request(:post, "http://some.other.endpoint/some.json").to_return(status: 200)
 
-    response = GdsApi::JsonClient.new.post_json("http://some.other.endpoint/some.json", {},
-                                                { "HEADER-A" => "B", "HEADER-C" => "D" })
+    GdsApi::JsonClient.new.post_json("http://some.other.endpoint/some.json", {},
+                                                "HEADER-A" => "B", "HEADER-C" => "D")
 
     assert_requested(:post, %r{/some.json}) do |request|
-      headers_with_uppercase_names = Hash[request.headers.collect {|key, value| [key.upcase, value] }]
+      headers_with_uppercase_names = Hash[request.headers.collect { |key, value| [key.upcase, value] }]
       headers_with_uppercase_names["HEADER-A"] == "B" && headers_with_uppercase_names["HEADER-C"] == "D"
     end
   end
@@ -686,11 +686,11 @@ class JsonClientTest < MiniTest::Spec
   def test_client_can_set_custom_headers_on_puts
     stub_request(:put, "http://some.other.endpoint/some.json").to_return(status: 200)
 
-    response = GdsApi::JsonClient.new.put_json("http://some.other.endpoint/some.json", {},
-                                               { "HEADER-A" => "B", "HEADER-C" => "D" })
+    GdsApi::JsonClient.new.put_json("http://some.other.endpoint/some.json", {},
+                                               "HEADER-A" => "B", "HEADER-C" => "D")
 
     assert_requested(:put, %r{/some.json}) do |request|
-      headers_with_uppercase_names = Hash[request.headers.collect {|key, value| [key.upcase, value] }]
+      headers_with_uppercase_names = Hash[request.headers.collect { |key, value| [key.upcase, value] }]
       headers_with_uppercase_names["HEADER-A"] == "B" && headers_with_uppercase_names["HEADER-C"] == "D"
     end
   end
@@ -698,11 +698,11 @@ class JsonClientTest < MiniTest::Spec
   def test_client_can_set_custom_headers_on_deletes
     stub_request(:delete, "http://some.other.endpoint/some.json").to_return(status: 200)
 
-    response = GdsApi::JsonClient.new.delete_json("http://some.other.endpoint/some.json",
-                                                  { "HEADER-A" => "B", "HEADER-C" => "D" })
+    GdsApi::JsonClient.new.delete_json("http://some.other.endpoint/some.json",
+                                                  "HEADER-A" => "B", "HEADER-C" => "D")
 
     assert_requested(:delete, %r{/some.json}) do |request|
-      headers_with_uppercase_names = Hash[request.headers.collect {|key, value| [key.upcase, value] }]
+      headers_with_uppercase_names = Hash[request.headers.collect { |key, value| [key.upcase, value] }]
       headers_with_uppercase_names["HEADER-A"] == "B" && headers_with_uppercase_names["HEADER-C"] == "D"
     end
   end
@@ -718,7 +718,7 @@ class JsonClientTest < MiniTest::Spec
 
     assert_requested(:get, %r{/some.json}) do |request|
       request.headers['Govuk-Request-Id'] == '12345' &&
-      request.headers['Govuk-Original-Url'] == 'http://example.com'
+        request.headers['Govuk-Original-Url'] == 'http://example.com'
     end
   end
 
@@ -764,7 +764,7 @@ class JsonClientTest < MiniTest::Spec
            }).
       to_return(body: '{"b": "1"}', status: 200)
 
-    response = @client.post_multipart("http://some.endpoint/some.json", {"a" => "123"})
+    response = @client.post_multipart("http://some.endpoint/some.json", "a" => "123")
     assert_equal "1", response["b"]
   end
 
@@ -773,7 +773,7 @@ class JsonClientTest < MiniTest::Spec
     stub_request(:post, url).to_return(body: '', status: 404)
 
     assert_raises GdsApi::HTTPNotFound do
-      @client.post_multipart("http://some.endpoint/some.json", {"a" => "123"})
+      @client.post_multipart("http://some.endpoint/some.json", "a" => "123")
     end
   end
 
@@ -782,7 +782,7 @@ class JsonClientTest < MiniTest::Spec
     stub_request(:post, url).to_return(body: '', status: 500)
 
     assert_raises GdsApi::HTTPServerError do
-      @client.post_multipart("http://some.endpoint/some.json", {"a" => "123"})
+      @client.post_multipart("http://some.endpoint/some.json", "a" => "123")
     end
   end
 
@@ -796,7 +796,7 @@ class JsonClientTest < MiniTest::Spec
            }).
       to_return(body: '{"b": "1"}', status: 200)
 
-    response = @client.put_multipart("http://some.endpoint/some.json", {"a" => "123"})
+    response = @client.put_multipart("http://some.endpoint/some.json", "a" => "123")
     assert_equal "1", response["b"]
   end
 
@@ -805,7 +805,7 @@ class JsonClientTest < MiniTest::Spec
     stub_request(:put, url).to_return(body: '', status: 404)
 
     assert_raises GdsApi::HTTPNotFound do
-      @client.put_multipart("http://some.endpoint/some.json", {"a" => "123"})
+      @client.put_multipart("http://some.endpoint/some.json", "a" => "123")
     end
   end
 
@@ -814,16 +814,16 @@ class JsonClientTest < MiniTest::Spec
     stub_request(:put, url).to_return(body: '', status: 500)
 
     assert_raises GdsApi::HTTPServerError do
-      @client.put_multipart("http://some.endpoint/some.json", {"a" => "123"})
+      @client.put_multipart("http://some.endpoint/some.json", "a" => "123")
     end
   end
 
   def test_should_raise_error_if_attempting_to_disable_timeout
     assert_raises RuntimeError do
-      GdsApi::JsonClient.new(:disable_timeout => true)
+      GdsApi::JsonClient.new(disable_timeout: true)
     end
     assert_raises RuntimeError do
-      GdsApi::JsonClient.new(:timeout => -1)
+      GdsApi::JsonClient.new(timeout: -1)
     end
   end
 

--- a/test/licence_application_api_test.rb
+++ b/test/licence_application_api_test.rb
@@ -20,8 +20,8 @@ class LicenceApplicationApiTest < Minitest::Test
   def test_should_return_list_of_licences
     stub_request(:get, "#{@core_url}/api/licences").
       with(headers: GdsApi::JsonClient.default_request_headers).
-      to_return(:status => 200,
-                :body => <<-EOS
+      to_return(status: 200,
+                body: <<-EOS
 [
    {
       "code":"1324-5-1",
@@ -81,11 +81,11 @@ EOS
   end
 
   def test_should_provide_full_licence_details_for_canonical_id
-    licence_exists('590001', {"isLocationSpecific" => true, "geographicalAvailability" => ["England","Wales"], "issuingAuthorities" => []})
+    licence_exists('590001', "isLocationSpecific" => true, "geographicalAvailability" => %w(England Wales), "issuingAuthorities" => [])
 
     expected = {
       "isLocationSpecific" => true,
-      "geographicalAvailability" => ["England", "Wales"],
+      "geographicalAvailability" => %w(England Wales),
       "issuingAuthorities" => []
     }
 
@@ -172,12 +172,10 @@ EOS
 
     assert_equal true, response["isLocationSpecific"]
 
-    assert_includes response["issuingAuthorities"][0]["authorityInteractions"]["apply"], {
-      "url" => "https://www.gov.uk/motor-salvage-operator-registration/city-of-london/apply-1",
+    assert_includes response["issuingAuthorities"][0]["authorityInteractions"]["apply"], "url" => "https://www.gov.uk/motor-salvage-operator-registration/city-of-london/apply-1",
       "usesLicensify" => true,
       "description" => "Application to register as a motor salvage operator",
       "payment" => "none"
-    }
   end
 
   def test_should_raise_exception_on_timeout

--- a/test/list_response_test.rb
+++ b/test/list_response_test.rb
@@ -2,24 +2,19 @@ require_relative 'test_helper'
 require 'gds_api/list_response'
 
 describe GdsApi::ListResponse do
-
   describe "accessing results" do
     before :each do
     end
 
     it "should allow Enumerable access to the results array" do
       data = {
-        "results" => [
-          "foo",
-          "bar",
-          "baz",
-        ],
+        "results" => %w(foo bar baz),
         "total" => 3,
         "_response_info" => {
           "status" => "ok",
         }
       }
-      response = GdsApi::ListResponse.new(stub(:body => data.to_json), nil)
+      response = GdsApi::ListResponse.new(stub(body: data.to_json), nil)
 
       assert_equal "foo", response.first
       assert_equal %w(foo bar baz), response.to_a
@@ -34,7 +29,7 @@ describe GdsApi::ListResponse do
           "status" => "ok",
         }
       }
-      response = GdsApi::ListResponse.new(stub(:body => data.to_json), nil)
+      response = GdsApi::ListResponse.new(stub(body: data.to_json), nil)
 
       assert_equal [], response.to_a
       assert ! response.any?
@@ -44,39 +39,39 @@ describe GdsApi::ListResponse do
   describe "handling pagination" do
     before :each do
       page_1 = {
-        "results" => ["foo1", "bar1"],
+        "results" => %w(foo1 bar1),
         "total" => 6,
         "current_page" => 1, "pages" => 3, "page_size" => 2,
         "_response_info" => {
           "status" => "ok",
           "links" => [
-            {"href" => "http://www.example.com/2", "rel" => "next"},
-            {"href" => "http://www.example.com/1", "rel" => "self"},
+            { "href" => "http://www.example.com/2", "rel" => "next" },
+            { "href" => "http://www.example.com/1", "rel" => "self" },
           ]
         }
       }
       page_2 = {
-        "results" => ["foo2", "bar2"],
+        "results" => %w(foo2 bar2),
         "total" => 6,
         "current_page" => 2, "pages" => 3, "page_size" => 2,
         "_response_info" => {
           "status" => "ok",
           "links" => [
-            {"href" => "http://www.example.com/1", "rel" => "previous"},
-            {"href" => "http://www.example.com/3", "rel" => "next"},
-            {"href" => "http://www.example.com/2", "rel" => "self"},
+            { "href" => "http://www.example.com/1", "rel" => "previous" },
+            { "href" => "http://www.example.com/3", "rel" => "next" },
+            { "href" => "http://www.example.com/2", "rel" => "self" },
           ]
         }
       }
       page_3 = {
-        "results" => ["foo3", "bar3"],
+        "results" => %w(foo3 bar3),
         "total" => 6,
         "current_page" => 3, "pages" => 3, "page_size" => 2,
         "_response_info" => {
           "status" => "ok",
           "links" => [
-            {"href" => "http://www.example.com/2", "rel" => "previous"},
-            {"href" => "http://www.example.com/3", "rel" => "self"},
+            { "href" => "http://www.example.com/2", "rel" => "previous" },
+            { "href" => "http://www.example.com/3", "rel" => "self" },
           ]
         }
       }
@@ -102,7 +97,7 @@ describe GdsApi::ListResponse do
         }
       )
 
-      @client = stub()
+      @client = stub
       @client.stubs(:get_list!).with("http://www.example.com/1").returns(GdsApi::ListResponse.new(@p1_response, @client))
       @client.stubs(:get_list!).with("http://www.example.com/2").returns(GdsApi::ListResponse.new(@p2_response, @client))
       @client.stubs(:get_list!).with("http://www.example.com/3").returns(GdsApi::ListResponse.new(@p3_response, @client))
@@ -164,7 +159,7 @@ describe GdsApi::ListResponse do
       it "should allow iteration across multiple pages" do
         assert_equal 6, @response.with_subsequent_pages.count
         assert_equal %w(foo1 bar1 foo2 bar2 foo3 bar3), @response.with_subsequent_pages.to_a
-        assert_equal %w(foo1 foo2 foo3), @response.with_subsequent_pages.select {|s| s =~ /foo/}
+        assert_equal %w(foo1 foo2 foo3), @response.with_subsequent_pages.select { |s| s =~ /foo/ }
       end
 
       it "should not load a page multiple times" do
@@ -179,13 +174,13 @@ describe GdsApi::ListResponse do
 
       it "should work with a non-paginated response" do
         data = {
-          "results" => ["foo1", "bar1"],
+          "results" => %w(foo1 bar1),
           "total" => 2,
           "_response_info" => {
             "status" => "ok",
           }
         }
-        response = GdsApi::ListResponse.new(stub(:body => data.to_json, :status => 200, :headers => {}), nil)
+        response = GdsApi::ListResponse.new(stub(body: data.to_json, status: 200, headers: {}), nil)
 
         assert_equal %w(foo1 bar1), response.with_subsequent_pages.to_a
       end

--- a/test/mapit_test.rb
+++ b/test/mapit_test.rb
@@ -12,22 +12,22 @@ describe GdsApi::Mapit do
 
   describe "postcodes" do
     it "should return the coordinates" do
-      mapit_has_a_postcode("SW1A 1AA", [ 51.5010096, -0.1415870 ])
+      mapit_has_a_postcode("SW1A 1AA", [51.5010096, -0.1415870])
 
       response = @api.location_for_postcode("SW1A 1AA")
       assert_equal 51.5010096, response.lat
-      assert_equal -0.1415870, response.lon
+      assert_equal(-0.1415870, response.lon)
     end
 
     it "should return the postcode" do
-      mapit_has_a_postcode("SW1A 1AA", [ 51.5010096, -0.1415870 ])
+      mapit_has_a_postcode("SW1A 1AA", [51.5010096, -0.1415870])
 
       response = @api.location_for_postcode("SW1A 1AA")
       assert_equal "SW1A 1AA", response.postcode
     end
 
     it "should return areas" do
-      mapit_has_a_postcode_and_areas("SW1A 1AA", [ 51.5010096, -0.1415870 ], [
+      mapit_has_a_postcode_and_areas("SW1A 1AA", [51.5010096, -0.1415870], [
         { 'name' => 'Lancashire County Council', 'type' => 'CTY', 'ons' => '30', 'gss' => 'E10000017' },
         { 'name' => 'South Ribble Borough Council', 'type' => 'DIS', 'ons' => '30UN', 'gss' => 'E07000126' }
       ])
@@ -64,11 +64,9 @@ describe GdsApi::Mapit do
 
   describe "areas_for_type" do
     before do
-       mapit_has_areas('EUR', {
-        "123" => { "name" => "Eastern", "id" => "123", "country_name" => "England" },
-        "234" => { "name" => "North West", "id" => "234", "country_name" => "England" },
-        "345" => { "name" => "Scotland", "id" => "345", "country_name" => "Scotland" }
-      })
+      mapit_has_areas('EUR', "123" => { "name" => "Eastern", "id" => "123", "country_name" => "England" },
+       "234" => { "name" => "North West", "id" => "234", "country_name" => "England" },
+       "345" => { "name" => "Scotland", "id" => "345", "country_name" => "Scotland" })
       mapit_does_not_have_areas('FOO')
     end
     it "should return areas of a type" do

--- a/test/middleware/govuk_header_sniffer_test.rb
+++ b/test/middleware/govuk_header_sniffer_test.rb
@@ -5,7 +5,7 @@ describe GdsApi::GovukHeaderSniffer do
   include Rack::Test::Methods
 
   let(:inner_app) do
-    lambda { |env| [200, {'Content-Type' => 'text/plain'}, ['All good!']] }
+    lambda { |_env| [200, { 'Content-Type' => 'text/plain' }, ['All good!']] }
   end
 
   let(:app) { GdsApi::GovukHeaderSniffer.new(inner_app, 'HTTP_GOVUK_REQUEST_ID') }

--- a/test/need_api_test.rb
+++ b/test/need_api_test.rb
@@ -35,7 +35,7 @@ describe GdsApi::NeedApi do
     end
 
     it "returns a list of needs matching the IDs" do
-      needs = @api.needs_by_id(1,2,3)
+      needs = @api.needs_by_id(1, 2, 3)
 
       assert_equal 3, needs.count
       assert_equal %w(1 2 3), needs.map { |need| need['id'] }
@@ -45,7 +45,7 @@ describe GdsApi::NeedApi do
     end
 
     it "makes the same request regardless of the order of the IDs" do
-      needs = @api.needs_by_id(2,1,3)
+      needs = @api.needs_by_id(2, 1, 3)
 
       assert_equal 3, needs.count
       assert_equal %w(1 2 3), needs.map { |need| need['id'] }
@@ -139,9 +139,9 @@ describe GdsApi::NeedApi do
   describe "creating needs" do
     it "should post to the right endpoint" do
       request_stub = stub_request(:post, @base_api_url + "/needs").with(
-        :body => '{"goal":"I wanna sammich!"}'
+        body: '{"goal":"I wanna sammich!"}'
       )
-      @api.create_need({"goal" => "I wanna sammich!"})
+      @api.create_need("goal" => "I wanna sammich!")
       assert_requested(request_stub)
     end
   end
@@ -278,10 +278,10 @@ describe GdsApi::NeedApi do
 
     it "should return organisations with abbreviations if present" do
       request_stub = need_api_has_organisations(
-        "committee-on-climate-change" => {"name" => "Committee on Climate Change",
-                                          "abbreviation" => "CCC"},
-        "competition-commission" => {"name" => "Competition Commission",
-                                     "abbreviation" => "CC"}
+        "committee-on-climate-change" => { "name" => "Committee on Climate Change",
+                                          "abbreviation" => "CCC" },
+        "competition-commission" => { "name" => "Competition Commission",
+                                     "abbreviation" => "CC" }
       )
       orgs = @api.organisations
 

--- a/test/organisations_api_test.rb
+++ b/test/organisations_api_test.rb
@@ -21,7 +21,7 @@ describe GdsApi::Organisations do
     end
 
     it "should handle the pagination" do
-      organisation_slugs = (1..50).map {|n| "organisation-#{n}" }
+      organisation_slugs = (1..50).map { |n| "organisation-#{n}" }
       organisations_api_has_organisations(organisation_slugs)
 
       response = @api.organisations
@@ -32,7 +32,7 @@ describe GdsApi::Organisations do
     end
 
     it "should raise error if endpoint 404s" do
-      stub_request(:get, "#{@base_api_url}/api/organisations").to_return(:status => 404)
+      stub_request(:get, "#{@base_api_url}/api/organisations").to_return(status: 404)
       assert_raises GdsApi::HTTPNotFound do
         @api.organisations
       end

--- a/test/panopticon_registerer_test.rb
+++ b/test/panopticon_registerer_test.rb
@@ -11,7 +11,7 @@ describe GdsApi::Panopticon::Registerer do
       it "should create an instance using the current Plek environment as the platform by default" do
         Plek.stubs(:current).returns(stub(find: "http://thisplace"))
 
-        GdsApi::Panopticon.expects(:new).with("http://thisplace", anything()).returns(:panopticon_instance)
+        GdsApi::Panopticon.expects(:new).with("http://thisplace", anything).returns(:panopticon_instance)
         r = GdsApi::Panopticon::Registerer.new({})
         assert_equal :panopticon_instance, r.send(:panopticon)
       end
@@ -19,28 +19,28 @@ describe GdsApi::Panopticon::Registerer do
       it "should pass through the endpoint url" do
         Plek.stubs(:current).returns(stub(find: "http://thisplace"))
 
-        GdsApi::Panopticon.expects(:new).with("http://otherplace", anything()).returns(:panopticon_instance)
-        r = GdsApi::Panopticon::Registerer.new({endpoint_url: "http://otherplace"})
+        GdsApi::Panopticon.expects(:new).with("http://otherplace", anything).returns(:panopticon_instance)
+        r = GdsApi::Panopticon::Registerer.new(endpoint_url: "http://otherplace")
         assert_equal :panopticon_instance, r.send(:panopticon)
       end
     end
 
     describe "setting other options" do
       it "should create an instance with a default timeout of 10 seconds" do
-        GdsApi::Panopticon.expects(:new).with(anything(), {timeout: 10}).returns(:panopticon_instance)
+        GdsApi::Panopticon.expects(:new).with(anything, timeout: 10).returns(:panopticon_instance)
         r = GdsApi::Panopticon::Registerer.new({})
         assert_equal :panopticon_instance, r.send(:panopticon)
       end
 
       it "should allow overriding the timeout" do
-        GdsApi::Panopticon.expects(:new).with(anything(), {timeout: 15}).returns(:panopticon_instance)
-        r = GdsApi::Panopticon::Registerer.new({timeout: 15})
+        GdsApi::Panopticon.expects(:new).with(anything, timeout: 15).returns(:panopticon_instance)
+        r = GdsApi::Panopticon::Registerer.new(timeout: 15)
         assert_equal :panopticon_instance, r.send(:panopticon)
       end
 
       it "shoule merge in the api credentials" do
-        GdsApi::Panopticon::Registerer.any_instance.stubs(:panopticon_api_credentials).returns({foo: "Bar", baz: "kablooie"})
-        GdsApi::Panopticon.expects(:new).with(anything(), {timeout: 10, foo: "Bar", baz: "kablooie"}).returns(:panopticon_instance)
+        GdsApi::Panopticon::Registerer.any_instance.stubs(:panopticon_api_credentials).returns(foo: "Bar", baz: "kablooie")
+        GdsApi::Panopticon.expects(:new).with(anything, timeout: 10, foo: "Bar", baz: "kablooie").returns(:panopticon_instance)
         r = GdsApi::Panopticon::Registerer.new({})
         assert_equal :panopticon_instance, r.send(:panopticon)
       end
@@ -63,7 +63,7 @@ describe GdsApi::Panopticon::Registerer do
       name: 'A guide to beards',
       description: '5 tips for keeping your beard in check',
       state: 'draft',
-      need_ids: ["100001", "100002"],
+      need_ids: %w(100001 100002),
       public_timestamp: "2014-01-01T12:00:00+00:00",
       latest_change_note: 'Added more stubble',
       content_id: 'f47b4fab-46fa-4020-97a2-3413a5d75402'
@@ -78,7 +78,7 @@ describe GdsApi::Panopticon::Registerer do
         title: 'A guide to beards',
         description: '5 tips for keeping your beard in check',
         state: 'draft',
-        need_ids: ["100001", "100002"],
+        need_ids: %w(100001 100002),
         primary_section: "tax/vat",
         sections: ["tax/vat", "tax/capital-gains"],
         specialist_sectors: ["oil-and-gas/wells", "oil-and-gas/licensing"],

--- a/test/panopticon_test.rb
+++ b/test/panopticon_test.rb
@@ -44,13 +44,13 @@ describe GdsApi::Panopticon do
 
   it 'fetches an artefact as a hash given a slug' do
     panopticon_has_metadata(basic_artefact)
-    artefact = api.artefact_for_slug(basic_artefact[:slug], :as_hash => true)
+    artefact = api.artefact_for_slug(basic_artefact[:slug], as_hash: true)
     assert_equal basic_artefact[:name], artefact['name']
   end
 
   it 'fetches and parses JSON into a hash' do
     url = "#{base_api_endpoint}/some.json"
-    stub_request(:get, url).to_return(body: {a:1}.to_json)
+    stub_request(:get, url).to_return(body: { a: 1 }.to_json)
 
     assert_equal 1, api.get_json(url)['a']
   end
@@ -110,7 +110,7 @@ describe GdsApi::Panopticon do
   end
 
   it 'uses basic auth' do
-    credentials = {user: 'fred', password: 'secret'}
+    credentials = { user: 'fred', password: 'secret' }
     api = GdsApi::Panopticon.new('http://some.url', basic_auth: credentials)
     url = "http://#{credentials[:user]}:#{credentials[:password]}@some.url/artefacts/1.json"
     stub_request(:put, url)
@@ -121,7 +121,7 @@ describe GdsApi::Panopticon do
 
   it 'registers new artefacts en masse' do
     r = GdsApi::Panopticon::Registerer.new(endpoint_url: base_api_endpoint, owning_app: 'my-app')
-    artefact = registerable_artefact()
+    artefact = registerable_artefact
     panopticon_has_no_metadata_for('foo')
 
     stub_request(:put, "#{base_api_endpoint}/artefacts/foo.json")
@@ -138,7 +138,7 @@ describe GdsApi::Panopticon do
   end
 
   it 'registers existing artefacts en masse' do
-    artefact = registerable_artefact()
+    artefact = registerable_artefact
     r = GdsApi::Panopticon::Registerer.new(endpoint_url: base_api_endpoint, owning_app: 'my-app')
 
     panopticon_has_metadata(artefact)

--- a/test/pp_data_in_test.rb
+++ b/test/pp_data_in_test.rb
@@ -11,7 +11,7 @@ describe GdsApi::PerformancePlatform::DataIn do
   end
 
   it "can submit a day aggregate for service feedback for a particular slug" do
-    request_details = {"some"=> "data"}
+    request_details = { "some" => "data" }
 
     stub_post = stub_service_feedback_day_aggregate_submission("some-slug", request_details)
 
@@ -21,7 +21,7 @@ describe GdsApi::PerformancePlatform::DataIn do
   end
 
   it "can submit entries counts for corporate content problem reports" do
-    entries = ["some", "entries"]
+    entries = %w(some entries)
 
     stub_post = stub_corporate_content_problem_report_count_submission(entries)
 
@@ -31,7 +31,7 @@ describe GdsApi::PerformancePlatform::DataIn do
   end
 
   it "can submit the corporate content urls with the most problem reports" do
-    entries = ["some", "entries"]
+    entries = %w(some entries)
 
     stub_post = stub_corporate_content_urls_with_the_most_problem_reports_submission(entries)
 

--- a/test/publishing_api_test.rb
+++ b/test/publishing_api_test.rb
@@ -44,8 +44,6 @@ describe GdsApi::PublishingApi do
     it "returns 200 OK if intent existed and was deleted" do
       base_path = "/test-intent"
 
-      publish_intent = intent_for_publishing_api(base_path)
-
       publishing_api
         .given("a publish intent exists at /test-intent")
         .upon_receiving("a request to delete a publish intent")
@@ -67,8 +65,6 @@ describe GdsApi::PublishingApi do
 
     it "returns 404 Not found if the intent does not exist" do
       base_path = "/test-intent"
-
-      publish_intent = intent_for_publishing_api(base_path)
 
       publishing_api
         .given("no content exists")
@@ -143,9 +139,9 @@ describe GdsApi::PublishingApi do
           body: {
             "error" => {
               "code" => 422,
-              "message" => Pact.term(generate: "Unprocessable", matcher:/\S+/),
+              "message" => Pact.term(generate: "Unprocessable", matcher: /\S+/),
               "fields" => {
-                "base_path" => Pact.each_like("has been reserved", :min => 1),
+                "base_path" => Pact.each_like("has been reserved", min: 1),
               },
             },
           },

--- a/test/publishing_api_v2_test.rb
+++ b/test/publishing_api_v2_test.rb
@@ -83,9 +83,9 @@ describe GdsApi::PublishingApiV2 do
             body: {
               "error" => {
                 "code" => 422,
-                "message" => Pact.term(generate: "Conflict", matcher:/\S+/),
+                "message" => Pact.term(generate: "Conflict", matcher: /\S+/),
                 "fields" => {
-                  "base_path" => Pact.each_like("is already in use by the 'publisher' app", :min => 1),
+                  "base_path" => Pact.each_like("is already in use by the 'publisher' app", min: 1),
                 },
               },
             },
@@ -200,9 +200,9 @@ describe GdsApi::PublishingApiV2 do
               body: {
                 "error" => {
                   "code" => 409,
-                  "message" => Pact.term(generate: "Conflict", matcher:/\S+/),
+                  "message" => Pact.term(generate: "Conflict", matcher: /\S+/),
                   "fields" => {
-                    "previous_version" => Pact.each_like("does not match", :min => 1),
+                    "previous_version" => Pact.each_like("does not match", min: 1),
                   },
                 },
               },
@@ -365,7 +365,7 @@ describe GdsApi::PublishingApiV2 do
             .will_respond_with(
               status: 200,
               body: {
-                "warnings" => Pact.like({"content_item_blocking_publish" => "message"}),
+                "warnings" => Pact.like("content_item_blocking_publish" => "message"),
                 "content_id" => @content_id,
                 "document_type" => Pact.like("special_route"),
                 "schema_name" => Pact.like("special_route"),
@@ -388,7 +388,6 @@ describe GdsApi::PublishingApiV2 do
           assert_equal 200, response.code
           assert_equal hash_including("content_item_blocking_publish"), response["warnings"]
         end
-
       end
 
       describe "when requesting the published version" do
@@ -492,7 +491,7 @@ describe GdsApi::PublishingApiV2 do
             body: {
               "error" => {
                 "code" => 404,
-                "message" => Pact.term(generate: "not found", matcher:/\S+/)
+                "message" => Pact.term(generate: "not found", matcher: /\S+/)
               },
             },
             headers: {
@@ -585,9 +584,9 @@ describe GdsApi::PublishingApiV2 do
             body: {
               "error" => {
                 "code" => 422,
-                "message" => Pact.term(generate: "Unprocessable entity", matcher:/\S+/),
+                "message" => Pact.term(generate: "Unprocessable entity", matcher: /\S+/),
                 "fields" => {
-                  "update_type" => Pact.each_like("is required", :min => 1),
+                  "update_type" => Pact.each_like("is required", min: 1),
                 },
               },
             }
@@ -623,7 +622,7 @@ describe GdsApi::PublishingApiV2 do
             status: 400,
             body: {
               "error" => {
-                "code" => 400, "message" => Pact.term(generate: "Cannot publish an already published content item", matcher:/\S+/),
+                "code" => 400, "message" => Pact.term(generate: "Cannot publish an already published content item", matcher: /\S+/),
               },
             }
           )
@@ -715,9 +714,9 @@ describe GdsApi::PublishingApiV2 do
               body: {
                 "error" => {
                   "code" => 409,
-                  "message" => Pact.term(generate: "Conflict", matcher:/\S+/),
+                  "message" => Pact.term(generate: "Conflict", matcher: /\S+/),
                   "fields" => {
-                    "previous_version" => Pact.each_like("does not match", :min => 1),
+                    "previous_version" => Pact.each_like("does not match", min: 1),
                   },
                 },
               },
@@ -814,7 +813,7 @@ describe GdsApi::PublishingApiV2 do
             body: {
               "error" => {
                 "code" => 422,
-                "message" => Pact.term(generate: "not-a-valid-type is not a valid unpublishing type", matcher:/\S+/),
+                "message" => Pact.term(generate: "not-a-valid-type is not a valid unpublishing type", matcher: /\S+/),
                 "fields" => {},
               },
             }
@@ -906,9 +905,9 @@ describe GdsApi::PublishingApiV2 do
               body: {
                 "error" => {
                   "code" => 409,
-                  "message" => Pact.term(generate: "Conflict", matcher:/\S+/),
+                  "message" => Pact.term(generate: "Conflict", matcher: /\S+/),
                   "fields" => {
-                    "previous_version" => Pact.each_like("does not match", :min => 1),
+                    "previous_version" => Pact.each_like("does not match", min: 1),
                   },
                 },
               },
@@ -1149,9 +1148,9 @@ describe GdsApi::PublishingApiV2 do
               body: {
                 "error" => {
                   "code" => 409,
-                  "message" => Pact.term(generate: "Conflict", matcher:/\S+/),
+                  "message" => Pact.term(generate: "Conflict", matcher: /\S+/),
                   "fields" => {
-                    "previous_version" => Pact.each_like("does not match", :min => 1),
+                    "previous_version" => Pact.each_like("does not match", min: 1),
                   },
                 },
               },
@@ -1267,10 +1266,9 @@ describe GdsApi::PublishingApiV2 do
         ["total", 2],
         ["pages", 1],
         ["current_page", 1],
-        ["links", [{"href"=>"http://example.org/v2/content?document_type=topic&fields[]=title&fields[]=base_path&page=1", "rel"=>"self"}]],
-        ["results", [{"title"=>"Content Item A", "base_path"=>"/a-base-path"}, {"title"=>"Content Item B", "base_path"=>"/another-base-path"}]]
+        ["links", [{ "href" => "http://example.org/v2/content?document_type=topic&fields[]=title&fields[]=base_path&page=1", "rel" => "self" }]],
+        ["results", [{ "title" => "Content Item A", "base_path" => "/a-base-path" }, { "title" => "Content Item B", "base_path" => "/another-base-path" }]]
       ], response.to_a
-
     end
 
     it "returns the content items in english locale by default" do
@@ -1312,8 +1310,8 @@ describe GdsApi::PublishingApiV2 do
         ["total", 1],
         ["pages", 1],
         ["current_page", 1],
-        ["links", [{"href"=>"http://example.org/v2/content?document_type=topic&fields[]=content_id&fields[]=locale&page=1", "rel"=>"self"}]],
-        ["results", [{"content_id"=>"bed722e6-db68-43e5-9079-063f623335a7", "locale"=>"en"}]]
+        ["links", [{ "href" => "http://example.org/v2/content?document_type=topic&fields[]=content_id&fields[]=locale&page=1", "rel" => "self" }]],
+        ["results", [{ "content_id" => "bed722e6-db68-43e5-9079-063f623335a7", "locale" => "en" }]]
       ], response.to_a
     end
 
@@ -1356,8 +1354,8 @@ describe GdsApi::PublishingApiV2 do
         ["total", 1],
         ["pages", 1],
         ["current_page", 1],
-        ["links", [{"href"=>"http://example.org/v2/content?document_type=topic&fields[]=content_id&fields[]=locale&locale=fr&page=1", "rel"=>"self"}]],
-        ["results", [{"content_id"=>"bed722e6-db68-43e5-9079-063f623335a7", "locale"=>"fr"}]]
+        ["links", [{ "href" => "http://example.org/v2/content?document_type=topic&fields[]=content_id&fields[]=locale&locale=fr&page=1", "rel" => "self" }]],
+        ["results", [{ "content_id" => "bed722e6-db68-43e5-9079-063f623335a7", "locale" => "fr" }]]
       ], response.to_a
     end
 
@@ -1402,11 +1400,11 @@ describe GdsApi::PublishingApiV2 do
         ["total", 3],
         ["pages", 1], ["current_page", 1],
         ["links",
-         [{"href"=>"http://example.org/v2/content?document_type=topic&fields[]=content_id&fields[]=locale&locale=all&page=1", "rel"=>"self"}]],
+         [{ "href" => "http://example.org/v2/content?document_type=topic&fields[]=content_id&fields[]=locale&locale=all&page=1", "rel" => "self" }]],
         ["results",
-         [{"content_id"=>"bed722e6-db68-43e5-9079-063f623335a7", "locale"=>"en"},
-          {"content_id"=>"bed722e6-db68-43e5-9079-063f623335a7", "locale"=>"fr"},
-          {"content_id"=>"bed722e6-db68-43e5-9079-063f623335a7", "locale"=>"ar"}]]
+         [{ "content_id" => "bed722e6-db68-43e5-9079-063f623335a7", "locale" => "en" },
+          { "content_id" => "bed722e6-db68-43e5-9079-063f623335a7", "locale" => "fr" },
+          { "content_id" => "bed722e6-db68-43e5-9079-063f623335a7", "locale" => "ar" }]]
       ], response.to_a
     end
 
@@ -1433,7 +1431,7 @@ describe GdsApi::PublishingApiV2 do
               rel: "self"
             }],
             results: [
-              { content_id: @content_id, details: {foo: :bar} }
+              { content_id: @content_id, details: { foo: :bar } }
             ]
           }
         )
@@ -1449,8 +1447,8 @@ describe GdsApi::PublishingApiV2 do
         ["total", 1],
         ["pages", 1],
         ["current_page", 1],
-        ["links", [{"href"=>"http://example.org/v2/content?document_type=topic&fields[]=content_id&fields[]=details&page=1", "rel"=>"self"}]],
-        ["results", [{"content_id"=>"bed722e6-db68-43e5-9079-063f623335a7", "details"=>{"foo"=>"bar"}}]]
+        ["links", [{ "href" => "http://example.org/v2/content?document_type=topic&fields[]=content_id&fields[]=details&page=1", "rel" => "self" }]],
+        ["results", [{ "content_id" => "bed722e6-db68-43e5-9079-063f623335a7", "details" => { "foo" => "bar" } }]]
       ], response.to_a
     end
   end
@@ -1552,7 +1550,7 @@ describe GdsApi::PublishingApiV2 do
             body: {
               "error" => {
                 "code" => 404,
-                "message" => Pact.term(generate: "not found", matcher:/\S+/)
+                "message" => Pact.term(generate: "not found", matcher: /\S+/)
               },
             },
             headers: {
@@ -1581,12 +1579,12 @@ describe GdsApi::PublishingApiV2 do
         @linking_content_item1 = content_item_for_content_id(content_id3,
           "base_path" => "/item-b",
           "links" => {
-            "topic" => [ @linked_content_item['content_id1'] ]
+            "topic" => [@linked_content_item['content_id1']]
         })
         @linking_content_item2 = content_item_for_content_id(content_id2,
           "base_path" => "/item-a",
           "links" => {
-            "topic" => [ @linked_content_item['content_id1'] ],
+            "topic" => [@linked_content_item['content_id1']],
         })
 
         publishing_api
@@ -1618,10 +1616,8 @@ describe GdsApi::PublishingApiV2 do
       it "returns the requested fields of linking items" do
         response = @api_client.get_linked_items(
           @linked_content_item["content_id"],
-          {
-            link_type: "topic",
-            fields: ["content_id", "base_path"],
-          }
+                      link_type: "topic",
+            fields: %w(content_id base_path)
         )
         assert_equal 200, response.code
 

--- a/test/response_test.rb
+++ b/test/response_test.rb
@@ -2,10 +2,9 @@ require_relative 'test_helper'
 require 'gds_api/response'
 
 describe GdsApi::Response do
-
   describe "accessing HTTP response details" do
     before :each do
-      @mock_http_response = stub(:body => "A Response body", :code => 200, :headers => {:cache_control => 'public'})
+      @mock_http_response = stub(body: "A Response body", code: 200, headers: { cache_control: 'public' })
       @response = GdsApi::Response.new(@mock_http_response)
     end
 
@@ -18,17 +17,17 @@ describe GdsApi::Response do
     end
 
     it "should pass-on the response headers" do
-      assert_equal({:cache_control => 'public'}, @response.headers)
+      assert_equal({ cache_control: 'public' }, @response.headers)
     end
   end
 
   describe ".expires_at" do
     it "should be calculated from cache-control max-age" do
       Timecop.freeze(Time.parse("15:00")) do
-        cache_control_headers = { :cache_control => 'public, max-age=900' }
+        cache_control_headers = { cache_control: 'public, max-age=900' }
         headers = cache_control_headers.merge(date: Time.now.httpdate)
 
-        mock_http_response = stub(:body => "A Response body", :code => 200, :headers => headers)
+        mock_http_response = stub(body: "A Response body", code: 200, headers: headers)
         response = GdsApi::Response.new(mock_http_response)
 
         assert_equal Time.parse("15:15"), response.expires_at
@@ -37,10 +36,10 @@ describe GdsApi::Response do
 
     it "should be same as the value of Expires header in absence of max-age" do
       Timecop.freeze(Time.parse("15:00")) do
-        cache_headers = { :cache_control => 'public', :expires => (Time.now + 900).httpdate }
+        cache_headers = { cache_control: 'public', expires: (Time.now + 900).httpdate }
         headers = cache_headers.merge(date: Time.now.httpdate)
 
-        mock_http_response = stub(:body => "A Response body", :code => 200, :headers => headers)
+        mock_http_response = stub(body: "A Response body", code: 200, headers: headers)
         response = GdsApi::Response.new(mock_http_response)
 
         assert_equal Time.parse("15:15"), response.expires_at
@@ -48,14 +47,14 @@ describe GdsApi::Response do
     end
 
     it "should be nil in absence of Expires header and max-age" do
-      mock_http_response = stub(:body => "A Response body", :code => 200, :headers => { :date => Time.now.httpdate })
+      mock_http_response = stub(body: "A Response body", code: 200, headers: { date: Time.now.httpdate })
       response = GdsApi::Response.new(mock_http_response)
 
       assert_nil response.expires_at
     end
 
     it "should be nil in absence of Date header and max-age" do
-      mock_http_response = stub(:body => "A Response body", :code => 200, :headers => {})
+      mock_http_response = stub(body: "A Response body", code: 200, headers: {})
       response = GdsApi::Response.new(mock_http_response)
 
       assert_nil response.expires_at
@@ -64,9 +63,9 @@ describe GdsApi::Response do
 
   describe ".expires_in" do
     it "should be seconds remaining from expiration time inferred from max-age" do
-      cache_control_headers = { :cache_control => 'public, max-age=900' }
+      cache_control_headers = { cache_control: 'public, max-age=900' }
       headers = cache_control_headers.merge(date: Time.now.httpdate)
-      mock_http_response = stub(:body => "A Response body", :code => 200, :headers => headers)
+      mock_http_response = stub(body: "A Response body", code: 200, headers: headers)
 
       Timecop.travel(12 * 60) do
         response = GdsApi::Response.new(mock_http_response)
@@ -75,9 +74,9 @@ describe GdsApi::Response do
     end
 
     it "should be seconds remaining from expiration time inferred from Expires header" do
-      cache_headers = { :cache_control => 'public', :expires => (Time.now + 900).httpdate }
+      cache_headers = { cache_control: 'public', expires: (Time.now + 900).httpdate }
       headers = cache_headers.merge(date: Time.now.httpdate)
-      mock_http_response = stub(:body => "A Response body", :code => 200, :headers => headers)
+      mock_http_response = stub(body: "A Response body", code: 200, headers: headers)
 
       Timecop.travel(12 * 60) do
         response = GdsApi::Response.new(mock_http_response)
@@ -86,15 +85,15 @@ describe GdsApi::Response do
     end
 
     it "should be nil in absence of Expires header and max-age" do
-      mock_http_response = stub(:body => "A Response body", :code => 200, :headers => { :date => Time.now.httpdate })
+      mock_http_response = stub(body: "A Response body", code: 200, headers: { date: Time.now.httpdate })
       response = GdsApi::Response.new(mock_http_response)
 
       assert_nil response.expires_in
     end
 
     it "should be nil in absence of Date header" do
-      cache_control_headers = { :cache_control => 'public, max-age=900' }
-      mock_http_response = stub(:body => "A Response body", :code => 200, :headers => cache_control_headers)
+      cache_control_headers = { cache_control: 'public, max-age=900' }
+      mock_http_response = stub(body: "A Response body", code: 200, headers: cache_control_headers)
       response = GdsApi::Response.new(mock_http_response)
 
       assert_nil response.expires_in
@@ -103,7 +102,7 @@ describe GdsApi::Response do
 
   describe "processing web_urls" do
     def build_response(body_string, relative_to = "https://www.gov.uk")
-      GdsApi::Response.new(stub(:body => body_string), :web_urls_relative_to => relative_to)
+      GdsApi::Response.new(stub(body: body_string), web_urls_relative_to: relative_to)
     end
 
     it "should map web URLs" do
@@ -149,7 +148,7 @@ describe GdsApi::Response do
     end
 
     it "should handle nil values" do
-      body = {"web_url" => nil}.to_json
+      body = { "web_url" => nil }.to_json
 
       response = build_response(body)
       assert_nil response['web_url']
@@ -210,12 +209,12 @@ describe GdsApi::Response do
             "language" => "en",
         },
         "tags" => [
-          {"slug" => "foo"},
-          {"slug" => "bar"},
-          {"slug" => "baz"},
+          { "slug" => "foo" },
+          { "slug" => "bar" },
+          { "slug" => "baz" },
         ],
       }
-      @response = GdsApi::Response.new(stub(:body => @response_data.to_json))
+      @response = GdsApi::Response.new(stub(body: @response_data.to_json))
     end
 
     describe "behaving like a read-only hash" do

--- a/test/router_test.rb
+++ b/test/router_test.rb
@@ -2,7 +2,6 @@ require 'test_helper'
 require 'gds_api/router'
 
 describe GdsApi::Router do
-
   before do
     @base_api_url = "http://router-api.example.com"
     @api = GdsApi::Router.new(@base_api_url)
@@ -12,8 +11,8 @@ describe GdsApi::Router do
     describe "fetching details about a backend" do
       it "should return backend details" do
         req = WebMock.stub_request(:get, "#{@base_api_url}/backends/foo").
-          to_return(:body => {"backend_id" => "foo", "backend_url" => "http://foo.example.com/"}.to_json,
-                    :headers => {"Content-type" => "application/json"})
+          to_return(body: { "backend_id" => "foo", "backend_url" => "http://foo.example.com/" }.to_json,
+                    headers: { "Content-type" => "application/json" })
 
         response = @api.get_backend("foo")
         assert_equal 200, response.code
@@ -24,7 +23,7 @@ describe GdsApi::Router do
 
       it "raises for a non-existend backend" do
         req = WebMock.stub_request(:get, "#{@base_api_url}/backends/foo").
-          to_return(:status => 404)
+          to_return(status: 404)
 
         assert_raises(GdsApi::HTTPNotFound) do
           @api.get_backend("foo")
@@ -35,7 +34,7 @@ describe GdsApi::Router do
 
       it "should URI escape the given ID" do
         req = WebMock.stub_request(:get, "#{@base_api_url}/backends/foo+bar").
-          to_return(:status => 404)
+          to_return(status: 404)
 
         assert_raises(GdsApi::HTTPNotFound) do
           @api.get_backend("foo bar")
@@ -48,9 +47,9 @@ describe GdsApi::Router do
     describe "creating/updating a backend" do
       it "should allow creating/updating a backend" do
         req = WebMock.stub_request(:put, "#{@base_api_url}/backends/foo").
-          with(:body => {"backend" => {"backend_url" => "http://foo.example.com/"}}.to_json).
-          to_return(:status => 201, :body => {"backend_id" => "foo", "backend_url" => "http://foo.example.com/"}.to_json,
-                    :headers => {"Content-type" => "application/json"})
+          with(body: { "backend" => { "backend_url" => "http://foo.example.com/" } }.to_json).
+          to_return(status: 201, body: { "backend_id" => "foo", "backend_url" => "http://foo.example.com/" }.to_json,
+                    headers: { "Content-type" => "application/json" })
 
         response = @api.add_backend("foo", "http://foo.example.com/")
         assert_equal 201, response.code
@@ -60,10 +59,10 @@ describe GdsApi::Router do
       end
 
       it "should raise an error if creating/updating a backend fails" do
-        response_data = {"backend_id" => "foo", "backend_url" => "ftp://foo.example.com/", "errors" => {"backend_url" => "is not an HTTP URL"}}
+        response_data = { "backend_id" => "foo", "backend_url" => "ftp://foo.example.com/", "errors" => { "backend_url" => "is not an HTTP URL" } }
         req = WebMock.stub_request(:put, "#{@base_api_url}/backends/foo").
-          with(:body => {"backend" => {"backend_url" => "http://foo.example.com/"}}.to_json).
-          to_return(:status => 400, :body => response_data.to_json, :headers => {"Content-type" => "application/json"})
+          with(body: { "backend" => { "backend_url" => "http://foo.example.com/" } }.to_json).
+          to_return(status: 400, body: response_data.to_json, headers: { "Content-type" => "application/json" })
 
         e = nil
         begin
@@ -81,13 +80,14 @@ describe GdsApi::Router do
 
       it "should URI escape the passed id" do
         req = WebMock.stub_request(:put, "#{@base_api_url}/backends/foo+bar").
-          with(:body => {"backend" => {"backend_url" => "http://foo.example.com/"}}.to_json).
-          to_return(:status => 404, :body => "Not found")
+          with(body: { "backend" => { "backend_url" => "http://foo.example.com/" } }.to_json).
+          to_return(status: 404, body: "Not found")
 
         # We expect a GdsApi::HTTPErrorResponse, but we want to ensure nothing else is raised
         begin
           @api.add_backend("foo bar", "http://foo.example.com/")
         rescue GdsApi::HTTPErrorResponse
+          nil
         end
 
         assert_requested(req)
@@ -97,8 +97,8 @@ describe GdsApi::Router do
     describe "deleting a backend" do
       it "allow deleting a backend" do
         req = WebMock.stub_request(:delete, "#{@base_api_url}/backends/foo").
-          to_return(:status => 200, :body => {"backend_id" => "foo", "backend_url" => "http://foo.example.com/"}.to_json,
-                    :headers => {"Content-type" => "application/json"})
+          to_return(status: 200, body: { "backend_id" => "foo", "backend_url" => "http://foo.example.com/" }.to_json,
+                    headers: { "Content-type" => "application/json" })
 
         response = @api.delete_backend("foo")
         assert_equal 200, response.code
@@ -108,9 +108,9 @@ describe GdsApi::Router do
       end
 
       it "should raise an error if deleting the backend fails" do
-        response_data = {"backend_id" => "foo", "backend_url" => "ftp://foo.example.com/", "errors" => {"base" => "Backend has routes - can't delete"}}
+        response_data = { "backend_id" => "foo", "backend_url" => "ftp://foo.example.com/", "errors" => { "base" => "Backend has routes - can't delete" } }
         req = WebMock.stub_request(:delete, "#{@base_api_url}/backends/foo").
-          to_return(:status => 400, :body => response_data.to_json, :headers => {"Content-type" => "application/json"})
+          to_return(status: 400, body: response_data.to_json, headers: { "Content-type" => "application/json" })
 
         e = nil
         begin
@@ -128,12 +128,11 @@ describe GdsApi::Router do
 
       it "should URI escape the passed id" do
         req = WebMock.stub_request(:delete, "#{@base_api_url}/backends/foo+bar").
-          to_return(:status => 404, :body => "Not found")
+          to_return(status: 404, body: "Not found")
 
         # We expect a GdsApi::HTTPErrorResponse, but we want to ensure nothing else is raised
-        begin
+        assert_raises GdsApi::HTTPErrorResponse do
           @api.delete_backend("foo bar")
-        rescue GdsApi::HTTPErrorResponse
         end
 
         assert_requested(req)
@@ -144,15 +143,15 @@ describe GdsApi::Router do
   describe "managing routes" do
     before :each do
       @commit_req = WebMock.stub_request(:post, "#{@base_api_url}/routes/commit").
-        to_return(:status => 200, :body => "Routers updated")
+        to_return(status: 200, body: "Routers updated")
     end
 
     describe "fetching a route" do
       it "should return the route details" do
-        route_data = {"incoming_path" => "/foo", "route_type" => "exact", "handler" => "backend", "backend_id" => "foo"}
+        route_data = { "incoming_path" => "/foo", "route_type" => "exact", "handler" => "backend", "backend_id" => "foo" }
         req = WebMock.stub_request(:get, "#{@base_api_url}/routes").
-          with(:query => {"incoming_path" => "/foo"}).
-          to_return(:status => 200, :body => route_data.to_json, :headers => {"Content-type" => "application/json"})
+          with(query: { "incoming_path" => "/foo" }).
+          to_return(status: 200, body: route_data.to_json, headers: { "Content-type" => "application/json" })
 
         response = @api.get_route("/foo")
         assert_equal 200, response.code
@@ -164,8 +163,8 @@ describe GdsApi::Router do
 
       it "should raise if nothing found" do
         req = WebMock.stub_request(:get, "#{@base_api_url}/routes").
-          with(:query => {"incoming_path" => "/foo"}).
-          to_return(:status => 404)
+          with(query: { "incoming_path" => "/foo" }).
+          to_return(status: 404)
 
         assert_raises(GdsApi::HTTPNotFound) do
           @api.get_route("/foo")
@@ -179,8 +178,8 @@ describe GdsApi::Router do
         # The WebMock query matcher matches unescaped params.  The call blows up if they're not escaped
 
         req = WebMock.stub_request(:get, "#{@base_api_url}/routes").
-          with(:query => {"incoming_path" => "/foo bar"}).
-          to_return(:status => 404)
+          with(query: { "incoming_path" => "/foo bar" }).
+          to_return(status: 404)
 
         assert_raises(GdsApi::HTTPNotFound) do
           @api.get_route("/foo bar")
@@ -193,10 +192,10 @@ describe GdsApi::Router do
 
     describe "creating/updating a route" do
       it "should allow creating/updating a route" do
-        route_data = {"incoming_path" => "/foo", "route_type" => "exact", "handler" => "backend", "backend_id" => "foo"}
+        route_data = { "incoming_path" => "/foo", "route_type" => "exact", "handler" => "backend", "backend_id" => "foo" }
         req = WebMock.stub_request(:put, "#{@base_api_url}/routes").
-          with(:body => {"route" => route_data}.to_json).
-          to_return(:status => 201, :body => route_data.to_json, :headers => {"Content-type" => "application/json"})
+          with(body: { "route" => route_data }.to_json).
+          to_return(status: 201, body: route_data.to_json, headers: { "Content-type" => "application/json" })
 
         response = @api.add_route("/foo", "exact", "foo")
         assert_equal 201, response.code
@@ -208,21 +207,21 @@ describe GdsApi::Router do
 
       it "should commit the routes when asked to" do
         req = WebMock.stub_request(:put, "#{@base_api_url}/routes").
-          to_return(:status => 201, :body => {}.to_json, :headers => {"Content-type" => "application/json"})
+          to_return(status: 201, body: {}.to_json, headers: { "Content-type" => "application/json" })
 
-        @api.add_route("/foo", "exact", "foo", :commit => true)
+        @api.add_route("/foo", "exact", "foo", commit: true)
 
         assert_requested(req)
         assert_requested(@commit_req)
       end
 
       it "should raise an error if creating/updating the route fails" do
-        route_data = {"incoming_path" => "/foo", "route_type" => "exact", "handler" => "backend", "backend_id" => "foo"}
-        response_data = route_data.merge("errors" => {"backend_id" => "does not exist"})
+        route_data = { "incoming_path" => "/foo", "route_type" => "exact", "handler" => "backend", "backend_id" => "foo" }
+        response_data = route_data.merge("errors" => { "backend_id" => "does not exist" })
 
         req = WebMock.stub_request(:put, "#{@base_api_url}/routes").
-          with(:body => {"route" => route_data}.to_json).
-          to_return(:status => 400, :body => response_data.to_json, :headers => {"Content-type" => "application/json"})
+          with(body: { "route" => route_data }.to_json).
+          to_return(status: 400, body: response_data.to_json, headers: { "Content-type" => "application/json" })
 
         e = nil
         begin
@@ -242,11 +241,11 @@ describe GdsApi::Router do
 
     describe "creating/updating a redirect route" do
       it "should allow creating/updating a redirect route" do
-        route_data = {"incoming_path" => "/foo", "route_type" => "exact", "handler" => "redirect",
-          "redirect_to" => "/bar", "redirect_type" => "permanent", "segments_mode" => nil}
+        route_data = { "incoming_path" => "/foo", "route_type" => "exact", "handler" => "redirect",
+          "redirect_to" => "/bar", "redirect_type" => "permanent", "segments_mode" => nil }
         req = WebMock.stub_request(:put, "#{@base_api_url}/routes").
-          with(:body => {"route" => route_data}.to_json).
-          to_return(:status => 201, :body => route_data.to_json, :headers => {"Content-type" => "application/json"})
+          with(body: { "route" => route_data }.to_json).
+          to_return(status: 201, body: route_data.to_json, headers: { "Content-type" => "application/json" })
 
         response = @api.add_redirect_route("/foo", "exact", "/bar")
         assert_equal 201, response.code
@@ -257,11 +256,11 @@ describe GdsApi::Router do
       end
 
       it "should allow creating/updating a temporary redirect route" do
-        route_data = {"incoming_path" => "/foo", "route_type" => "exact", "handler" => "redirect",
-          "redirect_to" => "/bar", "redirect_type" => "temporary", "segments_mode" => nil}
+        route_data = { "incoming_path" => "/foo", "route_type" => "exact", "handler" => "redirect",
+          "redirect_to" => "/bar", "redirect_type" => "temporary", "segments_mode" => nil }
         req = WebMock.stub_request(:put, "#{@base_api_url}/routes").
-          with(:body => {"route" => route_data}.to_json).
-          to_return(:status => 201, :body => route_data.to_json, :headers => {"Content-type" => "application/json"})
+          with(body: { "route" => route_data }.to_json).
+          to_return(status: 201, body: route_data.to_json, headers: { "Content-type" => "application/json" })
 
         response = @api.add_redirect_route("/foo", "exact", "/bar", "temporary")
         assert_equal 201, response.code
@@ -272,13 +271,13 @@ describe GdsApi::Router do
       end
 
       it "should allow creating/updating a redirect route which preserves segments" do
-        route_data = {"incoming_path" => "/foo", "route_type" => "exact", "handler" => "redirect",
-          "redirect_to" => "/bar", "redirect_type" => "temporary", "segments_mode" => "preserve"}
+        route_data = { "incoming_path" => "/foo", "route_type" => "exact", "handler" => "redirect",
+          "redirect_to" => "/bar", "redirect_type" => "temporary", "segments_mode" => "preserve" }
         req = WebMock.stub_request(:put, "#{@base_api_url}/routes").
-          with(:body => {"route" => route_data}.to_json).
-          to_return(:status => 201, :body => route_data.to_json, :headers => {"Content-type" => "application/json"})
+          with(body: { "route" => route_data }.to_json).
+          to_return(status: 201, body: route_data.to_json, headers: { "Content-type" => "application/json" })
 
-        response = @api.add_redirect_route("/foo", "exact", "/bar", "temporary", :segments_mode => "preserve")
+        response = @api.add_redirect_route("/foo", "exact", "/bar", "temporary", segments_mode: "preserve")
         assert_equal 201, response.code
         assert_equal "/bar", response['redirect_to']
 
@@ -288,22 +287,22 @@ describe GdsApi::Router do
 
       it "should commit the routes when asked to" do
         req = WebMock.stub_request(:put, "#{@base_api_url}/routes").
-          to_return(:status => 201, :body =>{}.to_json, :headers => {"Content-type" => "application/json"})
+          to_return(status: 201, body: {}.to_json, headers: { "Content-type" => "application/json" })
 
-        @api.add_redirect_route("/foo", "exact", "/bar", "temporary", :commit => true)
+        @api.add_redirect_route("/foo", "exact", "/bar", "temporary", commit: true)
 
         assert_requested(req)
         assert_requested(@commit_req)
       end
 
       it "should raise an error if creating/updating the redirect route fails" do
-        route_data = {"incoming_path" => "/foo", "route_type" => "exact", "handler" => "redirect",
-          "redirect_to" => "bar", "redirect_type" => "permanent", "segments_mode" => nil}
-        response_data = route_data.merge("errors" => {"redirect_to" => "is not a valid URL path"})
+        route_data = { "incoming_path" => "/foo", "route_type" => "exact", "handler" => "redirect",
+          "redirect_to" => "bar", "redirect_type" => "permanent", "segments_mode" => nil }
+        response_data = route_data.merge("errors" => { "redirect_to" => "is not a valid URL path" })
 
         req = WebMock.stub_request(:put, "#{@base_api_url}/routes").
-          with(:body => {"route" => route_data}.to_json).
-          to_return(:status => 400, :body => response_data.to_json, :headers => {"Content-type" => "application/json"})
+          with(body: { "route" => route_data }.to_json).
+          to_return(status: 400, body: response_data.to_json, headers: { "Content-type" => "application/json" })
 
         e = nil
         begin
@@ -323,10 +322,10 @@ describe GdsApi::Router do
 
     describe "#add_gone_route" do
       it "should allow creating/updating a gone route" do
-        route_data = {"incoming_path" => "/foo", "route_type" => "exact", "handler" => "gone"}
+        route_data = { "incoming_path" => "/foo", "route_type" => "exact", "handler" => "gone" }
         req = WebMock.stub_request(:put, "#{@base_api_url}/routes").
-          with(:body => {"route" => route_data}.to_json).
-          to_return(:status => 201, :body => route_data.to_json, :headers => {"Content-type" => "application/json"})
+          with(body: { "route" => route_data }.to_json).
+          to_return(status: 201, body: route_data.to_json, headers: { "Content-type" => "application/json" })
 
         response = @api.add_gone_route("/foo", "exact")
         assert_equal 201, response.code
@@ -338,21 +337,21 @@ describe GdsApi::Router do
 
       it "should commit the routes when asked to" do
         req = WebMock.stub_request(:put, "#{@base_api_url}/routes").
-          to_return(:status => 201, :body =>{}.to_json, :headers => {"Content-type" => "application/json"})
+          to_return(status: 201, body: {}.to_json, headers: { "Content-type" => "application/json" })
 
-        @api.add_gone_route("/foo", "exact", :commit => true)
+        @api.add_gone_route("/foo", "exact", commit: true)
 
         assert_requested(req)
         assert_requested(@commit_req)
       end
 
       it "should raise an error if creating/updating the gone route fails" do
-        route_data = {"incoming_path" => "foo", "route_type" => "exact", "handler" => "gone"}
-        response_data = route_data.merge("errors" => {"incoming_path" => "is not a valid URL path"})
+        route_data = { "incoming_path" => "foo", "route_type" => "exact", "handler" => "gone" }
+        response_data = route_data.merge("errors" => { "incoming_path" => "is not a valid URL path" })
 
         req = WebMock.stub_request(:put, "#{@base_api_url}/routes").
-          with(:body => {"route" => route_data}.to_json).
-          to_return(:status => 400, :body => response_data.to_json, :headers => {"Content-type" => "application/json"})
+          with(body: { "route" => route_data }.to_json).
+          to_return(status: 400, body: response_data.to_json, headers: { "Content-type" => "application/json" })
 
         e = nil
         begin
@@ -372,10 +371,10 @@ describe GdsApi::Router do
 
     describe "deleting a route" do
       it "should allow deleting a route" do
-        route_data = {"incoming_path" => "/foo", "route_type" => "exact", "handler" => "backend", "backend_id" => "foo"}
+        route_data = { "incoming_path" => "/foo", "route_type" => "exact", "handler" => "backend", "backend_id" => "foo" }
         req = WebMock.stub_request(:delete, "#{@base_api_url}/routes").
-          with(:query => {"incoming_path" => "/foo"}).
-          to_return(:status => 200, :body => route_data.to_json, :headers => {"Content-type" => "application/json"})
+          with(query: { "incoming_path" => "/foo" }).
+          to_return(status: 200, body: route_data.to_json, headers: { "Content-type" => "application/json" })
 
         response = @api.delete_route("/foo")
         assert_equal 200, response.code
@@ -387,10 +386,10 @@ describe GdsApi::Router do
 
       it "should commit the routes when asked to" do
         req = WebMock.stub_request(:delete, "#{@base_api_url}/routes").
-          with(:query => {"incoming_path" => "/foo"}).
-          to_return(:status => 200, :body => {}.to_json, :headers => {"Content-type" => "application/json"})
+          with(query: { "incoming_path" => "/foo" }).
+          to_return(status: 200, body: {}.to_json, headers: { "Content-type" => "application/json" })
 
-        @api.delete_route("/foo", :commit => true)
+        @api.delete_route("/foo", commit: true)
 
         assert_requested(req)
         assert_requested(@commit_req)
@@ -398,8 +397,8 @@ describe GdsApi::Router do
 
       it "should raise HTTPNotFound if nothing found" do
         req = WebMock.stub_request(:delete, "#{@base_api_url}/routes").
-          with(:query => {"incoming_path" => "/foo"}).
-          to_return(:status => 404)
+          with(query: { "incoming_path" => "/foo" }).
+          to_return(status: 404)
 
         e = nil
         begin
@@ -419,12 +418,11 @@ describe GdsApi::Router do
         # The WebMock query matcher matches unescaped params.  The call blows up if they're not escaped
 
         req = WebMock.stub_request(:delete, "#{@base_api_url}/routes").
-          with(:query => {"incoming_path" => "/foo bar"}).
-          to_return(:status => 404)
+          with(query: { "incoming_path" => "/foo bar" }).
+          to_return(status: 404)
 
-        begin
+        assert_raises GdsApi::HTTPNotFound do
           @api.delete_route("/foo bar")
-        rescue GdsApi::HTTPNotFound
         end
 
         assert_requested(req)
@@ -439,8 +437,8 @@ describe GdsApi::Router do
       end
 
       it "should raise an error if committing the routes fails" do
-        req = WebMock.stub_request(:post, "#{@base_api_url}/routes/commit").
-          to_return(:status => 500, :body => "Failed to update all routers")
+        WebMock.stub_request(:post, "#{@base_api_url}/routes/commit").
+          to_return(status: 500, body: "Failed to update all routers")
 
         e = nil
         begin

--- a/test/rummager_test.rb
+++ b/test/rummager_test.rb
@@ -12,28 +12,28 @@ describe GdsApi::Rummager do
   it "#advanced_search should raise an exception if the service at the search URI returns a 500" do
     stub_request(:get, /example.com\/advanced_search/).to_return(status: [500, "Internal Server Error"])
     assert_raises(GdsApi::HTTPServerError) do
-      GdsApi::Rummager.new("http://example.com").advanced_search({keywords: "query"})
+      GdsApi::Rummager.new("http://example.com").advanced_search(keywords: "query")
     end
   end
 
   it "#advanced_search should raise an exception if the service at the search URI returns a 404" do
     stub_request(:get, /example.com\/advanced_search/).to_return(status: [404, "Not Found"])
     assert_raises(GdsApi::HTTPNotFound) do
-      GdsApi::Rummager.new("http://example.com").advanced_search({keywords: "query"})
+      GdsApi::Rummager.new("http://example.com").advanced_search(keywords: "query")
     end
   end
 
   it "#advanced_search should raise an exception if the service at the search URI times out" do
     stub_request(:get, /example.com\/advanced_search/).to_timeout
     assert_raises(GdsApi::TimedOutException) do
-      GdsApi::Rummager.new("http://example.com").advanced_search({keywords: "query"})
+      GdsApi::Rummager.new("http://example.com").advanced_search(keywords: "query")
     end
   end
 
   it "#advanced_search should return the search deserialized from json" do
-    search_results = [{"title" => "document-title"}]
+    search_results = [{ "title" => "document-title" }]
     stub_request(:get, /example.com\/advanced_search/).to_return(body: search_results.to_json)
-    results = GdsApi::Rummager.new("http://example.com").advanced_search({keywords: "query"})
+    results = GdsApi::Rummager.new("http://example.com").advanced_search(keywords: "query")
 
     assert_equal search_results, results.to_hash
   end
@@ -46,18 +46,18 @@ describe GdsApi::Rummager do
 
   it "#advanced_search should return an empty set of results without making request if arguments is nil" do
     assert_raises(ArgumentError) do
-      results = GdsApi::Rummager.new("http://example.com").advanced_search(nil)
+      GdsApi::Rummager.new("http://example.com").advanced_search(nil)
     end
   end
 
   it "#advanced_search should request the search results in JSON format" do
-    GdsApi::Rummager.new("http://example.com").advanced_search({keywords: "query"})
+    GdsApi::Rummager.new("http://example.com").advanced_search(keywords: "query")
 
-    assert_requested :get, /.*/, headers: {"Accept" => "application/json"}
+    assert_requested :get, /.*/, headers: { "Accept" => "application/json" }
   end
 
   it "#advanced_search should issue a request for all the params supplied" do
-    GdsApi::Rummager.new("http://example.com").advanced_search({keywords: "query & stuff", topics: ["1","2"], order: {public_timestamp: "desc"}})
+    GdsApi::Rummager.new("http://example.com").advanced_search(keywords: "query & stuff", topics: %w(1 2), order: { public_timestamp: "desc" })
 
     assert_requested :get, /keywords=query%20%26%20stuff/
     assert_requested :get, /topics\[\]=1&topics\[\]=2/
@@ -83,7 +83,7 @@ describe GdsApi::Rummager do
   it "#search should raise an exception if the service at the search URI returns a 400" do
     stub_request(:get, /example.com\/search/).to_return(
       status: [400, "Bad Request"],
-      body: %q("error":"Filtering by \"coffee\" is not allowed"),
+      body: '"error":"Filtering by \"coffee\" is not allowed"',
     )
     assert_raises(GdsApi::HTTPClientError) do
       GdsApi::Rummager.new("http://example.com").search(q: "query", filter_coffee: "tea")
@@ -93,7 +93,7 @@ describe GdsApi::Rummager do
   it "#search should raise an exception if the service at the search URI returns a 422" do
     stub_request(:get, /example.com\/search/).to_return(
       status: [422, "Bad Request"],
-      body: %q("error":"Filtering by \"coffee\" is not allowed"),
+      body: '"error":"Filtering by \"coffee\" is not allowed"',
     )
     assert_raises(GdsApi::HTTPClientError) do
       GdsApi::Rummager.new("http://example.com").search(q: "query", filter_coffee: "tea")
@@ -108,7 +108,7 @@ describe GdsApi::Rummager do
   end
 
   it "#search should return the search deserialized from json" do
-    search_results = [{"title" => "document-title"}]
+    search_results = [{ "title" => "document-title" }]
     stub_request(:get, /example.com\/search/).to_return(body: search_results.to_json)
     results = GdsApi::Rummager.new("http://example.com").search(q: "query")
     assert_equal search_results, results.to_hash
@@ -117,13 +117,13 @@ describe GdsApi::Rummager do
   it "#search should request the search results in JSON format" do
     GdsApi::Rummager.new("http://example.com").search(q: "query")
 
-    assert_requested :get, /.*/, headers: {"Accept" => "application/json"}
+    assert_requested :get, /.*/, headers: { "Accept" => "application/json" }
   end
 
   it "#search should issue a request for all the params supplied" do
     GdsApi::Rummager.new("http://example.com").search(
       q: "query & stuff",
-      filter_topics: ["1", "2"],
+      filter_topics: %w(1 2),
       order: "-public_timestamp",
     )
 

--- a/test/support_api_test.rb
+++ b/test/support_api_test.rb
@@ -11,11 +11,11 @@ describe GdsApi::SupportApi do
   end
 
   it "can report a problem" do
-    request_details = {certain: "details"}
+    request_details = { certain: "details" }
 
     stub_post = stub_request(:post, "#{@base_api_url}/anonymous-feedback/problem-reports").
-      with(:body => {"problem_report" => request_details}.to_json).
-      to_return(:status => 201)
+      with(body: { "problem_report" => request_details }.to_json).
+      to_return(status: 201)
 
     @api.create_problem_report(request_details)
 
@@ -23,11 +23,11 @@ describe GdsApi::SupportApi do
   end
 
   it "can pass service feedback" do
-    request_details = {"transaction-completed-values"=>"1", "details"=>"abc"}
+    request_details = { "transaction-completed-values" => "1", "details" => "abc" }
 
     stub_post = stub_request(:post, "#{@base_api_url}/anonymous-feedback/service-feedback").
-      with(:body => {"service_feedback" => request_details}.to_json).
-      to_return(:status => 201)
+      with(body: { "service_feedback" => request_details }.to_json).
+      to_return(status: 201)
 
     @api.create_service_feedback(request_details)
 
@@ -35,11 +35,11 @@ describe GdsApi::SupportApi do
   end
 
   it "can submit long-form anonymous feedback" do
-    request_details = {certain: "details"}
+    request_details = { certain: "details" }
 
     stub_post = stub_request(:post, "#{@base_api_url}/anonymous-feedback/long-form-contacts").
-      with(:body => {"long_form_contact" => request_details}.to_json).
-      to_return(:status => 201)
+      with(body: { "long_form_contact" => request_details }.to_json).
+      to_return(status: 201)
 
     @api.create_anonymous_long_form_contact(request_details)
 
@@ -47,10 +47,10 @@ describe GdsApi::SupportApi do
   end
 
   it "fetches problem report daily totals" do
-    response_body = {"data" => ["results"]}
+    response_body = { "data" => ["results"] }
 
     stub_get = stub_request(:get, "#{@base_api_url}/anonymous-feedback/problem-reports/2014-07-12/totals").
-      to_return(:status => 200, body: response_body.to_json)
+      to_return(status: 200, body: response_body.to_json)
 
     result = @api.problem_report_daily_totals_for(Date.new(2014, 7, 12))
 
@@ -115,7 +115,7 @@ describe GdsApi::SupportApi do
 
   describe "POST /anonymous-feedback/global-export-requests" do
     it "makes a POST request to the support API" do
-      params = {from_date: "1 June 2016", to_date: "8 June 2016", notification_email: "foo@example.com"}
+      params = { from_date: "1 June 2016", to_date: "8 June 2016", notification_email: "foo@example.com" }
       stub_post = stub_support_global_export_request_creation(params)
 
       @api.create_global_export_request(params)
@@ -125,7 +125,7 @@ describe GdsApi::SupportApi do
 
   describe "POST /page-improvements" do
     it "makes a POST request to the support API" do
-      params = {description: "The title could be better."}
+      params = { description: "The title could be better." }
       stub_post = stub_create_page_improvement(params)
 
       @api.create_page_improvement(params)

--- a/test/support_test.rb
+++ b/test/support_test.rb
@@ -11,11 +11,11 @@ describe GdsApi::Support do
   end
 
   it "can create an FOI request" do
-    request_details = {"foi_request"=>{"requester"=>{"name"=>"A", "email"=>"a@b.com"}, "details"=>"abc"}}
+    request_details = { "foi_request" => { "requester" => { "name" => "A", "email" => "a@b.com" }, "details" => "abc" } }
 
     stub_post = stub_request(:post, "#{@base_api_url}/foi_requests").
-      with(:body => {"foi_request" => request_details}.to_json).
-      to_return(:status => 201)
+      with(body: { "foi_request" => request_details }.to_json).
+      to_return(status: 201)
 
     @api.create_foi_request(request_details)
 
@@ -29,11 +29,11 @@ describe GdsApi::Support do
   end
 
   it "can report a problem" do
-    request_details = {certain: "details"}
+    request_details = { certain: "details" }
 
     stub_post = stub_request(:post, "#{@base_api_url}/anonymous_feedback/problem_reports").
-      with(:body => {"problem_report" => request_details}.to_json).
-      to_return(:status => 201)
+      with(body: { "problem_report" => request_details }.to_json).
+      to_return(status: 201)
 
     @api.create_problem_report(request_details)
 
@@ -41,11 +41,11 @@ describe GdsApi::Support do
   end
 
   it "can submit long-form anonymous feedback" do
-    request_details = {certain: "details"}
+    request_details = { certain: "details" }
 
     stub_post = stub_request(:post, "#{@base_api_url}/anonymous_feedback/long_form_contacts").
-      with(:body => {"long_form_contact" => request_details}.to_json).
-      to_return(:status => 201)
+      with(body: { "long_form_contact" => request_details }.to_json).
+      to_return(status: 201)
 
     @api.create_anonymous_long_form_contact(request_details)
 
@@ -53,11 +53,11 @@ describe GdsApi::Support do
   end
 
   it "can create a named contact" do
-    request_details = {certain: "details"}
+    request_details = { certain: "details" }
 
     stub_post = stub_request(:post, "#{@base_api_url}/named_contacts").
-      with(:body => {"named_contact" => request_details}.to_json).
-      to_return(:status => 201)
+      with(body: { "named_contact" => request_details }.to_json).
+      to_return(status: 201)
 
     @api.create_named_contact(request_details)
 
@@ -71,11 +71,11 @@ describe GdsApi::Support do
   end
 
   it "can pass service feedback" do
-    request_details = {"transaction-completed-values"=>"1", "details"=>"abc"}
+    request_details = { "transaction-completed-values" => "1", "details" => "abc" }
 
     stub_post = stub_request(:post, "#{@base_api_url}/anonymous_feedback/service_feedback").
-      with(:body => {"service_feedback" => request_details}.to_json).
-      to_return(:status => 201)
+      with(body: { "service_feedback" => request_details }.to_json).
+      to_return(status: 201)
 
     @api.create_service_feedback(request_details)
 
@@ -91,6 +91,5 @@ describe GdsApi::Support do
   it "gets the correct feedback URL" do
     assert_equal("#{@base_api_url}/anonymous_feedback?path=foo",
                  @api.feedback_url('foo'))
-
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -45,7 +45,7 @@ module PactTest
 end
 
 def load_fixture_file(filename)
-  File.open( File.join( File.dirname(__FILE__), "fixtures", filename ), :encoding => 'utf-8' )
+  File.open(File.join(File.dirname(__FILE__), "fixtures", filename), encoding: 'utf-8')
 end
 
 require 'webmock/minitest'

--- a/test/test_helpers/email_alert_api_test.rb
+++ b/test/test_helpers/email_alert_api_test.rb
@@ -12,13 +12,13 @@ describe GdsApi::TestHelpers::EmailAlertApi do
     before { stub_any_email_alert_api_call }
 
     it "matches a post request with any empty attributes by default" do
-      email_alert_api.send_alert({ "foo" => "bar" })
+      email_alert_api.send_alert("foo" => "bar")
       assert_email_alert_sent
     end
 
     it "matches a post request subset of attributes" do
-      email_alert_api.send_alert({ "foo" => "bar", "baz" => "qux" })
-      assert_email_alert_sent({ "foo" => "bar" })
+      email_alert_api.send_alert("foo" => "bar", "baz" => "qux")
+      assert_email_alert_sent("foo" => "bar")
     end
   end
 end

--- a/test/test_helpers/pact_helper.rb
+++ b/test/test_helpers/pact_helper.rb
@@ -1,4 +1,4 @@
-PUBLISHING_API_PORT=3001
+PUBLISHING_API_PORT = 3001
 
 def publishing_api_host
   "http://localhost:#{PUBLISHING_API_PORT}"

--- a/test/test_helpers/panopticon_test.rb
+++ b/test/test_helpers/panopticon_test.rb
@@ -10,7 +10,7 @@ describe GdsApi::TestHelpers::Panopticon do
 
     assert(
       WebMock::StubRegistry.instance.registered_request?(expected_signature),
-      "Stub is not registered:\n\t#{expected_signature.to_s}"
+      "Stub is not registered:\n\t#{expected_signature}"
     )
   end
 

--- a/test/test_helpers/publishing_api_test.rb
+++ b/test/test_helpers/publishing_api_test.rb
@@ -9,7 +9,7 @@ describe GdsApi::TestHelpers::PublishingApi do
 
   describe '#request_json_matching predicate' do
     describe "nested required attribute" do
-      let(:matcher) { request_json_matching({"a" => {"b" => 1}}) }
+      let(:matcher) { request_json_matching("a" => { "b" => 1 }) }
 
       it "matches a body with exact same nested hash strucure" do
         assert matcher.call(stub("request", body: '{"a": {"b": 1}}'))
@@ -33,7 +33,7 @@ describe GdsApi::TestHelpers::PublishingApi do
     end
 
     describe "hash to match uses symbol keys" do
-      let(:matcher) { request_json_matching({a: 1}) }
+      let(:matcher) { request_json_matching(a: 1) }
 
       it "matches a json body" do
         assert matcher.call(stub("request", body: '{"a": 1}'))
@@ -55,7 +55,7 @@ describe GdsApi::TestHelpers::PublishingApi do
     end
 
     describe "one required attribute" do
-      let(:matcher) { request_json_including({"a" => 1}) }
+      let(:matcher) { request_json_including("a" => 1) }
 
       it "does not match an empty body" do
         refute matcher.call(stub("request", body: "{}"))
@@ -75,7 +75,7 @@ describe GdsApi::TestHelpers::PublishingApi do
     end
 
     describe "nested required attribute" do
-      let(:matcher) { request_json_including({"a" => {"b" => 1}}) }
+      let(:matcher) { request_json_including("a" => { "b" => 1 }) }
 
       it "matches a body with exact same nested hash strucure" do
         assert matcher.call(stub("request", body: '{"a": {"b": 1}}'))
@@ -95,7 +95,7 @@ describe GdsApi::TestHelpers::PublishingApi do
     end
 
     describe "hash to match uses symbol keys" do
-      let(:matcher) { request_json_including({a: {b: 1}}) }
+      let(:matcher) { request_json_including(a: { b: 1 }) }
 
       it "matches a json body" do
         assert matcher.call(stub("request", body: '{"a": {"b": 1}}'))
@@ -103,7 +103,7 @@ describe GdsApi::TestHelpers::PublishingApi do
     end
 
     describe "nested arrays" do
-      let(:matcher) { request_json_including({"a" => [1]}) }
+      let(:matcher) { request_json_including("a" => [1]) }
 
       it "matches a body with exact same inner array" do
         assert matcher.call(stub("request", body: '{"a": [1]}'))
@@ -115,7 +115,7 @@ describe GdsApi::TestHelpers::PublishingApi do
     end
 
     describe "hashes in nested arrays" do
-      let(:matcher) { request_json_including({"a" => [{"b" => 1}, 2]}) }
+      let(:matcher) { request_json_including("a" => [{ "b" => 1 }, 2]) }
 
       it "matches a body with exact same inner array" do
         assert matcher.call(stub("request", body: '{"a": [{"b": 1}, 2]}'))

--- a/test/test_helpers/publishing_api_v2_test.rb
+++ b/test/test_helpers/publishing_api_v2_test.rb
@@ -45,7 +45,7 @@ describe GdsApi::TestHelpers::PublishingApiV2 do
 
   describe "#publishing_api_has_content" do
     it "stubs the call to get content items" do
-      publishing_api_has_content([{"content_id" => "2878337b-bed9-4e7f-85b6-10ed2cbcd504"}])
+      publishing_api_has_content([{ "content_id" => "2878337b-bed9-4e7f-85b6-10ed2cbcd504" }])
 
       response = publishing_api.get_content_items({})['results']
 
@@ -83,13 +83,11 @@ describe GdsApi::TestHelpers::PublishingApiV2 do
           { "content_id" => content_id_2 },
           { "content_id" => content_id_3 },
         ],
-        {
-          page: 1,
+                  page: 1,
           per_page: 2
-        }
       )
 
-      response = publishing_api.get_content_items({ page: 1, per_page: 2 })
+      response = publishing_api.get_content_items(page: 1, per_page: 2)
       records = response['results']
 
       assert_equal(response['total'], 3)
@@ -110,13 +108,11 @@ describe GdsApi::TestHelpers::PublishingApiV2 do
           { "content_id" => content_id_1 },
           { "content_id" => content_id_2 },
         ],
-        {
-          page: 10,
+                  page: 10,
           per_page: 2
-        }
       )
 
-      response = publishing_api.get_content_items({ page: 10, per_page: 2 })
+      response = publishing_api.get_content_items(page: 10, per_page: 2)
       records = response['results']
 
       assert_equal(records, [])

--- a/test/worldwide_api_test.rb
+++ b/test/worldwide_api_test.rb
@@ -21,7 +21,7 @@ describe GdsApi::Worldwide do
     end
 
     it "should handle the pagination" do
-      country_slugs = (1..50).map {|n| "country-#{n}" }
+      country_slugs = (1..50).map { |n| "country-#{n}" }
       worldwide_api_has_locations(country_slugs)
 
       response = @api.world_locations
@@ -32,7 +32,7 @@ describe GdsApi::Worldwide do
     end
 
     it "should raise error if endpoint 404s" do
-      stub_request(:get, "#{@base_api_url}/api/world-locations").to_return(:status => 404)
+      stub_request(:get, "#{@base_api_url}/api/world-locations").to_return(status: 404)
       assert_raises GdsApi::HTTPNotFound do
         @api.world_locations
       end
@@ -73,7 +73,7 @@ describe GdsApi::Worldwide do
     end
 
     it "should raise error on 404" do
-      stub_request(:get, "#{@base_api_url}/api/world-locations/non-existent/organisations").to_return(:status => 404)
+      stub_request(:get, "#{@base_api_url}/api/world-locations/non-existent/organisations").to_return(status: 404)
       assert_raises GdsApi::HTTPNotFound do
         @api.organisations_for_world_location('non-existent')
       end


### PR DESCRIPTION
In https://github.com/alphagov/gds-api-adapters/pull/628 I'm attempting a large scale refactor. The linting won't pass for that PR because there are styleguide violations in all the files it's touching (we normally only run rubocop against changed files).

This fixes all styleguide violations so that that PR can be merged without noise.