### PR TITLE
Revert "Add method for calling the import endpoint"

### DIFF
--- a/lib/gds_api/publishing_api_v2.rb
+++ b/lib/gds_api/publishing_api_v2.rb
@@ -99,23 +99,6 @@ class GdsApi::PublishingApiV2 < GdsApi::Base
     post_json(publish_url(content_id), params)
   end
 
-  # Import content into the publishing API
-  #
-  # The publishing-api will delete any content which has the content
-  # id provided, and then import the events given.
-  #
-  # @param content_id [UUID]
-  # @param content_items [Array]
-  #
-  # @see https://github.com/alphagov/publishing-api/blob/master/doc/api.md#post-v2contentcontent_idpublish
-  def import(content_id, content_items)
-    params = {
-      content_items: content_items,
-    }
-
-    post_json("#{endpoint}/v2/content/#{content_id}/import", params)
-  end
-
   # Unpublish a content item
   #
   # The publishing API will "unpublish" a live item, to remove it from the public

--- a/test/publishing_api_v2_test.rb
+++ b/test/publishing_api_v2_test.rb
@@ -736,61 +736,6 @@ describe GdsApi::PublishingApiV2 do
     end
   end
 
-  describe "#import" do
-    describe "if the import command succeeds" do
-      let(:content_id) { SecureRandom.uuid }
-      let(:content_item) {
-        content_item_for_content_id(content_id,
-          state: "superseded"
-        )
-      }
-
-      let(:content_items) {
-        [
-          {
-            action: "PutContent",
-            payload: content_item,
-          },
-          {
-            action: "PutContent",
-            payload: content_item.merge(
-              state: "draft",
-              base_path: "/foo", routes: [{ path: "/foo", type: "exact" }],
-            ),
-          },
-          {
-            action: "Publish",
-            payload: content_item.merge(state: "published", update_type: "major"),
-          },
-        ]
-      }
-
-      before do
-        publishing_api
-          .given("no content exists")
-          .upon_receiving("an import request")
-          .with(
-            method: :post,
-            path: "/v2/content/#{content_id}/import",
-            body: {
-              content_items: content_items,
-            },
-            headers: GdsApi::JsonClient.default_request_with_json_body_headers.merge(
-              "Authorization" => "Bearer #{@bearer_token}"
-            ),
-          )
-          .will_respond_with(
-            status: 200
-          )
-      end
-
-      it "responds with 200 if the publish command succeeds" do
-        response = @api_client.import(content_id, content_items)
-        assert_equal 200, response.code
-      end
-    end
-  end
-
   describe "#unpublish" do
     describe "if the unpublish command succeeds" do
       before do


### PR DESCRIPTION
Reverts alphagov/gds-api-adapters#630 as some pact tests are failing. https://ci.dev.publishing.service.gov.uk/job/govuk_gds_api_adapters_branches/1150/console