### PR TITLE
Update gem author to be Government Digital Service

### DIFF
--- a/gds-api-adapters.gemspec
+++ b/gds-api-adapters.gemspec
@@ -8,8 +8,7 @@ Gem::Specification.new do |s|
   s.name         = "gds-api-adapters"
   s.version      = GdsApi::VERSION
   s.platform     = Gem::Platform::RUBY
-  s.authors      = ["James Stewart"]
-  s.email        = ["jystewart@gmail.com"]
+  s.authors      = ["Government Digital Service"]
   s.summary      = "Adapters to work with GDS APIs"
   s.homepage     = "http://github.com/alphagov/gds-api-adapters"
   s.description  = "A set of adapters providing easy access to the GDS GOV.UK APIs"


### PR DESCRIPTION
I believe that gems under the [govuk rubygems account](https://rubygems.org/profiles/govuk) should have no individual authors but mention `Government Digital Service` as a whole.

We are a team and most of us contribute to several gems but never got to add themselves as an author. By setting this as `Government Digital Service` it's self implied that anyone that contributed is contributing for the `Government Digital Service` as a team.

My other proposal would be to follow [Slimmer](https://github.com/alphagov/slimmer/blob/master/slimmer.gemspec#L11-L12) instead