### PR TITLE
Bump version to 39.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 39.0.0
+
+* Remove the `need_api_has_organisations` test helper.
+
 # 38.1.0
 
 * Handle URI::InvalidURIError exceptions with GdsApi::InvalidUrl

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '38.1.0'.freeze
+  VERSION = '39.0.0'.freeze
 end


### PR DESCRIPTION
- This version will break Maslow's master, hence the major version bump.
  Maslow is the only thing that uses `need_api_has_organisations` (but
  there's a PR on Maslow to stop it using this).