### PR TITLE
Remove test files from the built gem

### DIFF
--- a/gds-api-adapters.gemspec
+++ b/gds-api-adapters.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |s|
   s.description  = "A set of adapters providing easy access to the GDS GOV.UK APIs"
 
   s.files        = Dir.glob("lib/**/*") + %w(README.md Rakefile)
-  s.test_files   = Dir['test/**/*']
   s.require_path = 'lib'
   s.add_dependency 'plek', '>= 1.9.0'
   s.add_dependency 'null_logger'


### PR DESCRIPTION
When the test/spec directory is mentioned in the gemspec it actually
builds the gem with those files.

There's also no reason to send the test files to production.

### Before

<img width="472" alt="screen shot 2016-12-16 at 11 36 57" src="https://cloud.githubusercontent.com/assets/136777/21261661/c94863a0-c384-11e6-9bf4-67ecf2f8df52.png">

### After
<img width="403" alt="screen shot 2016-12-16 at 11 40 48" src="https://cloud.githubusercontent.com/assets/136777/21261662/c94b1d70-c384-11e6-8c0a-d1d07bf2e300.png">

