### PR TITLE
Include test/fixtures/**/* in the gem package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Unreleased
 
 * Remove Panopticon API
+* Include the files within the test/fixtures directory, this fixes
+  some test helpers that would have been broken since 39.0.0.
 
 # 39.2.0
 

--- a/gds-api-adapters.gemspec
+++ b/gds-api-adapters.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.homepage     = "http://github.com/alphagov/gds-api-adapters"
   s.description  = "A set of adapters providing easy access to the GDS GOV.UK APIs"
 
-  s.files        = Dir.glob("lib/**/*") + %w(README.md Rakefile)
+  s.files        = Dir.glob("lib/**/*") + Dir.glob("test/fixtures/**/*") + %w(README.md Rakefile)
   s.require_path = 'lib'
   s.add_dependency 'plek', '>= 1.9.0'
   s.add_dependency 'null_logger'


### PR DESCRIPTION
Some test helpers use data from within this directory. The last
version to contain the fixtures was 38.1.0, they were removed in
39.0.0.