### PR TITLE
Add explicit handling for Invalid URI exceptions

### DIFF
--- a/lib/gds_api/exceptions.rb
+++ b/lib/gds_api/exceptions.rb
@@ -46,6 +46,8 @@ module GdsApi
   class HTTPUnprocessableEntity < HTTPClientError
   end
 
+  class InvalidUrl < BaseError; end
+
   class NoBearerToken < BaseError; end
 
   module ExceptionHandling

--- a/lib/gds_api/json_client.rb
+++ b/lib/gds_api/json_client.rb
@@ -297,6 +297,10 @@ module GdsApi
       logger.error loggable.merge(status: 'timeout', error_message: e.message, error_class: e.class.name, end_time: Time.now.to_f).to_json
       raise GdsApi::TimedOutException.new
 
+    rescue URI::InvalidURIError => e
+      logger.error loggable.merge(status: 'invalid_uri', error_message: e.message, error_class: e.class.name, end_time: Time.now.to_f).to_json
+      raise GdsApi::InvalidUrl
+
     rescue RestClient::Exception => e
       # Log the error here, since we have access to loggable, but raise the
       # exception up to the calling method to deal with

--- a/test/json_client_test.rb
+++ b/test/json_client_test.rb
@@ -60,6 +60,13 @@ class JsonClientTest < MiniTest::Spec
     end
   end
 
+  def test_request_an_invalid_url
+    url = "http://www.example.com/there-is-a-space-in-this-slug /"
+    assert_raises GdsApi::InvalidUrl do
+      @client.get_json(url)
+    end
+  end
+
   def test_get_should_raise_endpoint_not_found_if_connection_refused
     url = "http://some.endpoint/some.json"
     stub_request(:get, url).to_raise(Errno::ECONNREFUSED)


### PR DESCRIPTION
Before sending a request, the ApiAdapters pass a string to the `URI` module for parsing. If this fails, we have been getting `URI::InvalidURIError` exceptions, which [we are seeing in Errbit](https://errbit.publishing.service.gov.uk/apps/53611a4b0da1151271001055/problems/584ebea66578630e38370100).  

In order to better handle errors thrown in the api-adapter, here we have created an exception class that derives from `GdsApiAdapters::BaseError` and this is thrown in the event of a malformed URL.
