### PR TITLE
Add a redirects option to the Unpublish adapter in Publishing API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Add a redirects option to the Unpublish adapter in Publishing API
+
 # 40.0.0
 
 * Remove Panopticon API

--- a/lib/gds_api/publishing_api_v2.rb
+++ b/lib/gds_api/publishing_api_v2.rb
@@ -129,9 +129,10 @@ class GdsApi::PublishingApiV2 < GdsApi::Base
   # @param previous_version [Integer] (optional) A lock version number for optimistic locking.
   # @param locale [String] (optional) The content item locale.
   # @param unpublished_at [Time] (optional) The time the content was withdrawn. Ignored for types other than withdrawn
+  # @param redirects [Array] (optional) Required if no alternative_path is given. An array of redirect values, ie: { path:, type:, destination: }
   #
   # @see https://github.com/alphagov/publishing-api/blob/master/doc/api.md#post-v2contentcontent_idunpublish
-  def unpublish(content_id, type:, explanation: nil, alternative_path: nil, discard_drafts: false, allow_draft: false, previous_version: nil, locale: nil, unpublished_at: nil)
+  def unpublish(content_id, type:, explanation: nil, alternative_path: nil, discard_drafts: false, allow_draft: false, previous_version: nil, locale: nil, unpublished_at: nil, redirects: nil)
     params = {
       type: type
     }
@@ -143,6 +144,7 @@ class GdsApi::PublishingApiV2 < GdsApi::Base
     params[:allow_draft] = allow_draft if allow_draft
     params[:locale] = locale if locale
     params[:unpublished_at] = unpublished_at.utc.iso8601 if unpublished_at
+    params[:redirects] = redirects if redirects
 
     post_json(unpublish_url(content_id), params)
   end


### PR DESCRIPTION
The Publishing API has recently added a `redirects` option to the
Unpublish endpoint.