### PR TITLE
Make `document_type` of special routes configurable

### DIFF
--- a/lib/gds_api/publishing_api/special_route_publisher.rb
+++ b/lib/gds_api/publishing_api/special_route_publisher.rb
@@ -15,7 +15,7 @@ module GdsApi
         put_content_response = publishing_api.put_content(
           options.fetch(:content_id),
           base_path: options.fetch(:base_path),
-          document_type: "special_route",
+          document_type: options[:document_type] || "special_route",
           schema_name: "special_route",
           title: options.fetch(:title),
           description: options[:description] || "",

--- a/test/list_response_test.rb
+++ b/test/list_response_test.rb
@@ -113,7 +113,7 @@ describe GdsApi::ListResponse do
       it "should return nil with no next page" do
         resp = GdsApi::ListResponse.new(@p3_response, @client)
         assert ! resp.has_next_page?
-        assert_equal nil, resp.next_page
+        assert_nil resp.next_page
       end
 
       it "should memoize the next_page" do
@@ -137,7 +137,7 @@ describe GdsApi::ListResponse do
       it "should return nil with no previous page" do
         resp = GdsApi::ListResponse.new(@p1_response, @client)
         assert ! resp.has_previous_page?
-        assert_equal nil, resp.previous_page
+        assert_nil resp.previous_page
       end
 
       it "should memoize the previous_page" do

--- a/test/publishing_api/special_route_publisher_test.rb
+++ b/test/publishing_api/special_route_publisher_test.rb
@@ -52,6 +52,15 @@ describe GdsApi::PublishingApi::SpecialRoutePublisher do
       end
     end
 
+    it "publishes customized document type" do
+      publisher.publish(special_route.merge(document_type: "other_document_type"))
+
+      assert_requested(:put, "#{endpoint}/v2/content/#{content_id}") do |req|
+        JSON.parse(req.body)["document_type"] == "other_document_type"
+      end
+      assert_publishing_api_publish(content_id, update_type: 'major')
+    end
+
     it "publishes links" do
       links = {
         links: {

--- a/test/response_test.rb
+++ b/test/response_test.rb
@@ -227,7 +227,7 @@ describe GdsApi::Response do
       end
 
       it "should return nil for a non-existent key" do
-        assert_equal nil, @response["foo"]
+        assert_nil @response["foo"]
       end
 
       it "should memoize the parsed hash" do


### PR DESCRIPTION
Some special routes such as the homepage and the search page need a more specific `document_type` so that they can be assigned to document supertypes.

Also add `assert_nil` to some other tests to fix the deprecation warnings when running the test suite.

https://trello.com/c/u1H1rgDA/525-some-finding-pages-are-still-being-tracked-as-thing