### PR TITLE
Remove business support schemes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 * Set the `update_type` to major in all of the Publishing API pact tests.
+* Remove support for `business_support_schemes`
 
 # 42.0.0
 

--- a/lib/gds_api/content_api.rb
+++ b/lib/gds_api/content_api.rb
@@ -92,16 +92,6 @@ class GdsApi::ContentApi < GdsApi::Base
     get_json("#{@endpoint}/licences.json?ids=#{ids}")
   end
 
-  def business_support_schemes(facets)
-    url = "#{base_url}/business_support_schemes.json"
-    query = facets.map { |k, v| "#{k}=#{v}" }
-    if query.any?
-      url += "?#{query.join('&')}"
-    end
-
-    get_json(url)
-  end
-
   def get_list(url)
     get_json(url) { |r|
       GdsApi::ListResponse.new(r, self, web_urls_relative_to: @web_urls_relative_to)

--- a/lib/gds_api/test_helpers/content_api.rb
+++ b/lib/gds_api/test_helpers/content_api.rb
@@ -343,26 +343,6 @@ module GdsApi
         end
       end
 
-      def setup_content_api_business_support_schemes_stubs
-        setup_business_support_stubs(CONTENT_API_ENDPOINT, 'business_support_schemes')
-      end
-
-      def content_api_has_business_support_scheme(scheme, facets)
-        api_has_business_support(scheme, facets)
-      end
-
-      def content_api_has_default_business_support_schemes
-        empty_results = {
-          "_response_info" => { "status" => "ok" },
-          "description" => "Business Support Schemes!",
-          "total" => 0, "startIndex" => 1, "pageSize" => 0, "currentPage" => 1, "pages" => 1,
-          "results" => []
-        }
-
-        stub_request(:get, %r{\A#{CONTENT_API_ENDPOINT}/business_support_schemes\.json}).
-          to_return(body: empty_results.to_json)
-      end
-
       def content_api_licence_hash(licence_identifier, options = {})
         details = {
           title: "Publisher title",

--- a/test/content_api_test.rb
+++ b/test/content_api_test.rb
@@ -598,54 +598,6 @@ describe GdsApi::ContentApi do
     end
   end
 
-  describe "business support schemes" do
-    it "should query content_api for business_support_schemes" do
-      stub_request(:get, %r{\A#{@base_api_url}/business_support_schemes.json}).
-        to_return(status: 200, body: { "foo" => "bar" }.to_json)
-
-      response = @api.business_support_schemes(drink: "coffee")
-
-      assert_equal({ "foo" => "bar" }, response.to_hash)
-      assert_requested :get, "#{@base_api_url}/business_support_schemes.json?drink=coffee", times: 1
-    end
-
-    it "should raise an error if content_api returns 404" do
-      stub_request(:get, %r{\A#{@base_api_url}/business_support_schemes.json}).
-        to_return(status: 404, body: "Not Found")
-
-      assert_raises GdsApi::HTTPNotFound do
-        @api.business_support_schemes(%w(foo bar))
-      end
-    end
-
-    it "should raise an error if content_api returns a 50x error" do
-      stub_request(:get, %r{\A#{@base_api_url}/business_support_schemes.json}).
-        to_return(status: 503, body: "Gateway timeout")
-
-      assert_raises GdsApi::HTTPServerError do
-        @api.business_support_schemes(%w(foo bar))
-      end
-    end
-
-    describe "test helpers" do
-      it "should have representative test helpers" do
-        setup_content_api_business_support_schemes_stubs
-        s1 = { "title" => "Scheme 1", "format" => "business_support" }
-        content_api_has_business_support_scheme(s1, locations: "england", sectors: "farming")
-        s2 = { "title" => "Scheme 2", "format" => "business_support" }
-        content_api_has_business_support_scheme(s2, sectors: "farming")
-        s3 = { "title" => "Scheme 3", "format" => "business_support" }
-        content_api_has_business_support_scheme(s3, locations: "england", sectors: "farming")
-
-        response = @api.business_support_schemes(locations: "england", sectors: "farming").to_hash
-
-        assert_equal 2, response["total"]
-        assert_equal s1["title"], response["results"].first["title"]
-        assert_equal s3["title"], response["results"].last["title"]
-      end
-    end
-  end
-
   describe "getting licence details" do
     it "should get licence details" do
       setup_content_api_licences_stubs


### PR DESCRIPTION
We’re retiring the bespoke `business-support-api` application, because
it’s being replaced by a specialist publisher-style finder.

This application used to rely on fetching `business_support_schemes.json`
from `govuk_content_api`, but since the app is being retired we no
longer need to serve this JSON file from `govuk_content_api`, and hence
don’t need the corresponding API adapters.

### Trello

https://trello.com/c/VUl4KZzL/75-remove-business-support-schemes-json-from-content-api