### PR TITLE
Remove deprecated 'format' field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Removed tests for the deprecated `format` field in the Publishing API.
+
 # 38.0.0
 
 * Added an adapter for the import endpoint of the Need API.

--- a/lib/gds_api/publishing_api_v2.rb
+++ b/lib/gds_api/publishing_api_v2.rb
@@ -263,17 +263,9 @@ class GdsApi::PublishingApiV2 < GdsApi::Base
   # FIXME: Add documentation
   #
   # @see https://github.com/alphagov/publishing-api/blob/master/doc/api.md#get-v2linkables
-  def get_linkables(document_type: nil, format: nil)
+  def get_linkables(document_type: nil)
     if document_type.nil?
-      if format.nil?
-        raise ArgumentError.new("Please provide a `document_type`")
-      else
-        self.class.logger.warn(
-          "Providing `format` to the `get_linkables` method is deprecated and will be removed in a " +
-          "future release.  Please use `document_type` instead."
-        )
-        document_type = format
-      end
+      raise ArgumentError.new("Please provide a `document_type`")
     end
 
     get_json("#{endpoint}/v2/linkables?document_type=#{document_type}")

--- a/lib/gds_api/test_helpers/content_item_helpers.rb
+++ b/lib/gds_api/test_helpers/content_item_helpers.rb
@@ -6,7 +6,8 @@ module GdsApi
         {
           "title" => titleize_base_path(base_path),
           "description" => "Description for #{base_path}",
-          "format" => "guide",
+          "schema_name" => "guide",
+          "document_type" => "guide",
           "need_ids" => ["100001"],
           "public_updated_at" => "2014-05-06T12:01:00+00:00",
           # base_path is added in as necessary (ie for content-store GET responses)
@@ -21,7 +22,7 @@ module GdsApi
         {
           "title" => nil,
           "description" => nil,
-          "format" => "gone",
+          "document_type" => "gone",
           "schema_name" => "gone",
           "public_updated_at" => nil,
           "base_path" => base_path,

--- a/lib/gds_api/test_helpers/publishing_api_v2.rb
+++ b/lib/gds_api/test_helpers/publishing_api_v2.rb
@@ -210,7 +210,7 @@ module GdsApi
 
       # This method has been refactored into publishing_api_has_content (above)
       # publishing_api_has_content allows for flexible passing in of arguments, please use instead
-      def publishing_api_has_fields_for_document(format, items, fields)
+      def publishing_api_has_fields_for_document(document_type, items, fields)
         body = Array(items).map { |item|
           item.with_indifferent_access.slice(*fields)
         }
@@ -219,7 +219,7 @@ module GdsApi
           "&fields%5B%5D=#{f}"
         }
 
-        url = PUBLISHING_API_V2_ENDPOINT + "/content?document_type=#{format}#{query_params.join('')}"
+        url = PUBLISHING_API_V2_ENDPOINT + "/content?document_type=#{document_type}#{query_params.join('')}"
 
         stub_request(:get, url).to_return(status: 200, body: { results: body }.to_json, headers: {})
       end

--- a/test/publishing_api_v2_test.rb
+++ b/test/publishing_api_v2_test.rb
@@ -11,7 +11,8 @@ describe GdsApi::PublishingApiV2 do
       "content_id" => content_id,
       "title" => "Instructions for crawler robots",
       "description" => "robots.txt provides rules for which parts of GOV.UK are permitted to be crawled by different bots.",
-      "format" => "special_route",
+      "schema_name" => "special_route",
+      "document_type" => "different_to_special_route",
       "public_updated_at" => "2015-07-30T13:58:11.000Z",
       "publishing_app" => "static",
       "rendering_app" => "static",
@@ -149,7 +150,6 @@ describe GdsApi::PublishingApiV2 do
             "details" => { "body" => [] },
             "previous_version" => "3"
           )
-          @content_item.delete("format")
 
           publishing_api
             .given("the content item #{@content_id} is at version 3")
@@ -182,7 +182,6 @@ describe GdsApi::PublishingApiV2 do
             "details" => { "body" => [] },
             "previous_version" => "2"
           )
-          @content_item.delete("format")
 
           publishing_api
             .given("the content item #{@content_id} is at version 3")
@@ -242,7 +241,7 @@ describe GdsApi::PublishingApiV2 do
             status: 200,
             body: {
               "content_id" => @content_id,
-              "document_type" => Pact.like("special_route"),
+              "document_type" => Pact.like("different_to_special_route"),
               "schema_name" => Pact.like("special_route"),
               "publishing_app" => Pact.like("publisher"),
               "rendering_app" => Pact.like("frontend"),
@@ -260,7 +259,7 @@ describe GdsApi::PublishingApiV2 do
       it "responds with 200 and the content item" do
         response = @api_client.get_content(@content_id)
         assert_equal 200, response.code
-        assert_equal @content_item["format"], response["document_type"]
+        assert_equal @content_item["document_type"], response["document_type"]
       end
     end
 
@@ -1199,7 +1198,7 @@ describe GdsApi::PublishingApiV2 do
 
     it "returns the content items of a given document_type" do
       publishing_api
-        .given("there is content with format 'topic'")
+        .given("there is content with document_type 'topic'")
         .upon_receiving("a get linkables request")
         .with(
           method: :get,
@@ -1217,18 +1216,13 @@ describe GdsApi::PublishingApiV2 do
       response = @api_client.get_linkables(document_type: "topic")
       assert_equal 200, response.code
       assert_equal linkables, response.to_a
-
-      # `format` is supported but deprecated for backwards compatibility
-      response = @api_client.get_linkables(format: "topic")
-      assert_equal 200, response.code
-      assert_equal linkables, response.to_a
     end
   end
 
   describe "#get_content_items" do
-    it "returns the content items of a certain format" do
+    it "returns the content items of a certain document_type" do
       publishing_api
-        .given("there is content with format 'topic'")
+        .given("there is content with document_type 'topic'")
         .upon_receiving("a get entries request")
         .with(
           method: :get,


### PR DESCRIPTION
This will shortly be removed from the publishing-api, therefore it is necessary to remove tests for it.