### PR TITLE
Pass optional header params to email_alert_api.send_alert

### DIFF
--- a/lib/gds_api/email_alert_api.rb
+++ b/lib/gds_api/email_alert_api.rb
@@ -32,8 +32,8 @@ class GdsApi::EmailAlertApi < GdsApi::Base
   # Post notification
   #
   # @param publication [Hash] Valid publication attributes
-  def send_alert(publication)
-    post_json("#{endpoint}/notifications", publication)
+  def send_alert(publication, headers = {})
+    post_json("#{endpoint}/notifications", publication, headers)
   end
 
   # Get notifications

--- a/test/email_alert_api_test.rb
+++ b/test/email_alert_api_test.rb
@@ -38,6 +38,14 @@ describe GdsApi::EmailAlertApi do
     it "returns the an empty response" do
       assert api_client.send_alert(publication_params).to_hash.empty?
     end
+
+    describe "when custom headers are passed in" do
+      it "posts a new alert with the custom headers" do
+        assert api_client.send_alert(publication_params, govuk_request_id: 'aaaaaaa-1111111')
+
+        assert_requested(:post, "#{base_url}/notifications", body: publication_params.to_json, headers: { 'Govuk-Request-Id' => 'aaaaaaa-1111111' })
+      end
+    end
   end
 
   describe "subscriber lists" do


### PR DESCRIPTION
This is required when called from email_alert_service
as this has picked a message up from rabbit MQ and
needs to manually pass the govuk request id in the
header.