### PR TITLE
Add params to test helpers

### DIFF
--- a/lib/gds_api/test_helpers/publishing_api_v2.rb
+++ b/lib/gds_api/test_helpers/publishing_api_v2.rb
@@ -296,7 +296,7 @@ module GdsApi
       # publishing_api_has_content allows for flexible passing in of arguments, please use instead
       def publishing_api_has_fields_for_document(document_type, items, fields)
         body = Array(items).map { |item|
-          item.with_indifferent_access.slice(*fields)
+          deep_stringify_keys(item).slice(*fields)
         }
 
         query_params = fields.map { |f|
@@ -320,7 +320,7 @@ module GdsApi
       #
       # @param item [Hash]
       def publishing_api_has_item(item)
-        item = item.with_indifferent_access
+        item = deep_transform_keys(item, &:to_sym)
         url = PUBLISHING_API_V2_ENDPOINT + "/content/" + item[:content_id]
         stub_request(:get, url).to_return(status: 200, body: item.to_json, headers: {})
       end
@@ -329,7 +329,7 @@ module GdsApi
       #
       # @param items [Array]
       def publishing_api_has_item_in_sequence(content_id, items)
-        items = items.map(&:with_indifferent_access)
+        items = items.each { |item| deep_transform_keys(item, &:to_sym) }
         url = PUBLISHING_API_V2_ENDPOINT + "/content/" + content_id
         calls = -1
 
@@ -380,7 +380,7 @@ module GdsApi
       #        "version" => 6
       #      }
       def publishing_api_has_links(links)
-        links = links.with_indifferent_access
+        links = deep_transform_keys(links, &:to_sym)
         url = PUBLISHING_API_V2_ENDPOINT + "/links/" + links[:content_id]
         stub_request(:get, url).to_return(status: 200, body: links.to_json, headers: {})
       end

--- a/lib/gds_api/test_helpers/publishing_api_v2.rb
+++ b/lib/gds_api/test_helpers/publishing_api_v2.rb
@@ -319,10 +319,12 @@ module GdsApi
       # Stub GET /v2/content/:content_id to return a specific content item hash
       #
       # @param item [Hash]
-      def publishing_api_has_item(item)
+      def publishing_api_has_item(item, params = {})
         item = deep_transform_keys(item, &:to_sym)
         url = PUBLISHING_API_V2_ENDPOINT + "/content/" + item[:content_id]
-        stub_request(:get, url).to_return(status: 200, body: item.to_json, headers: {})
+        stub_request(:get, url)
+          .with(query: hash_including(params))
+          .to_return(status: 200, body: item.to_json, headers: {})
       end
 
       # Stub GET /v2/content/:content_id to progress through a series of responses.

--- a/test/test_helpers/publishing_api_v2_test.rb
+++ b/test/test_helpers/publishing_api_v2_test.rb
@@ -126,7 +126,27 @@ describe GdsApi::TestHelpers::PublishingApiV2 do
 
       assert_equal({ "content_id" => "2878337b-bed9-4e7f-85b6-10ed2cbcd504" }, response)
     end
+
+    it 'allows params' do
+      publishing_api_has_item(
+        "content_id" => "2878337b-bed9-4e7f-85b6-10ed2cbcd504",
+        "version" => 3,
+      )
+
+      response = publishing_api.get_content(
+        "2878337b-bed9-4e7f-85b6-10ed2cbcd504",
+        "version" => 3,
+      ).parsed_content
+
+      assert_equal({
+          "content_id" => "2878337b-bed9-4e7f-85b6-10ed2cbcd504",
+          "version" => 3
+        },
+        response
+      )
+    end
   end
+
   describe "#publishing_api_has_expanded_links" do
     it "stubs the call to get expanded links" do
       payload = {

--- a/test/test_helpers/publishing_api_v2_test.rb
+++ b/test/test_helpers/publishing_api_v2_test.rb
@@ -119,6 +119,14 @@ describe GdsApi::TestHelpers::PublishingApiV2 do
     end
   end
 
+  describe "#publishing_api_has_item" do
+    it "stubs the call to get content items" do
+      publishing_api_has_item("content_id" => "2878337b-bed9-4e7f-85b6-10ed2cbcd504")
+      response = publishing_api.get_content("2878337b-bed9-4e7f-85b6-10ed2cbcd504").parsed_content
+
+      assert_equal({ "content_id" => "2878337b-bed9-4e7f-85b6-10ed2cbcd504" }, response)
+    end
+  end
   describe "#publishing_api_has_expanded_links" do
     it "stubs the call to get expanded links" do
       payload = {


### PR DESCRIPTION
Allow to pass params for #publishing_api_has_item means Maslow will be able to get successive versions of a piece of content, passing in the version as a param.

This also removes the with_indifferent_access method, which is a Rails method. Although gds-api-adapters is being used in Rails apps at the moment, Rails is not listed as a dependency. This replaces the use of with_indifferent_access with deep_transform_keys to convert keys to symbols, or deep_stringify_keys to convert them to strings.

[Trello](https://trello.com/c/8YShGG7D/24-get-maslow-to-render-content-from-the-publishing-api)