### PR TITLE
Add new fields to whitelist for `find_or_create_subscriber_list`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Unreleased
 
+* Add new fields to 'find_or_create_subscriber_list' to support whitehall migration
+  - email_document_supertype
+  - government_document_supertype
+  - gov_delivery_id
+
 # 41.0.0
 
 * Rename GOVUK_FACT_CHECK_ID header to GOVUK_AUTH_BYPASS_ID header

--- a/lib/gds_api/email_alert_api.rb
+++ b/lib/gds_api/email_alert_api.rb
@@ -13,6 +13,9 @@ class GdsApi::EmailAlertApi < GdsApi::Base
     tags = attributes["tags"]
     links = attributes["links"]
     document_type = attributes["document_type"]
+    email_document_supertype = attributes["email_document_supertype"]
+    government_document_supertype = attributes["government_document_supertype"]
+    gov_delivery_id = attributes["gov_delivery_id"]
 
     if tags && links
       message = "please provide either tags or links (or neither), but not both"
@@ -23,6 +26,9 @@ class GdsApi::EmailAlertApi < GdsApi::Base
     params[:tags] = tags if tags
     params[:links] = links if links
     params[:document_type] = document_type if document_type
+    params[:email_document_supertype] = email_document_supertype if email_document_supertype
+    params[:government_document_supertype] = government_document_supertype if government_document_supertype
+    params[:gov_delivery_id] = gov_delivery_id if gov_delivery_id
 
     search_subscriber_list(params)
   rescue GdsApi::HTTPNotFound

--- a/lib/gds_api/test_helpers/email_alert_api.rb
+++ b/lib/gds_api/test_helpers/email_alert_api.rb
@@ -100,11 +100,17 @@ module GdsApi
           tags = attributes["tags"]
           links = attributes["links"]
           document_type = attributes["document_type"]
+          email_document_supertype = attributes["email_document_supertype"]
+          government_document_supertype = attributes["government_document_supertype"]
+          gov_delivery_id = attributes["gov_delivery_id"]
 
           params = {}
           params[:tags] = tags if tags
           params[:links] = links if links
           params[:document_type] = document_type if document_type
+          params[:email_document_supertype] = email_document_supertype if email_document_supertype
+          params[:government_document_supertype] = government_document_supertype if government_document_supertype
+          params[:gov_delivery_id] = gov_delivery_id if gov_delivery_id
 
           query = Rack::Utils.build_nested_query(params)
         end

--- a/test/email_alert_api_test.rb
+++ b/test/email_alert_api_test.rb
@@ -135,6 +135,72 @@ describe GdsApi::EmailAlertApi do
         end
       end
 
+      describe "when the optional 'email_document_supertype' and 'government_document_supertype' are provided" do
+        let(:params) {
+          {
+            "title" => title,
+            "tags" => tags,
+            "email_document_supertype" => "publications",
+            "government_document_supertype" => "travel_advice",
+          }
+        }
+
+        before do
+          email_alert_api_has_subscriber_list(
+            "title" => "Some Title",
+            "tags" => tags,
+            "email_document_supertype" => "publications",
+            "government_document_supertype" => "travel_advice",
+            "subscription_url" => expected_subscription_url,
+          )
+        end
+
+        it "returns the subscriber list attributes" do
+          subscriber_list_attrs = api_client.find_or_create_subscriber_list(params)
+            .to_hash
+            .fetch("subscriber_list")
+
+          assert_equal(
+            "publications",
+            subscriber_list_attrs.fetch("email_document_supertype")
+          )
+          assert_equal(
+            "travel_advice",
+            subscriber_list_attrs.fetch("government_document_supertype")
+          )
+        end
+      end
+
+      describe "when the optional 'gov_delivery_id' is provided" do
+        let(:params) {
+          {
+            "title" => title,
+            "tags" => tags,
+            "gov_delivery_id" => "TOPIC-A",
+          }
+        }
+
+        before do
+          email_alert_api_has_subscriber_list(
+            "title" => "Some Title",
+            "tags" => tags,
+            "gov_delivery_id" => "TOPIC-A",
+            "subscription_url" => expected_subscription_url,
+          )
+        end
+
+        it "returns the subscriber list attributes" do
+          subscriber_list_attrs = api_client.find_or_create_subscriber_list(params)
+            .to_hash
+            .fetch("subscriber_list")
+
+          assert_equal(
+            "TOPIC-A",
+            subscriber_list_attrs.fetch("gov_delivery_id")
+          )
+        end
+      end
+
       describe "when both tags and links are provided" do
         let(:links) {
           {
@@ -167,6 +233,7 @@ describe GdsApi::EmailAlertApi do
       end
     end
   end
+
   describe "notifications" do
     it "retrieves notifications" do
       stubbed_request = email_alert_api_has_notifications([


### PR DESCRIPTION
This allow email_document_supertype, government_document_supertype
and gov_delivery_id to be passed through the API.

These field has been added to help support the whitehall
migration from govuk_delivery to email_alert_api.

https://trello.com/c/5yVMib2f/124-2-add-support-for-whitehall-topics-in-new-email-stack