### PR TITLE
When verifying the pact, use the local copy

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -102,7 +102,7 @@ node {
 
     stage("Run publishing-api pact") {
       dir("publishing-api") {
-        withEnv(["JOB_NAME=publishing-api"]) { // TODO: This environment is a hack
+        withEnv(["JOB_NAME=publishing-api", "USE_LOCAL_PACT=true"]) { // TODO: This environment is a hack
           govuk.bundleApp()
         }
         withCredentials([


### PR DESCRIPTION
For some reason, the pact recieved from the pact broker sometimes does
not match the file on disk, which should be published to the pact
broker.

To work around this, and make the whole situation simpler, just use the
local file.