### PR TITLE
Version 40.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Unreleased
 
+# 40.5.0
+
+* Add support to request expanded links from publishing api with or without drafts
+  - The default is false, for backward compatibility
+  - https://github.com/alphagov/gds-api-adapters/pull/676
+  - https://github.com/alphagov/publishing-api/blob/master/doc/api.md#query-string-parameters-2
+
 # 40.4.0
 
 * Add support for a customized `document_type` when publishing a special route,

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '40.4.0'.freeze
+  VERSION = '40.5.0'.freeze
 end


### PR DESCRIPTION
* Add support to request expanded links from publishing api with or without drafts
  - The default is false, for backward compatibility
  - https://github.com/alphagov/gds-api-adapters/pull/676
  - https://github.com/alphagov/publishing-api/blob/master/doc/api.md#query-string-parameters-2