### PR TITLE
Make git credentials available when publishing gem

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -133,7 +133,13 @@ node {
 
         stage("Publish gem") {
           echo 'Publishing gem'
-          sh("bundle exec rake publish_gem --trace")
+          withCredentials([
+            [
+              credentialsId: 'github-token-govuk-ci-username',
+            ]
+          ]) {
+            govuk.runRakeTask("publish_gem --trace")
+          }
         }
       }
     }


### PR DESCRIPTION
The publish_gem task pushes a Git tag, and I'm hoping that this will
make it work, instead of failing with an error that looks like its
missing credentials.