### PR TITLE
Remove the need_api_has_organisations test helper

### DIFF
--- a/lib/gds_api/test_helpers/need_api.rb
+++ b/lib/gds_api/test_helpers/need_api.rb
@@ -8,21 +8,6 @@ module GdsApi
 
       NEED_API_ENDPOINT = Plek.current.find('need-api')
 
-      def need_api_has_organisations(organisations)
-        url = NEED_API_ENDPOINT + "/organisations"
-
-        body = response_base.merge(
-          "organisations" => organisations.map {|id, attrs|
-            if attrs.is_a? String
-              { "id" => id }.merge("name" => attrs)
-            else
-              { "id" => id }.merge(attrs)
-            end
-          }
-        )
-        stub_request(:get, url).to_return(status: 200, body: body.to_json, headers: {})
-      end
-
       def need_api_has_needs_for_organisation(organisation, needs)
         url = NEED_API_ENDPOINT + "/needs?organisation_id=#{organisation}"
 

--- a/lib/gds_api/test_helpers/organisations.rb
+++ b/lib/gds_api/test_helpers/organisations.rb
@@ -59,6 +59,11 @@ module GdsApi
               to_return(status: 200, body: page_details.to_json, headers: { "Link" => link_headers.join(", ") })
           end
         end
+
+        if pages.empty?
+          # If there are no pages - and so no organisations specified - then stub /api/organisations.
+          stub_request(:get, "#{ORGANISATIONS_API_ENDPOINT}/api/organisations").to_return(status: 200, body: plural_response_base.to_json, headers: {})
+        end
       end
 
       def organisations_api_has_organisation(organisation_slug, details = nil)

--- a/test/need_api_test.rb
+++ b/test/need_api_test.rb
@@ -261,39 +261,6 @@ describe GdsApi::NeedApi do
     end
   end
 
-  describe "viewing organisations" do
-    it "should return a list of organisations" do
-      request_stub = need_api_has_organisations(
-        "committee-on-climate-change" => "Committee on Climate Change",
-        "competition-commission" => "Competition Commission"
-      )
-
-      orgs = @api.organisations
-
-      assert_requested(request_stub)
-      assert_equal "Committee on Climate Change", orgs[0]["name"]
-      assert_equal "Competition Commission", orgs[1]["name"]
-      assert_equal 2, orgs.size
-    end
-
-    it "should return organisations with abbreviations if present" do
-      request_stub = need_api_has_organisations(
-        "committee-on-climate-change" => { "name" => "Committee on Climate Change",
-                                          "abbreviation" => "CCC" },
-        "competition-commission" => { "name" => "Competition Commission",
-                                     "abbreviation" => "CC" }
-      )
-      orgs = @api.organisations
-
-      assert_requested(request_stub)
-      assert_equal "Committee on Climate Change", orgs[0]["name"]
-      assert_equal "Competition Commission", orgs[1]["name"]
-      assert_equal "CCC", orgs[0]["abbreviation"]
-      assert_equal "CC", orgs[1]["abbreviation"]
-      assert_equal 2, orgs.size
-    end
-  end
-
   describe "closing needs as duplicates" do
     it "should send a PUT request" do
       fields = {


### PR DESCRIPTION
- The Organisations API in Whitehall is the canonical source of
  Organisations. Nothing uses the Need API's endpoint anymore (only Maslow ever did).