### PR TITLE
Test published special routes against the schemas

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,6 +44,11 @@ node {
       }
     }
 
+    stage("Set up content schema dependency") {
+      govuk.contentSchemaDependency('deployed-to-production')
+      govuk.setEnvar("GOVUK_CONTENT_SCHEMAS_PATH", "${pwd()}/tmp/govuk-content-schemas")
+    }
+
     for (rubyVersion in rubyVersions) {
       stage("Test with ruby $rubyVersion") {
         dir("gds-api-adapters") {
@@ -109,11 +114,6 @@ node {
           ]
         ]
       ])
-
-      dir("publishing-api") {
-        govuk.contentSchemaDependency('deployed-to-production')
-        govuk.setEnvar("GOVUK_CONTENT_SCHEMAS_PATH", "tmp/govuk-content-schemas")
-      }
     }
 
     stage("Run publishing-api pact") {

--- a/gds-api-adapters.gemspec
+++ b/gds-api-adapters.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rack-cache'
 
   s.add_development_dependency 'gem_publisher', '~> 1.5.0'
+  s.add_development_dependency 'govuk-content-schema-test-helpers', '~> 1.4.0'
   s.add_development_dependency 'mocha', "> 1.0.0"
   s.add_development_dependency "minitest", "> 5.0.0"
   s.add_development_dependency 'pry'

--- a/gds-api-adapters.gemspec
+++ b/gds-api-adapters.gemspec
@@ -34,11 +34,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'simplecov', '~> 0.5.4'
   s.add_development_dependency 'simplecov-rcov'
   s.add_development_dependency 'timecop', '~> 0.5.1'
-
-  # Webmock 1.24.3 complains that "WebMock does not support matching body for multipart/form-data requests"
-  # This is currently breaks existing tests. Revisit this when new version of
-  # webmock is released.
-  s.add_development_dependency 'webmock', '1.24.2'
+  s.add_development_dependency 'webmock', '~> 1.24.6'
 
   s.add_development_dependency 'pact', '1.9.0'
   s.add_development_dependency 'pact-mock_service', '0.8.1'

--- a/test/asset_manager_test.rb
+++ b/test/asset_manager_test.rb
@@ -24,8 +24,9 @@ describe GdsApi::AssetManager do
 
   it "creates an asset with a file" do
     req = stub_request(:post, "#{base_api_url}/assets").
-      with(body: %r{Content\-Disposition: form\-data; name="asset\[file\]"; filename="hello\.txt"\r\nContent\-Type: text/plain}).
-      to_return(body: JSON.dump(asset_manager_response), status: 201)
+      with { |request|
+        request.body =~ %r{Content\-Disposition: form\-data; name="asset\[file\]"; filename="hello\.txt"\r\nContent\-Type: text/plain}
+      }.to_return(body: JSON.dump(asset_manager_response), status: 201)
 
     response = api.create_asset(file: file_fixture)
 

--- a/test/json_client_test.rb
+++ b/test/json_client_test.rb
@@ -765,11 +765,9 @@ class JsonClientTest < MiniTest::Spec
   def test_client_can_post_multipart_responses
     url = "http://some.endpoint/some.json"
     stub_request(:post, url).
-      with(body: %r{------RubyFormBoundary\w+\r\nContent-Disposition: form-data; name="a"\r\n\r\n123\r\n------RubyFormBoundary\w+--\r\n},
-           headers: {
-             'Content-Type' => %r{multipart/form-data; boundary=----RubyFormBoundary\w+}
-           }).
-      to_return(body: '{"b": "1"}', status: 200)
+      with(headers: { 'Content-Type' => %r{multipart/form-data; boundary=----RubyFormBoundary\w+} }) { |request|
+        request.body =~ %r{------RubyFormBoundary\w+\r\nContent-Disposition: form-data; name="a"\r\n\r\n123\r\n------RubyFormBoundary\w+--\r\n}
+      }.to_return(body: '{"b": "1"}', status: 200)
 
     response = @client.post_multipart("http://some.endpoint/some.json", "a" => "123")
     assert_equal "1", response["b"]
@@ -797,11 +795,9 @@ class JsonClientTest < MiniTest::Spec
   def test_client_can_put_multipart_responses
     url = "http://some.endpoint/some.json"
     stub_request(:put, url).
-      with(body: %r{------RubyFormBoundary\w+\r\nContent-Disposition: form-data; name="a"\r\n\r\n123\r\n------RubyFormBoundary\w+--\r\n},
-           headers: {
-             'Content-Type' => %r{multipart/form-data; boundary=----RubyFormBoundary\w+}
-           }).
-      to_return(body: '{"b": "1"}', status: 200)
+      with(headers: { 'Content-Type' => %r{multipart/form-data; boundary=----RubyFormBoundary\w+} }) { |request|
+        request.body =~ %r{------RubyFormBoundary\w+\r\nContent-Disposition: form-data; name="a"\r\n\r\n123\r\n------RubyFormBoundary\w+--\r\n}
+      }.to_return(body: '{"b": "1"}', status: 200)
 
     response = @client.put_multipart("http://some.endpoint/some.json", "a" => "123")
     assert_equal "1", response["b"]

--- a/test/publishing_api/special_route_publisher_test.rb
+++ b/test/publishing_api/special_route_publisher_test.rb
@@ -1,5 +1,6 @@
 require 'test_helper'
 require "gds_api/publishing_api/special_route_publisher"
+require "govuk-content-schema-test-helpers"
 require File.dirname(__FILE__) + '/../../lib/gds_api/test_helpers/publishing_api_v2'
 
 describe GdsApi::PublishingApi::SpecialRoutePublisher do
@@ -13,8 +14,8 @@ describe GdsApi::PublishingApi::SpecialRoutePublisher do
       description: "A description",
       base_path: "/favicon.ico",
       type: "exact",
-      publishing_app: "static-publisher",
-      rendering_app: "static-frontend",
+      publishing_app: "static",
+      rendering_app: "static",
     }
   }
 
@@ -26,7 +27,7 @@ describe GdsApi::PublishingApi::SpecialRoutePublisher do
       stub_any_publishing_api_call
     end
 
-    it "publishes the special routes" do
+    it "publishes valid special routes" do
       Timecop.freeze(Time.now) do
         publisher.publish(special_route)
 
@@ -48,6 +49,7 @@ describe GdsApi::PublishingApi::SpecialRoutePublisher do
         }
 
         assert_requested(:put, "#{endpoint}/v2/content/#{content_id}", body: expected_payload)
+        assert_valid_special_route(expected_payload)
         assert_publishing_api_publish(content_id, update_type: 'major')
       end
     end
@@ -109,5 +111,15 @@ describe GdsApi::PublishingApi::SpecialRoutePublisher do
         end
       end
     end
+  end
+
+  def assert_valid_special_route(payload)
+    validator = GovukContentSchemaTestHelpers::Validator.new(
+      "special_route",
+      "schema",
+      payload
+    )
+
+    assert validator.valid?, validator.errors.join("\n")
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,6 +14,7 @@ require 'simplecov-rcov'
 require 'mocha/mini_test'
 require 'timecop'
 require 'gds-api-adapters'
+require 'govuk-content-schema-test-helpers'
 
 SimpleCov.start do
   add_filter "/test/"
@@ -53,3 +54,8 @@ WebMock.disable_net_connect!
 
 require 'gds_api/test_helpers/json_client_helper'
 require 'test_helpers/pact_helper'
+
+GovukContentSchemaTestHelpers.configure do |config|
+  config.schema_type = 'publisher_v2'
+  config.project_root = File.absolute_path(File.join(File.basename(__FILE__), '..'))
+end


### PR DESCRIPTION
Add govuk-content-schema-test-helpers dependency and use it to check that special route pages sent to the publishing API match the publishing schema.

It includes a commit to update the webmock dependency and fix the broken tests because I thought that was necessary to add govuk-content-schema-test-helpers. That turned out to be wrong (I misread the bundler error message), but I think it's still a useful fix.

This whole change should help us update the special-routes schemas by providing extra regression tests. I'll add this gem to the downstream schema test list so that gets run against each version of the schemas.

Trello: https://trello.com/c/u1H1rgDA/525-some-finding-pages-are-still-being-tracked-as-thing