### PR TITLE
Rename fact_check_id to auth_bypass_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Rename GOVUK_FACT_CHECK_ID header to GOVUK_AUTH_BYPASS_ID header
+
 # 40.5.0
 
 * Add support to request expanded links from publishing api with or without drafts

--- a/lib/gds_api/railtie.rb
+++ b/lib/gds_api/railtie.rb
@@ -18,8 +18,8 @@ module GdsApi
     end
 
     initializer "gds_api.initialize_govuk_content_id_sniffer" do |app|
-      Rails.logger.info "Using middleware GdsApi::GovukHeaderSniffer to sniff for GOVUK-Fact-Check-Id header"
-      app.middleware.use GdsApi::GovukHeaderSniffer, 'HTTP_GOVUK_FACT_CHECK_ID'
+      Rails.logger.info "Using middleware GdsApi::GovukHeaderSniffer to sniff for GOVUK-Auth-Bypass-Id header"
+      app.middleware.use GdsApi::GovukHeaderSniffer, 'HTTP_GOVUK_AUTH_BYPASS_ID'
     end
   end
 end


### PR DESCRIPTION
Content needs to be previewable by users without signon accounts in most
stages of a publishers workflow, not just during fact check.

https://trello.com/c/7oRBYwnn/690-rename-fact-check-id-to-auth-bypass-id