### PR TITLE
Add rummager test helper with missing keys

### DIFF
--- a/lib/gds_api/test_helpers/rummager.rb
+++ b/lib/gds_api/test_helpers/rummager.rb
@@ -95,6 +95,11 @@ module GdsApi
         run_example_query
       end
 
+      def rummager_has_services_and_info_data_with_missing_keys_for_organisation
+        stub_request_for(search_results_found_with_missing_keys)
+        run_example_query
+      end
+
       def rummager_has_no_services_and_info_data_for_organisation
         stub_request_for(no_search_results_found)
         run_example_query
@@ -134,6 +139,15 @@ module GdsApi
         File.read(
           File.expand_path(
             "../../../../test/fixtures/services_and_info_fixture.json",
+            __FILE__
+          )
+        )
+      end
+
+      def search_results_found_with_missing_keys
+        File.read(
+          File.expand_path(
+            "../../../../test/fixtures/services_and_info_missing_keys_fixture.json",
             __FILE__
           )
         )

--- a/test/fixtures/services_and_info_missing_keys_fixture.json
+++ b/test/fixtures/services_and_info_missing_keys_fixture.json
@@ -1,0 +1,69 @@
+{
+  "results": [ ],
+  "total": 3138,
+  "start": 0,
+  "facets": {
+    "specialist_sectors": {
+      "options": [
+      {
+        "value": {
+          "slug": "environmental-management/environmental-permits",
+          "example_info": {
+            "total": 47,
+            "examples": [
+            {
+              "title": "Check if you need an environmental permit",
+              "link": "/environmental-permit-check-if-you-need-one"
+            },
+            {
+              "title": "Environmental permit: how to apply",
+              "link": "/environmental-permit-how-to-apply"
+            },
+            {
+              "title": "Standard rules: environmental permitting",
+              "link": "/government/collections/standard-rules-environmental-permitting"
+            },
+            {
+              "title": "Environmental permitting (EP) charges scheme: April 2014 to March 2015",
+              "link": "/government/publications/environmental-permitting-ep-charges-scheme-april-2014-to-march-2015"
+            }
+            ]
+          }
+        },
+        "documents": 47
+      },
+      {
+        "value": {
+          "slug": "environmental-management/waste",
+          "example_info": {
+            "total": 49,
+            "examples": [
+            {
+              "title": "Register as a waste carrier, broker or dealer (England)",
+              "link": "/waste-carrier-or-broker-registration"
+            },
+            {
+              "title": "Hazardous waste producer registration (England and Wales)",
+              "link": "/hazardous-waste-producer-registration"
+            },
+            {
+              "title": "Check if you need an environmental permit",
+              "link": "/environmental-permit-check-if-you-need-one"
+            },
+            {
+              "title": "Classify different types of waste",
+              "link": "/how-to-classify-different-types-of-waste"
+            }
+            ]
+          }
+        },
+        "documents": 47
+      }
+      ],
+        "documents_with_no_value": 2900,
+        "total_options": 17,
+        "missing_options": 0
+    }
+  },
+  "suggested_queries": [ ]
+}


### PR DESCRIPTION
This commit adds a rummager test helper which returns search results with missing keys to simulate unexpanded links due to unsynced data between rummager and publishing-api.