### PR TITLE
Add a Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,143 @@
+#!/usr/bin/env groovy
+
+REPOSITORY = 'gds-api-adapters'
+
+node {
+  def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
+
+  try {
+    stage("Checkout gds-api-adapters") {
+      echo "Checkout gds-api-adapters branch: ${env.BRANCH_NAME}"
+      checkout([
+        changelog: false,
+        poll: false,
+        scm: [
+          $class: 'GitSCM',
+          branches: [[name: '*/master']],
+          doGenerateSubmoduleConfigurations: false,
+          extensions: [
+            [
+              $class: 'RelativeTargetDirectory',
+              relativeTargetDir: 'gds-api-adapters'
+            ],
+          ],
+          submoduleCfg: [],
+          userRemoteConfigs: [
+            [
+              credentialsId: 'github-token-govuk-ci-username',
+              name: 'gds-api-adapters',
+              url: 'https://github.com/alphagov/gds-api-adapters.git'
+            ]
+          ]
+        ]
+      ])
+    }
+
+    stage("Build") {
+      dir("gds-api-adapters") {
+        // TODO: I gave up trying to get Jenkins to do this, but maybe it can?
+        sh "git checkout ${env.BRANCH_NAME}"
+        sh "${WORKSPACE}/gds-api-adapters/jenkins.sh"
+
+        publishHTML(target: [
+          allowMissing: false,
+          alwaysLinkToLastBuild: false,
+          keepAll: true,
+          reportDir: 'coverage/rcov',
+          reportFiles: 'index.html',
+          reportName: 'RCov Report'
+        ])
+      }
+    }
+
+    stage("Publish pact") {
+      dir("gds-api-adapters") {
+        withCredentials([
+          [
+            $class: 'UsernamePasswordMultiBinding',
+            credentialsId: 'pact-broker-ci-dev',
+            usernameVariable: 'PACT_BROKER_USERNAME',
+            passwordVariable: 'PACT_BROKER_PASSWORD'
+          ]
+        ]) {
+          withEnv([
+            "PACT_TARGET_BRANCH=branch-${env.BRANCH_NAME}",
+            "PACT_BROKER_BASE_URL=https://pact-broker.dev.publishing.service.gov.uk"
+          ]) {
+            govuk.runRakeTask("pact:publish:branch")
+          }
+        }
+      }
+    }
+
+    stage("Checkout publishing-api") {
+      checkout([
+        changelog: false,
+        poll: false,
+        scm: [
+          $class: 'GitSCM',
+          branches: [
+            [
+              name: '*/master'
+            ]
+          ],
+          doGenerateSubmoduleConfigurations: false,
+          extensions: [
+            [
+              $class: 'RelativeTargetDirectory',
+              relativeTargetDir: 'publishing-api'
+            ]
+          ],
+          submoduleCfg: [],
+          userRemoteConfigs: [
+            [
+              credentialsId: 'github-token-govuk-ci-username',
+              name: 'publishing-api',
+              url: 'https://github.com/alphagov/publishing-api.git'
+            ]
+          ]
+        ]
+      ])
+    }
+
+    stage("Run publishing-api pact") {
+      dir("publishing-api") {
+        withEnv(["JOB_NAME=publishing-api"]) { // TODO: This environment is a hack
+          govuk.bundleApp()
+        }
+        withCredentials([
+          [
+            $class: 'UsernamePasswordMultiBinding',
+            credentialsId: 'pact-broker-ci-dev',
+            usernameVariable: 'PACT_BROKER_USERNAME',
+            passwordVariable: 'PACT_BROKER_PASSWORD'
+          ]
+        ]) {
+          govuk.runRakeTask("pact:verify:branch[${env.BRANCH_NAME}]")
+        }
+      }
+    }
+
+    if (env.BRANCH_NAME == 'master') {
+      dir("gds-api-adapters") {
+        stage("Push release tag") {
+          echo 'Pushing tag'
+          govuk.pushTag(REPOSITORY, env.BRANCH_NAME, 'release_' + env.BUILD_NUMBER)
+        }
+
+        stage("Publish gem") {
+          echo 'Publishing gem'
+          bundleApp()
+          sh("bundle exec rake publish_gem --trace")
+        }
+      }
+    }
+  } catch (e) {
+    currentBuild.result = "FAILED"
+    step([$class: 'Mailer',
+          notifyEveryUnstableBuild: true,
+          recipients: 'govuk-ci-notifications@digital.cabinet-office.gov.uk',
+          sendToIndividuals: true])
+    throw e
+  }
+}

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,32 +1,6 @@
 #!/bin/bash
 
-REPO_NAME=${REPO_NAME:-"alphagov/gds-api-adapters"}
-CONTEXT_MESSAGE=${CONTEXT_MESSAGE:-"default"}
-GH_STATUS_GIT_COMMIT=${SCHEMA_GIT_COMMIT:-${GIT_COMMIT}}
-
-function github_status {
-  REPO_NAME="$1"
-  STATUS="$2"
-  MESSAGE="$3"
-  gh-status "$REPO_NAME" "$GH_STATUS_GIT_COMMIT" "$STATUS" -d "Build #${BUILD_NUMBER} ${MESSAGE}" -u "$BUILD_URL" -c "$CONTEXT_MESSAGE" >/dev/null
-}
-
-function error_handler {
-  trap - ERR # disable error trap to avoid recursion
-  local parent_lineno="$1"
-  local message="$2"
-  local code="${3:-1}"
-  if [[ -n "$message" ]] ; then
-    echo "Error on or near line ${parent_lineno}: ${message}; exiting with status ${code}"
-  else
-    echo "Error on or near line ${parent_lineno}; exiting with status ${code}"
-  fi
-  github_status "$REPO_NAME" error "errored on Jenkins"
-  exit "${code}"
-}
-
-trap 'error_handler ${LINENO}' ERR
-github_status "$REPO_NAME" pending "is running on Jenkins"
+export PACT_BROKER_BASE_URL=${PACT_BROKER_BASE_URL:-"https://pact-broker.dev.publishing.service.gov.uk"}
 
 # Cleanup anything left from previous test runs
 git clean -fdx
@@ -53,10 +27,7 @@ for version in 2.3 2.2 2.1; do
       --format clang
   fi
 
-  if ! bundle exec rake ${TEST_TASK:-"default"}; then
-    github_status "$REPO_NAME" failure "failed on Jenkins"
-    exit 1
-  fi
+  bundle exec rake ${TEST_TASK:-"default"}
 done
 unset RBENV_VERSION
 
@@ -68,5 +39,3 @@ if [[ -n "$PUBLISH_GEM" ]]; then
   bundle install --path "${HOME}/bundles/${JOB_NAME}"
   bundle exec rake publish_gem --trace
 fi
-
-github_status "$REPO_NAME" success "succeeded on Jenkins"


### PR DESCRIPTION
Remove the GitHub integration and error handling from the jenkins.sh
script, as this is run from the Jenkinsfile which handles this.

Currently the pact test checks in the Publishing API are not being run due to changes in the Publishing API repository. This will fix this by moving all the logic regarding setting up for the pact test checks in the Publishing API in to the Jenkinsfile.

Do not merge, as the build numbers need fudging manually immediately prior to this being merged: https://github.gds/pages/gds/opsmanual/infrastructure/testing/application-testing.html#incrementing-build-numbers