### PR TITLE
Bump release version to 40.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# 40.1.0
+
 * Add a redirects option to the Unpublish adapter in Publishing API
 
 # 40.0.0

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '40.0.0'.freeze
+  VERSION = '40.1.0'.freeze
 end


### PR DESCRIPTION
This release includes the adding of the redirects option to the unpublish adapter for Pubishing API.

https://trello.com/c/jWVgYcxQ/618-investigate-unpublishing-parted-formats-with-redirects