### PR TITLE
Allow passing with_drafts param to get_expanded_links

### DIFF
--- a/lib/gds_api/publishing_api_v2.rb
+++ b/lib/gds_api/publishing_api_v2.rb
@@ -199,10 +199,11 @@ class GdsApi::PublishingApiV2 < GdsApi::Base
   # Return the expanded links of the item.
   #
   # @param content_id [UUID]
+  # @param with_drafts [Bool] Whether links to draft-only editions are returned, defaulting to `true`.
   #
   # @example
   #
-  #   publishing_api.get_expanded_links("8157589b-65e2-4df6-92ba-2c91d80006c0").to_h
+  #   publishing_api.get_expanded_links("8157589b-65e2-4df6-92ba-2c91d80006c0", with_drafts: false).to_h
   #
   #   #=> {
   #     "content_id" => "8157589b-65e2-4df6-92ba-2c91d80006c0",
@@ -218,10 +219,11 @@ class GdsApi::PublishingApiV2 < GdsApi::Base
   #   }
   #
   # @see https://github.com/alphagov/publishing-api/blob/master/doc/api.md#get-v2expanded-linkscontent_id
-  def get_expanded_links(content_id)
+  def get_expanded_links(content_id, with_drafts: true)
+    params = with_drafts ? {} : { with_drafts: "false" }
+    query = query_string(params)
     validate_content_id(content_id)
-    url = "#{endpoint}/v2/expanded-links/#{content_id}"
-    get_json(url)
+    get_json("#{endpoint}/v2/expanded-links/#{content_id}#{query}")
   end
 
   # Patch the links of a content item

--- a/lib/gds_api/test_helpers/publishing_api_v2.rb
+++ b/lib/gds_api/test_helpers/publishing_api_v2.rb
@@ -441,9 +441,10 @@ module GdsApi
       #           ]
       #         }
       #       }
-      def publishing_api_has_expanded_links(links)
+      def publishing_api_has_expanded_links(links, with_drafts: true)
         links = deep_transform_keys(links, &:to_sym)
-        url = PUBLISHING_API_V2_ENDPOINT + "/expanded-links/" + links[:content_id]
+        query = with_drafts ? "" : "?with_drafts=false"
+        url = PUBLISHING_API_V2_ENDPOINT + "/expanded-links/" + links[:content_id] + query
         stub_request(:get, url).to_return(status: 200, body: links.to_json, headers: {})
       end
 

--- a/test/test_helpers/publishing_api_v2_test.rb
+++ b/test/test_helpers/publishing_api_v2_test.rb
@@ -193,6 +193,29 @@ describe GdsApi::TestHelpers::PublishingApiV2 do
         ]
       }, response.to_h)
     end
+
+    it "stubs with query parameters" do
+      payload = {
+        "content_id" => "2e20294a-d694-4083-985e-d8bedefc2354",
+        organisations: [
+          {
+            content_id: ["a8a09822-1729-48a7-8a68-d08300de9d1e"]
+          }
+        ]
+      }
+
+      publishing_api_has_expanded_links(payload, with_drafts: false)
+      response = publishing_api.get_expanded_links("2e20294a-d694-4083-985e-d8bedefc2354", with_drafts: false)
+
+      assert_equal({
+        "content_id" => "2e20294a-d694-4083-985e-d8bedefc2354",
+        "organisations" => [
+          {
+            "content_id" => ["a8a09822-1729-48a7-8a68-d08300de9d1e"]
+          }
+        ]
+      }, response.to_h)
+    end
   end
 
   describe "stub_any_publishing_api_publish" do


### PR DESCRIPTION
This commit allows the new `with_drafts` param to be passed to `get_expanded_links` for `publishing-api`. Depends on https://github.com/alphagov/publishing-api/pull/831.

Trello: https://trello.com/c/LmVHv7Jv/537-build-design-for-tagging-to-draft-taxons-in-whitehall