### PR TITLE
Add new adapter to give access to public holidays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Add api adapter for the bank-holidays json provided by calendars
+
 # 44.0.0
 
 * Revert changes made to `update_type` in the Publishing API pact tests in release 43.0.0

--- a/lib/gds_api/calendars.rb
+++ b/lib/gds_api/calendars.rb
@@ -1,0 +1,10 @@
+require_relative 'base'
+
+class GdsApi::Calendars < GdsApi::Base
+  def bank_holidays(division = nil)
+    json_url = "#{endpoint}/bank-holidays"
+    json_url += "/#{division.to_s.tr('_', '-')}" unless division.nil?
+    json_url += ".json"
+    get_json json_url
+  end
+end

--- a/lib/gds_api/test_helpers/calendars.rb
+++ b/lib/gds_api/test_helpers/calendars.rb
@@ -1,0 +1,58 @@
+module GdsApi
+  module TestHelpers
+    module Calendars
+      CALENDARS_ENDPOINT = Plek.current.find('calendars')
+
+      def calendars_endpoint(in_division: nil)
+        endpoint = "#{CALENDARS_ENDPOINT}/bank-holidays"
+        endpoint += "/#{in_division}" unless in_division.nil?
+        endpoint + '.json'
+      end
+
+      def calendars_has_no_bank_holidays(in_division: nil)
+        calendars_has_bank_holidays_on([], in_division: in_division)
+      end
+
+      def calendars_has_bank_holidays_on(dates, in_division: nil)
+        events = dates.map.with_index do |date, idx|
+          {
+            title: "Caturday #{idx}!",
+            date: date.to_date.iso8601,
+            notes: "Y'know, for cats!",
+            bunting: true
+          }
+        end
+
+        response =
+          if in_division.nil?
+            {
+              'england-and-wales' => {
+                division: 'england-and-wales',
+                events: events
+              },
+              'scotland' => {
+                division: 'scotland',
+                events: events
+              },
+              'northern-ireland' => {
+                division: 'northern-ireland',
+                events: events
+              }
+            }
+          else
+            {
+              division: in_division,
+              events: events
+            }
+          end
+
+        stub_request(:get, calendars_endpoint(in_division: in_division))
+          .to_return(body: response.to_json, status: 200)
+      end
+
+      def calendars_has_a_bank_holiday_on(date, in_division: nil)
+        calendars_has_bank_holidays_on([date], in_division: in_division)
+      end
+    end
+  end
+end

--- a/test/calendars_test.rb
+++ b/test/calendars_test.rb
@@ -1,0 +1,66 @@
+require_relative 'test_helper'
+require 'gds_api/calendars'
+require 'gds_api/test_helpers/calendars'
+
+describe GdsApi::Calendars do
+  include GdsApi::TestHelpers::Calendars
+
+  before do
+    @host = Plek.current.find("calendars")
+    @api = GdsApi::Calendars.new(@host)
+  end
+
+  describe "#bank_holidays" do
+    it "fetches all bank holidays when called with no argument" do
+      holidays_request = stub_request(:get, "#{@host}/bank-holidays.json").to_return(status: 200, body: "{}")
+
+      @api.bank_holidays
+
+      assert_requested(holidays_request)
+    end
+
+    it "fetches just the requested bank holidays when called with an argument" do
+      all_holidays_request = stub_request(:get, "#{@host}/bank-holidays.json")
+      scotland_holidays_request = stub_request(:get, "#{@host}/bank-holidays/scotland.json").to_return(status: 200, body: "{}")
+
+      @api.bank_holidays(:scotland)
+
+      assert_not_requested(all_holidays_request)
+      assert_requested(scotland_holidays_request)
+    end
+
+    it "normalises the argument from underscores to dashes" do
+      underscored_england_and_wales_holidays_request = stub_request(:get, "#{@host}/bank-holidays/england_and_wales.json").to_return(status: 200, body: '{}')
+      dashed_england_and_wales_holidays_request = stub_request(:get, "#{@host}/bank-holidays/england-and-wales.json").to_return(status: 200, body: "{}")
+
+      @api.bank_holidays(:england_and_wales)
+
+      assert_not_requested(underscored_england_and_wales_holidays_request)
+      assert_requested(dashed_england_and_wales_holidays_request)
+    end
+
+    it "should raise error if argument is for an area we don't have holidays for" do
+      stub_request(:get, "#{@host}/bank-holidays/lyonesse.json").to_return(status: 404)
+      assert_raises GdsApi::HTTPNotFound do
+        @api.bank_holidays(:lyonesse)
+      end
+    end
+
+    it "fetches the bank holidays requested for all divisions" do
+      calendars_has_a_bank_holiday_on(Date.parse('2012-12-12'))
+      holidays = @api.bank_holidays
+
+      assert_equal "2012-12-12", holidays['england-and-wales']['events'][0]['date']
+      assert_equal "2012-12-12", holidays['scotland']['events'][0]['date']
+      assert_equal "2012-12-12", holidays['northern-ireland']['events'][0]['date']
+    end
+
+    it "fetches the bank holidays requested for just one divisions" do
+      calendars_has_a_bank_holiday_on(Date.parse('2012-12-12'), in_division: 'scotland')
+      holidays = @api.bank_holidays(:scotland)
+
+      assert_equal "2012-12-12", holidays['events'][0]['date']
+      assert_equal "scotland", holidays['division']
+    end
+  end
+end


### PR DESCRIPTION
The calendars app provides a json feed for public holidays. You can get
all public holidays from `bank-holidays.json` or you can ask for just the
locale you care about via `bank-holidays/{locale}.json`.

The app also provides `.ics` files, but this adapter doesn't do anything
with them.

We've introduced this because we want to use public holidays when 
calculating a deadline in the fact check email that publisher sends (see:
https://trello.com/c/VSg9iWPO/156-factcheck-email-include-the-date-in-email )