### PR TITLE
Fix gem publishing from CI.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -135,6 +135,7 @@ node {
           echo 'Publishing gem'
           withCredentials([
             [
+              $class: 'UsernamePasswordMultiBinding',
               credentialsId: 'github-token-govuk-ci-username',
             ]
           ]) {


### PR DESCRIPTION
Jenkins is complaining "must specify $class with an implementation ofs
class", so add the missing value.

Not sure whether this is the right value, or how to test it, since this is only triggered on master, so this is a speculative fix.