### PR TITLE
Bump to version 41.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# 41.0.0
+
 * Rename GOVUK_FACT_CHECK_ID header to GOVUK_AUTH_BYPASS_ID header
 
 # 40.5.0

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '40.5.0'.freeze
+  VERSION = '41.0.0'.freeze
 end


### PR DESCRIPTION
This release changes the HeaderSniffer to look for AUTH_BYPASS_ID instead of FACT_CHECK_ID.

https://trello.com/c/7oRBYwnn/690-rename-fact-check-id-to-auth-bypass-id