### PR TITLE
Allow publishing_api_has_expanded_links to take content_id as string

### DIFF
--- a/lib/gds_api/test_helpers/publishing_api_v2.rb
+++ b/lib/gds_api/test_helpers/publishing_api_v2.rb
@@ -442,6 +442,7 @@ module GdsApi
       #         }
       #       }
       def publishing_api_has_expanded_links(links)
+        links = deep_transform_keys(links, &:to_sym)
         url = PUBLISHING_API_V2_ENDPOINT + "/expanded-links/" + links[:content_id]
         stub_request(:get, url).to_return(status: 200, body: links.to_json, headers: {})
       end

--- a/test/test_helpers/publishing_api_v2_test.rb
+++ b/test/test_helpers/publishing_api_v2_test.rb
@@ -148,9 +148,32 @@ describe GdsApi::TestHelpers::PublishingApiV2 do
   end
 
   describe "#publishing_api_has_expanded_links" do
-    it "stubs the call to get expanded links" do
+    it "stubs the call to get expanded links when content_id is a symbol" do
       payload = {
         content_id: "2e20294a-d694-4083-985e-d8bedefc2354",
+        organisations: [
+          {
+            content_id: ["a8a09822-1729-48a7-8a68-d08300de9d1e"]
+          }
+        ]
+      }
+
+      publishing_api_has_expanded_links(payload)
+      response = publishing_api.get_expanded_links("2e20294a-d694-4083-985e-d8bedefc2354")
+
+      assert_equal({
+        "content_id" => "2e20294a-d694-4083-985e-d8bedefc2354",
+        "organisations" => [
+          {
+            "content_id" => ["a8a09822-1729-48a7-8a68-d08300de9d1e"]
+          }
+        ]
+      }, response.to_h)
+    end
+
+    it "stubs the call to get expanded links when content_id is a string" do
+      payload = {
+        "content_id" => "2e20294a-d694-4083-985e-d8bedefc2354",
         organisations: [
           {
             content_id: ["a8a09822-1729-48a7-8a68-d08300de9d1e"]


### PR DESCRIPTION
The test helper for publishing_api_v2, publishing_api_has_expanded_links,
takes a hash as its argument. The content_id key inside this hash currently
needs to be a symbol. This commit allows the content_id to be either a
symbol or a string. This makes the method consistent with other helper
methods and also with the docs, which show content_id as a string.

[Trello card](https://trello.com/c/pL3wWaSo/476-fix-example-in-gds-api-adapters-documentation)