### PR TITLE
Change remote name in Jenkinsfile to origin

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ node {
           userRemoteConfigs: [
             [
               credentialsId: 'github-token-govuk-ci-username',
-              name: 'gds-api-adapters',
+              name: 'origin',
               url: 'https://github.com/alphagov/gds-api-adapters.git'
             ]
           ]


### PR DESCRIPTION
The GemPublisher which is run as the final stage when building the
"master" branch on CI seems to fail if this is not the case.