### PR TITLE
Bump version to 38.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-# Unreleased
+# 38.1.0
 
+* Handle URI::InvalidURIError exceptions with GdsApi::InvalidUrl
 * Removed tests for the deprecated `format` field in the Publishing API.
 
 # 38.0.0

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '38.0.0'.freeze
+  VERSION = '38.1.0'.freeze
 end


### PR DESCRIPTION
There was a change in the handling of Invalid URI exceptions which, while
not part of the public API, may have been handled in downstream applications. Hence the minor-version bump.