### PR TITLE
Revert "Make git credentials available when publishing gem"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -133,13 +133,7 @@ node {
 
         stage("Publish gem") {
           echo 'Publishing gem'
-          withCredentials([
-            [
-              credentialsId: 'github-token-govuk-ci-username',
-            ]
-          ]) {
-            govuk.runRakeTask("publish_gem --trace")
-          }
+          sh("bundle exec rake publish_gem --trace")
         }
       }
     }


### PR DESCRIPTION
Reverts alphagov/gds-api-adapters#650

This couldn't be made to work; the previous behaviour does publish the gem, although it reports the build as broken.