### PR TITLE
Support custom schemas for Special Route Publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Set the `update_type` to major in all of the Publishing API pact tests.
 * Remove support for `business_support_schemes`
+* Support custom schemas in the SpecialRoutePublisher
 
 # 42.0.0
 

--- a/lib/gds_api/publishing_api/special_route_publisher.rb
+++ b/lib/gds_api/publishing_api/special_route_publisher.rb
@@ -15,10 +15,10 @@ module GdsApi
         put_content_response = publishing_api.put_content(
           options.fetch(:content_id),
           base_path: options.fetch(:base_path),
-          document_type: options[:document_type] || "special_route",
+          document_type: options.fetch(:document_type, "special_route"),
           schema_name: "special_route",
           title: options.fetch(:title),
-          description: options[:description] || "",
+          description: options.fetch(:description, ""),
           locale: "en",
           details: {},
           routes: [

--- a/lib/gds_api/publishing_api/special_route_publisher.rb
+++ b/lib/gds_api/publishing_api/special_route_publisher.rb
@@ -16,7 +16,7 @@ module GdsApi
           options.fetch(:content_id),
           base_path: options.fetch(:base_path),
           document_type: options.fetch(:document_type, "special_route"),
-          schema_name: "special_route",
+          schema_name: options.fetch(:schema_name, "special_route"),
           title: options.fetch(:title),
           description: options.fetch(:description, ""),
           locale: "en",

--- a/test/publishing_api/special_route_publisher_test.rb
+++ b/test/publishing_api/special_route_publisher_test.rb
@@ -65,6 +65,14 @@ describe GdsApi::PublishingApi::SpecialRoutePublisher do
       assert_publishing_api_publish(content_id, update_type: 'major')
     end
 
+    it "publishes customized schema_name" do
+      publisher.publish(special_route.merge(schema_name: "dummy_schema"))
+
+      assert_requested(:put, "#{endpoint}/v2/content/#{content_id}") do |req|
+        JSON.parse(req.body)["schema_name"] == "dummy_schema"
+      end
+    end
+
     it "publishes links" do
       links = {
         links: {


### PR DESCRIPTION
Allows a custom schema to be passed in when publishing a special route.