### PR TITLE
Release 40.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# 40.0.0
+
 * Remove Panopticon API
 * Include the files within the test/fixtures directory, this fixes
   some test helpers that would have been broken since 39.0.0.

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '39.2.0'.freeze
+  VERSION = '40.0.0'.freeze
 end


### PR DESCRIPTION
This release removes the Panopticon API, and adds back in the test
fixtures which are used by some test helpers.