### PR TITLE
Release version 41.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Unreleased
 
+# 41.2.0
+
+* Update webmock gem dependency
+* Add new `locale` and `details` fields to special routes
+
 # 41.1.0
 
 * Add new fields to 'find_or_create_subscriber_list' to support whitehall migration

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '41.1.0'.freeze
+  VERSION = '41.2.0'.freeze
 end


### PR DESCRIPTION
Trello: https://trello.com/c/u1H1rgDA/525-some-finding-pages-are-still-being-tracked-as-thing