### PR TITLE
Make the Jenkins build fail when it encounters errors at any step

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 # Cleanup anything left from previous test runs
 git clean -fdx


### PR DESCRIPTION
- I had some test errors (not failures) in a branch:

  472 runs, 756 assertions, 0 failures, 2 errors, 1 skips
  [...]
  rake aborted!
  Command failed with status (1):
  [/usr/lib/rbenv/versions/2.1.8/bin/ruby -I"...]

  Jenkins wasn't exiting at that point, it was carrying on to do the
  rest of the tasks and eventually exited with `SUCCESS`.