### PR TITLE
Update publishing of gem

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -143,7 +143,7 @@ node {
 
         stage("Publish gem") {
           echo 'Publishing gem'
-          govuk.runRakeTask("publish_gem --trace")
+          govuk.publishGem(REPOSITORY, env.BRANCH_NAME)
         }
       }
     }


### PR DESCRIPTION
This changes the Jenkinsfile to use the `publishGem` method available in the groovy scripts in Puppet.