### PR TITLE
Make LGIL code mandatory for local links requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Make `lgil` mandatory when requesting links from Local Links Manager
+
 # 41.5.0
 
 * Add missing `link-checker-api` test helpers from the previous release.

--- a/lib/gds_api/local_links_manager.rb
+++ b/lib/gds_api/local_links_manager.rb
@@ -1,9 +1,8 @@
 require_relative 'base'
 
 class GdsApi::LocalLinksManager < GdsApi::Base
-  def local_link(authority_slug, lgsl, lgil = nil)
-    url = "#{endpoint}/api/link?authority_slug=#{authority_slug}&lgsl=#{lgsl}"
-    url += "&lgil=#{lgil}" if lgil
+  def local_link(authority_slug, lgsl, lgil)
+    url = "#{endpoint}/api/link?authority_slug=#{authority_slug}&lgsl=#{lgsl}&lgil=#{lgil}"
     get_json(url)
   end
 

--- a/lib/gds_api/test_helpers/local_links_manager.rb
+++ b/lib/gds_api/test_helpers/local_links_manager.rb
@@ -55,53 +55,21 @@ module GdsApi
           .to_return(body: response.to_json, status: 200)
       end
 
-      def local_links_manager_has_a_fallback_link(authority_slug:, lgsl:, lgil:, url:)
-        response = {
-          "local_authority" => {
-            "name" => authority_slug.capitalize,
-            "snac" => "00AG",
-            "tier" => "unitary",
-            "homepage_url" => "http://#{authority_slug}.example.com",
-          },
-          "local_interaction" => {
-            "lgsl_code" => lgsl,
-            "lgil_code" => lgil,
-            "url" => url,
-          }
-        }
-
-        stub_request(:get, "#{LOCAL_LINKS_MANAGER_ENDPOINT}/api/link")
-          .with(query: { authority_slug: authority_slug, lgsl: lgsl })
-          .to_return(body: response.to_json, status: 200)
-      end
-
-      def local_links_manager_has_no_fallback_link(authority_slug:, lgsl:)
-        response = {
-          "local_authority" => {
-            "name" => authority_slug.capitalize,
-            "snac" => "00AG",
-            "tier" => "unitary",
-            "homepage_url" => "http://#{authority_slug}.example.com",
-          },
-        }
-
-        stub_request(:get, "#{LOCAL_LINKS_MANAGER_ENDPOINT}/api/link")
-          .with(query: { authority_slug: authority_slug, lgsl: lgsl })
-          .to_return(body: response.to_json, status: 200)
-      end
-
-      def local_links_manager_request_with_missing_parameters(authority_slug, lgsl)
+      def local_links_manager_request_with_missing_parameters(authority_slug, lgsl, lgil)
         # convert nil to an empty string, otherwise query param is not expressed correctly
-        params = { authority_slug: authority_slug || "", lgsl: lgsl || "" }
+        params = {
+          authority_slug: authority_slug || "",
+          lgsl: lgsl || "",
+          lgil: lgil || "",
+        }
 
         stub_request(:get, "#{LOCAL_LINKS_MANAGER_ENDPOINT}/api/link")
           .with(query: params)
           .to_return(body: {}.to_json, status: 400)
       end
 
-      def local_links_manager_does_not_have_required_objects(authority_slug, lgsl, lgil = nil)
-        params = { authority_slug: authority_slug, lgsl: lgsl }
-        params[:lgil] = lgil if lgil
+      def local_links_manager_does_not_have_required_objects(authority_slug, lgsl, lgil)
+        params = { authority_slug: authority_slug, lgsl: lgsl, lgil: lgil }
 
         stub_request(:get, "#{LOCAL_LINKS_MANAGER_ENDPOINT}/api/link")
           .with(query: params)

--- a/test/local_links_manager_api_test.rb
+++ b/test/local_links_manager_api_test.rb
@@ -11,7 +11,7 @@ describe GdsApi::LocalLinksManager do
   end
 
   describe "#link" do
-    describe "when making request for specific LGIL" do
+    describe "when making a request" do
       it "returns the local authority and local interaction details if link present" do
         local_links_manager_has_a_link(
           authority_slug: "blackburn",
@@ -79,85 +79,46 @@ describe GdsApi::LocalLinksManager do
       end
     end
 
-    describe "when making request without LGIL" do
-      it "returns the local authority and local interaction details if link present" do
-        local_links_manager_has_a_fallback_link(
-          authority_slug: "blackburn",
-          lgsl: 2,
-          lgil: 3,
-          url: "http://blackburn.example.com/abandoned-shopping-trolleys/report"
-        )
-
-        expected_response = {
-          "local_authority" => {
-            "name" => "Blackburn",
-              "snac" => "00AG",
-              "tier" => "unitary",
-              "homepage_url" => "http://blackburn.example.com",
-          },
-          "local_interaction" => {
-            "lgsl_code" => 2,
-            "lgil_code" => 3,
-            "url" => "http://blackburn.example.com/abandoned-shopping-trolleys/report",
-          }
-        }
-
-        response = @api.local_link("blackburn", 2)
-        assert_equal expected_response, response.to_hash
-      end
-
-      it "returns the local authority and local interaction details if no link present" do
-        local_links_manager_has_no_fallback_link(
-          authority_slug: "blackburn",
-          lgsl: 2
-        )
-
-        expected_response = {
-          "local_authority" => {
-            "name" => "Blackburn",
-              "snac" => "00AG",
-              "tier" => "unitary",
-              "homepage_url" => "http://blackburn.example.com",
-          },
-        }
-
-        response = @api.local_link("blackburn", 2)
-        assert_equal expected_response, response.to_hash
-      end
-    end
-
     describe "when making request with missing required parameters" do
       it "raises HTTPClientError when authority_slug is missing" do
-        local_links_manager_request_with_missing_parameters(nil, 2)
+        local_links_manager_request_with_missing_parameters(nil, 2, 8)
 
         assert_raises GdsApi::HTTPClientError do
-          @api.local_link(nil, 2)
+          @api.local_link(nil, 2, 8)
         end
       end
 
       it "raises HTTPClientError when LGSL is missing" do
-        local_links_manager_request_with_missing_parameters('blackburn', nil)
+        local_links_manager_request_with_missing_parameters('blackburn', nil, 8)
 
         assert_raises GdsApi::HTTPClientError do
-          @api.local_link('blackburn', nil)
+          @api.local_link('blackburn', nil, 8)
+        end
+      end
+
+      it "raises HTTPClientError when LGIL is missing" do
+        local_links_manager_request_with_missing_parameters('blackburn', 2, nil)
+
+        assert_raises GdsApi::HTTPClientError do
+          @api.local_link('blackburn', 2, nil)
         end
       end
     end
 
     describe "when making request with invalid required parameters" do
       it "raises when authority_slug is invalid" do
-        local_links_manager_does_not_have_required_objects("hogwarts", 2)
+        local_links_manager_does_not_have_required_objects("hogwarts", 2, 8)
 
         assert_raises(GdsApi::HTTPNotFound) do
-          @api.local_link("hogwarts", 2)
+          @api.local_link("hogwarts", 2, 8)
         end
       end
 
       it "raises when LGSL is invalid" do
-        local_links_manager_does_not_have_required_objects("blackburn", 999)
+        local_links_manager_does_not_have_required_objects("blackburn", 999, 8)
 
         assert_raises(GdsApi::HTTPNotFound) do
-          @api.local_link("blackburn", 999)
+          @api.local_link("blackburn", 999, 8)
         end
       end
 


### PR DESCRIPTION
So that we can make administering links easier, we want to be able to only
support a defined set of LGSL / LGIL combinations.  We currently have some
logic to find the "best" result if an LGIL code isn't supplied with a request
for a link, but this results in some tricky code, more links to support and
uncertainty about whether the links that we provide are as good as they might
be.

To do this we need to:

- Assign LGIL codes to all `local_transaction` formats in
Publisher (done)
- Make this change to GDS API adapters (and bump the major version)
- Bump the Gem in Frontend and make sure that everything works
- Make the LGIL code mandatory on the LLM api