### PR TITLE
Bump major version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# 42.0.0
+
 * Make `lgil` mandatory when requesting links from Local Links Manager
 
 # 41.5.0

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '41.5.0'.freeze
+  VERSION = '42.0.0'.freeze
 end


### PR DESCRIPTION
Changed the Local Links Manager api to make LGIL codes mandatory when requesting links