### PR TITLE
Improve versioning for the Pact Broker

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,8 @@ node {
     govuk.initializeParameters([
       'PUBLISHING_API_BRANCH': 'master',
     ])
-    govuk.setEnvar("PACT_TARGET_BRANCH", "branch-${env.BRANCH_NAME}")
+    def pact_branch = (env.BRANCH_NAME == 'master' ? 'master' : "branch-${env.BRANCH_NAME}")
+    govuk.setEnvar("PACT_TARGET_BRANCH", pact_branch)
     govuk.setEnvar("PACT_BROKER_BASE_URL", "https://pact-broker.dev.publishing.service.gov.uk")
 
     stage("Checkout gds-api-adapters") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,39 +4,41 @@ REPOSITORY = 'gds-api-adapters'
 
 node {
   def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
+  properties([
+    parameters([
+      stringParam(
+        defaultValue: 'master',
+        description: 'Branch of publishing-api to run pacts against',
+        name: 'PUBLISHING_API_BRANCH'
+      ),
+    ])
+  ])
 
   try {
+    govuk.initializeParameters([
+      'PUBLISHING_API_BRANCH': 'master',
+    ])
+    govuk.setEnvar("PACT_TARGET_BRANCH", "branch-${env.BRANCH_NAME}")
+    govuk.setEnvar("PACT_BROKER_BASE_URL", "https://pact-broker.dev.publishing.service.gov.uk")
+
     stage("Checkout gds-api-adapters") {
-      echo "Checkout gds-api-adapters branch: ${env.BRANCH_NAME}"
       checkout([
-        changelog: false,
-        poll: false,
-        scm: [
-          $class: 'GitSCM',
-          branches: [[name: '*/master']],
-          doGenerateSubmoduleConfigurations: false,
-          extensions: [
-            [
-              $class: 'RelativeTargetDirectory',
-              relativeTargetDir: 'gds-api-adapters'
-            ],
-          ],
-          submoduleCfg: [],
-          userRemoteConfigs: [
-            [
-              credentialsId: 'github-token-govuk-ci-username',
-              name: 'origin',
-              url: 'https://github.com/alphagov/gds-api-adapters.git'
-            ]
-          ]
-        ]
+        $class: 'GitSCM',
+        branches: scm.branches,
+        extensions: [
+          [$class: 'RelativeTargetDirectory',
+           relativeTargetDir: 'gds-api-adapters'],
+          [$class: 'CleanCheckout'],
+        ],
+        userRemoteConfigs: scm.userRemoteConfigs
       ])
+      dir('gds-api-adapters') {
+        govuk.mergeMasterBranch()
+      }
     }
 
     stage("Build") {
       dir("gds-api-adapters") {
-        // TODO: I gave up trying to get Jenkins to do this, but maybe it can?
-        sh "git checkout ${env.BRANCH_NAME}"
         sh "${WORKSPACE}/gds-api-adapters/jenkins.sh"
 
         publishHTML(target: [
@@ -60,12 +62,7 @@ node {
             passwordVariable: 'PACT_BROKER_PASSWORD'
           ]
         ]) {
-          withEnv([
-            "PACT_TARGET_BRANCH=branch-${env.BRANCH_NAME}",
-            "PACT_BROKER_BASE_URL=https://pact-broker.dev.publishing.service.gov.uk"
-          ]) {
-            govuk.runRakeTask("pact:publish:branch")
-          }
+          govuk.runRakeTask("pact:publish:branch")
         }
       }
     }
@@ -78,7 +75,7 @@ node {
           $class: 'GitSCM',
           branches: [
             [
-              name: '*/master'
+              name: PUBLISHING_API_BRANCH
             ]
           ],
           doGenerateSubmoduleConfigurations: false,
@@ -91,8 +88,6 @@ node {
           submoduleCfg: [],
           userRemoteConfigs: [
             [
-              credentialsId: 'github-token-govuk-ci-username',
-              name: 'publishing-api',
               url: 'https://github.com/alphagov/publishing-api.git'
             ]
           ]
@@ -141,18 +136,13 @@ node {
               passwordVariable: 'PACT_BROKER_PASSWORD'
             ]
           ]) {
-            withEnv([
-              "PACT_TARGET_BRANCH=branch-${env.BRANCH_NAME}",
-              "PACT_BROKER_BASE_URL=https://pact-broker.dev.publishing.service.gov.uk"
-            ]) {
-              govuk.runRakeTask("pact:publish:released_version")
-            }
+            govuk.runRakeTask("pact:publish:released_version")
           }
         }
 
         stage("Publish gem") {
           echo 'Publishing gem'
-          sh("bundle exec rake publish_gem --trace")
+          govuk.runRakeTask("publish_gem --trace")
         }
       }
     }

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,14 +1,6 @@
 #!/bin/bash
 set -e
 
-# Cleanup anything left from previous test runs
-git clean -fdx
-
-# Try to merge master into the current branch, and abort if it doesn't exit
-# cleanly (ie there are conflicts). This will be a noop if the current branch
-# is master.
-git merge --no-commit origin/master || git merge --abort
-
 # Bundle and run tests against multiple ruby versions
 for version in 2.3 2.2 2.1; do
   rm -f Gemfile.lock


### PR DESCRIPTION
Allow a manual run of the Jenkins job to specify a branch of publishing-api to run against; this should make it possible to break the deadlock when trying to merge backwards-incompatible changes.

Also fix the naming of the PACT_TARGET_BRANCH; when the job runs on master we do need to publish the pact as "master" rather than "branch-master" so that the broker orders it correctly and
the publishing-api tests run against the correct branch.