### PR TITLE
Add logging parameters to GovUkDelivery notify call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Add support for passing logging parameters through to Gov Uk Delivery.
+
 # 40.1.0
 
 * Add a redirects option to the Unpublish adapter in Publishing API

--- a/lib/gds_api/gov_uk_delivery.rb
+++ b/lib/gds_api/gov_uk_delivery.rb
@@ -26,8 +26,8 @@ class GdsApi::GovUkDelivery < GdsApi::Base
     end
   end
 
-  def notify(feed_urls, subject, body)
-    data = { feed_urls: feed_urls, subject: subject, body: body }
+  def notify(feed_urls, subject, body, logging_params = {})
+    data = { feed_urls: feed_urls, subject: subject, body: body, logging_params: logging_params }
     url = "#{base_url}/notifications"
     post_url(url, data)
   end

--- a/test/gov_uk_delivery_test.rb
+++ b/test/gov_uk_delivery_test.rb
@@ -27,10 +27,10 @@ describe GdsApi::GovUkDelivery do
   end
 
   it "can post a notification" do
-    expected_payload = { feed_urls: ['http://example.com/feed'], subject: 'Test', body: '<p>Something</p>' }
+    expected_payload = { feed_urls: ['http://example.com/feed'], subject: 'Test', body: '<p>Something</p>', logging_params: { content_id: 'aaaaaa-11111' } }
     stub = stub_gov_uk_delivery_post_request('notifications', expected_payload).to_return(created_response_hash)
 
-    assert @api.notify(['http://example.com/feed'], 'Test', '<p>Something</p>')
+    assert @api.notify(['http://example.com/feed'], 'Test', '<p>Something</p>', content_id: 'aaaaaa-11111')
     assert_requested stub
   end
 


### PR DESCRIPTION
This will allow us to log which notifications are sent out
from GovUkDelivery and compare this against what EmqailAlertApi
is sending.