### PR TITLE
Lock the publishing API test DB when running tests in CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -129,8 +129,10 @@ node {
             passwordVariable: 'PACT_BROKER_PASSWORD'
           ]
         ]) {
-          govuk.runRakeTask("db:reset")
-          govuk.runRakeTask("pact:verify:branch[${env.BRANCH_NAME}]")
+          lock("publishing-api-$NODE_NAME-test") {
+            govuk.runRakeTask("db:reset")
+            govuk.runRakeTask("pact:verify:branch[${env.BRANCH_NAME}]")
+          }
         }
       }
     }


### PR DESCRIPTION
This prevents this project's builds and publishing API builds from trying to write to the same test database at once, which will prevent intermittent failed builds.