### PR TITLE
Bump to version 41.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Unreleased
 
+# 41.1.0
+
 * Add new fields to 'find_or_create_subscriber_list' to support whitehall migration
   - email_document_supertype
   - government_document_supertype
   - gov_delivery_id
+* Port all jenkins.sh steps to Jenkinsfile
 
 # 41.0.0
 

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '41.0.0'.freeze
+  VERSION = '41.1.0'.freeze
 end


### PR DESCRIPTION
This release adds supertype support for email-alert-api
and ports jenkins config to Jenkinsfile