### PR TITLE
Add new special route fields to special route publisher

### DIFF
--- a/lib/gds_api/publishing_api/special_route_publisher.rb
+++ b/lib/gds_api/publishing_api/special_route_publisher.rb
@@ -19,6 +19,8 @@ module GdsApi
           schema_name: "special_route",
           title: options.fetch(:title),
           description: options[:description] || "",
+          locale: "en",
+          details: {},
           routes: [
             {
               path: options.fetch(:base_path),

--- a/test/publishing_api/special_route_publisher_test.rb
+++ b/test/publishing_api/special_route_publisher_test.rb
@@ -43,6 +43,8 @@ describe GdsApi::PublishingApi::SpecialRoutePublisher do
               type: special_route[:type],
             }
           ],
+          locale: "en",
+          details: {},
           publishing_app: special_route[:publishing_app],
           rendering_app: special_route[:rendering_app],
           public_updated_at: Time.now.iso8601,

--- a/test/publishing_api_v2_test.rb
+++ b/test/publishing_api_v2_test.rb
@@ -16,13 +16,15 @@ describe GdsApi::PublishingApiV2 do
       "public_updated_at" => "2015-07-30T13:58:11.000Z",
       "publishing_app" => "static",
       "rendering_app" => "static",
+      "locale" => "en",
       "routes" => [
         {
           "path" => attrs["base_path"] || "/robots.txt",
           "type" => "exact"
         }
       ],
-      "update_type" => "major"
+      "update_type" => "major",
+      "details" => {},
     }.merge(attrs)
   end
 


### PR DESCRIPTION
Add fields which have just been added to the content schemas. These are currently optional, but will be made mandatory in an upcoming schema update.

https://trello.com/c/u1H1rgDA/525-some-finding-pages-are-still-being-tracked-as-thing