### PR TITLE
Publish the released version of the pact.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -45,9 +45,5 @@ require "gem_publisher"
 desc "Publish gem to rubygems.org if necessary"
 task :publish_gem do |_t|
   gem = GemPublisher.publish_if_updated("gds-api-adapters.gemspec", :rubygems)
-  if gem
-    puts "Published #{gem}"
-
-    Rake::Task["pact:publish:released_version"].invoke
-  end
+  puts "Published #{gem}" if gem
 end


### PR DESCRIPTION
This used to be part of the publish_gem rake task, but that job has
been failing since the move to Jenkins 2 - although the gem is
successfully published, it reports an error and fails to proceed, so
never invokes the pact:publish:released_version task.

This change moves the task out into a separate Jenkins stage, which
makes it clearer what is happening anyway.