### PR TITLE
Add api adapter for /v2/lookup-by-base-path

### DIFF
--- a/gds-api-adapters.gemspec
+++ b/gds-api-adapters.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'gem_publisher', '~> 1.5.0'
   s.add_development_dependency 'mocha', "> 1.0.0"
   s.add_development_dependency "minitest", "> 5.0.0"
-  s.add_development_dependency 'pry'
+  s.add_development_dependency 'pry-byebug'
   s.add_development_dependency 'rack', '~> 1.6.4'
   s.add_development_dependency 'rack-test'
   s.add_development_dependency 'rake', '~> 0.9.2.2'

--- a/lib/gds_api/test_helpers/publishing_api_v2.rb
+++ b/lib/gds_api/test_helpers/publishing_api_v2.rb
@@ -471,6 +471,40 @@ module GdsApi
         stub_request(:post, url).to_return(body: lookup_hash.to_json)
       end
 
+      # Stub calls to /v2/lookup-by-base-path
+      #
+      # @param lookup_hash [Hash] /v2/lookup-by-base-path response
+      #
+      # @example
+      #
+      #  publishing_api_has_lookups(
+      #    {
+      #      "/foo" => {
+      #        "draft" => {"content_id" => "51ac4247-fd92-470a-a207-6b852a97f2db", "locale" => "en"}},
+      #        "live" => {"content_id" => "51ac4247-fd92-470a-a207-6b852a97f2db", "locale" => "en"}},
+      #      },
+      #      "/bar" => nil,
+      #    },
+      #    method: :post,
+      #  )
+      #
+      def publishing_api_has_v2_lookups(lookup_hash)
+        url = Plek.current.find('publishing-api') + '/v2/lookup-by-base-path'
+        base_paths = lookup_hash.keys
+
+        if base_paths.size == 1
+          method = :get
+          request_params = { query: { base_paths: base_paths } }
+        else
+          method = :post
+          request_params = { body: { base_paths: base_paths } }
+        end
+
+        stub_request(method, url)
+          .with(request_params)
+          .to_return(body: lookup_hash.to_json)
+      end
+
       #
       # Stub calls to the get linked items endpoint
       #

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,6 +14,7 @@ require 'simplecov-rcov'
 require 'mocha/mini_test'
 require 'timecop'
 require 'gds-api-adapters'
+require 'pry-byebug'
 
 SimpleCov.start do
   add_filter "/test/"

--- a/test/test_helpers/publishing_api_v2_test.rb
+++ b/test/test_helpers/publishing_api_v2_test.rb
@@ -33,13 +33,47 @@ describe GdsApi::TestHelpers::PublishingApiV2 do
   end
 
   describe "#publishing_api_has_lookups" do
-    it "stubs the lookup for content items" do
+    it "stubs the lookup for content ids" do
       lookup_hash = { "/foo" => "2878337b-bed9-4e7f-85b6-10ed2cbcd504" }
 
       publishing_api_has_lookups(lookup_hash)
 
       assert_equal publishing_api.lookup_content_ids(base_paths: ["/foo"]), lookup_hash
       assert_equal publishing_api.lookup_content_id(base_path: "/foo"), "2878337b-bed9-4e7f-85b6-10ed2cbcd504"
+    end
+  end
+
+  describe "#publishing_api_has_v2_lookups" do
+    let(:editions) do
+      {
+        "draft" => { "content_id" => "51ac4247-fd92-470a-a207-6b852a97f2db", "locale" => "en", "document_type" => "publication" },
+        "live" => { "content_id" => "51ac4247-fd92-470a-a207-6b852a97f2db", "locale" => "en", "document_type" => "publication" },
+      }
+    end
+
+    it "stubs the lookup for multiple base paths" do
+      lookup_hash = {
+        "/foo" => editions,
+        "/bar" => nil,
+      }
+
+      publishing_api_has_v2_lookups(
+        lookup_hash
+      )
+
+      assert_equal(
+        publishing_api.lookup_by_base_paths(["/foo", "/bar"]),
+        lookup_hash
+      )
+    end
+
+    it "stubs the lookup for a single base path" do
+      publishing_api_has_v2_lookups("/foo" => editions)
+
+      assert_equal(
+        publishing_api.lookup_by_base_path("/foo"),
+        editions
+      )
     end
   end
 


### PR DESCRIPTION
Adapters for https://github.com/alphagov/publishing-api/pull/822

Trello: https://trello.com/c/MHBTiA65/544-publishing-api-support-for-lookups-of-draft-content-split-from-allow-users-to-tag-draft-content