### PR TITLE
Remove unnecessary bundleApp call

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -127,7 +127,6 @@ node {
 
         stage("Publish gem") {
           echo 'Publishing gem'
-          bundleApp()
           sh("bundle exec rake publish_gem --trace")
         }
       }


### PR DESCRIPTION
This is also broken, as it would need to be prefixed by govuk. but
remove it as its unnecessary, by this stage in the process, all the gems
should be available (its currently done in jenkins.sh).