### PR TITLE
Release version 40.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Unreleased
 
+# 40.4.0
+
+* Add support for a customized `document_type` when publishing a special route,
+  but keep the default `document_type` of `special_route`.
+
 # 40.3.0
 
 * Allow headers to be passed into `EmailAlertApi.send_alert`. This change is

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '40.3.0'.freeze
+  VERSION = '40.4.0'.freeze
 end


### PR DESCRIPTION
https://trello.com/c/u1H1rgDA/525-some-finding-pages-are-still-being-tracked-as-thing