### PR TITLE
Tidy up support and support-api adapters and test helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 * Drop dead endpoints from support adapter
+* Rename test helpers for support-api to make it clearer they stub requests to support-api
 
 # 45.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Drop dead endpoints from support adapter
+
 # 45.0.0
 
 * Add api adapter for the bank-holidays json provided by calendars

--- a/lib/gds_api/support.rb
+++ b/lib/gds_api/support.rb
@@ -5,24 +5,8 @@ class GdsApi::Support < GdsApi::Base
     post_json("#{base_url}/foi_requests", foi_request: request_details)
   end
 
-  def create_problem_report(request_details)
-    post_json("#{base_url}/anonymous_feedback/problem_reports", problem_report: request_details)
-  end
-
   def create_named_contact(request_details)
     post_json("#{base_url}/named_contacts", named_contact: request_details)
-  end
-
-  def create_anonymous_long_form_contact(request_details)
-    post_json("#{base_url}/anonymous_feedback/long_form_contacts", long_form_contact: request_details)
-  end
-
-  def create_service_feedback(request_details)
-    post_json("#{base_url}/anonymous_feedback/service_feedback", service_feedback: request_details)
-  end
-
-  def feedback_url(slug)
-    "#{base_url}/anonymous_feedback?path=#{slug}"
   end
 
 private

--- a/lib/gds_api/test_helpers/support.rb
+++ b/lib/gds_api/test_helpers/support.rb
@@ -9,27 +9,9 @@ module GdsApi
         post_stub.to_return(status: 201)
       end
 
-      def stub_support_problem_report_creation(request_details = nil)
-        post_stub = stub_http_request(:post, "#{SUPPORT_ENDPOINT}/anonymous_feedback/problem_reports")
-        post_stub.with(body: { problem_report: request_details }) unless request_details.nil?
-        post_stub.to_return(status: 201)
-      end
-
       def stub_support_named_contact_creation(request_details = nil)
         post_stub = stub_http_request(:post, "#{SUPPORT_ENDPOINT}/named_contacts")
         post_stub.with(body: { named_contact: request_details }) unless request_details.nil?
-        post_stub.to_return(status: 201)
-      end
-
-      def stub_support_long_form_anonymous_contact_creation(request_details = nil)
-        post_stub = stub_http_request(:post, "#{SUPPORT_ENDPOINT}/anonymous_feedback/long_form_contacts")
-        post_stub.with(body: { long_form_contact: request_details }) unless request_details.nil?
-        post_stub.to_return(status: 201)
-      end
-
-      def stub_support_service_feedback_creation(feedback_details = nil)
-        post_stub = stub_http_request(:post, "#{SUPPORT_ENDPOINT}/anonymous_feedback/service_feedback")
-        post_stub.with(body: { service_feedback: feedback_details }) unless feedback_details.nil?
         post_stub.to_return(status: 201)
       end
 

--- a/lib/gds_api/test_helpers/support_api.rb
+++ b/lib/gds_api/test_helpers/support_api.rb
@@ -18,31 +18,31 @@ module GdsApi
         post_stub.to_return(status: 201)
       end
 
-      def stub_support_long_form_anonymous_contact_creation(request_details = nil)
+      def stub_support_api_long_form_anonymous_contact_creation(request_details = nil)
         post_stub = stub_http_request(:post, "#{SUPPORT_API_ENDPOINT}/anonymous-feedback/long-form-contacts")
         post_stub.with(body: { long_form_contact: request_details }) unless request_details.nil?
         post_stub.to_return(status: 202)
       end
 
-      def stub_support_feedback_export_request_creation(request_details = nil)
+      def stub_support_api_feedback_export_request_creation(request_details = nil)
         post_stub = stub_http_request(:post, "#{SUPPORT_API_ENDPOINT}/anonymous-feedback/export-requests")
         post_stub.with(body: { export_request: request_details }) unless request_details.nil?
         post_stub.to_return(status: 202)
       end
 
-      def stub_support_global_export_request_creation(request_details = nil)
+      def stub_support_api_global_export_request_creation(request_details = nil)
         post_stub = stub_http_request(:post, "#{SUPPORT_API_ENDPOINT}/anonymous-feedback/global-export-requests")
         post_stub.with(body: { global_export_request: request_details }) unless request_details.nil?
         post_stub.to_return(status: 202)
       end
 
-      def stub_create_page_improvement(params)
+      def stub_support_api_create_page_improvement(params)
         post_stub = stub_http_request(:post, "#{SUPPORT_API_ENDPOINT}/page-improvements")
         post_stub.with(body: params)
         post_stub.to_return(status: 201)
       end
 
-      def stub_problem_report_daily_totals_for(date, expected_results = nil)
+      def stub_support_api_problem_report_daily_totals_for(date, expected_results = nil)
         date_string = date.strftime("%Y-%m-%d")
         get_stub = stub_http_request(:get, "#{SUPPORT_API_ENDPOINT}/anonymous-feedback/problem-reports/#{date_string}/totals")
         response = { status: 200 }
@@ -50,13 +50,13 @@ module GdsApi
         get_stub.to_return(response)
       end
 
-      def stub_support_problem_reports(params, response_body = {})
+      def stub_support_api_problem_reports(params, response_body = {})
         stub_http_request(:get, "#{SUPPORT_API_ENDPOINT}/anonymous-feedback/problem-reports").
           with(query: params).
           to_return(status: 200, body: response_body.to_json)
       end
 
-      def stub_support_mark_reviewed_for_spam(request_details = nil, response_body = {})
+      def stub_support_api_mark_reviewed_for_spam(request_details = nil, response_body = {})
         post_stub = stub_http_request(:put, "#{SUPPORT_API_ENDPOINT}/anonymous-feedback/problem-reports/mark-reviewed-for-spam")
         post_stub.with(body: { reviewed_problem_report_ids: request_details }) unless request_details.nil?
         post_stub.to_return(status: 200, body: response_body.to_json)
@@ -66,20 +66,20 @@ module GdsApi
         stub_request(:post, /#{SUPPORT_API_ENDPOINT}\/.*/).to_return(status: 503)
       end
 
-      def stub_anonymous_feedback(params, response_body = {})
+      def stub_support_api_anonymous_feedback(params, response_body = {})
         stub_http_request(:get, "#{SUPPORT_API_ENDPOINT}/anonymous-feedback").
           with(query: params).
           to_return(status: 200, body: response_body.to_json)
       end
 
-      def stub_anonymous_feedback_organisation_summary(slug, ordering = nil, response_body = {})
+      def stub_support_api_anonymous_feedback_organisation_summary(slug, ordering = nil, response_body = {})
         uri = "#{SUPPORT_API_ENDPOINT}/anonymous-feedback/organisations/#{slug}"
         uri << "?ordering=#{ordering}" if ordering
         stub_http_request(:get, uri).
           to_return(status: 200, body: response_body.to_json)
       end
 
-      def stub_organisations_list(response_body = nil)
+      def stub_support_api_organisations_list(response_body = nil)
         response_body ||= [{
           slug: "cabinet-office",
           web_url: "https://www.gov.uk/government/organisations/cabinet-office",
@@ -92,7 +92,7 @@ module GdsApi
           to_return(status: 200, body: response_body.to_json)
       end
 
-      def stub_organisation(slug = "cabinet-office", response_body = nil)
+      def stub_support_api_organisation(slug = "cabinet-office", response_body = nil)
         response_body ||= {
           slug: slug,
           web_url: "https://www.gov.uk/government/organisations/#{slug}",
@@ -105,7 +105,7 @@ module GdsApi
           to_return(status: 200, body: response_body.to_json)
       end
 
-      def stub_support_feedback_export_request(id, response_body = nil)
+      def stub_support_api_feedback_export_request(id, response_body = nil)
         response_body ||= {
           filename: "feedex_0000-00-00_2015-01-01.csv",
           ready: true

--- a/test/support_api_test.rb
+++ b/test/support_api_test.rb
@@ -13,9 +13,7 @@ describe GdsApi::SupportApi do
   it "can report a problem" do
     request_details = { certain: "details" }
 
-    stub_post = stub_request(:post, "#{@base_api_url}/anonymous-feedback/problem-reports").
-      with(body: { "problem_report" => request_details }.to_json).
-      to_return(status: 201)
+    stub_post = stub_support_api_problem_report_creation(request_details)
 
     @api.create_problem_report(request_details)
 
@@ -25,9 +23,7 @@ describe GdsApi::SupportApi do
   it "can pass service feedback" do
     request_details = { "transaction-completed-values" => "1", "details" => "abc" }
 
-    stub_post = stub_request(:post, "#{@base_api_url}/anonymous-feedback/service-feedback").
-      with(body: { "service_feedback" => request_details }.to_json).
-      to_return(status: 201)
+    stub_post = stub_support_api_service_feedback_creation(request_details)
 
     @api.create_service_feedback(request_details)
 
@@ -37,9 +33,7 @@ describe GdsApi::SupportApi do
   it "can submit long-form anonymous feedback" do
     request_details = { certain: "details" }
 
-    stub_post = stub_request(:post, "#{@base_api_url}/anonymous-feedback/long-form-contacts").
-      with(body: { "long_form_contact" => request_details }.to_json).
-      to_return(status: 201)
+    stub_post = stub_support_api_long_form_anonymous_contact_creation(request_details)
 
     @api.create_anonymous_long_form_contact(request_details)
 
@@ -48,11 +42,11 @@ describe GdsApi::SupportApi do
 
   it "fetches problem report daily totals" do
     response_body = { "data" => ["results"] }
+    request_date = Date.new(2014, 7, 12)
 
-    stub_get = stub_request(:get, "#{@base_api_url}/anonymous-feedback/problem-reports/2014-07-12/totals").
-      to_return(status: 200, body: response_body.to_json)
+    stub_get = stub_support_api_problem_report_daily_totals_for(request_date, response_body.to_json)
 
-    result = @api.problem_report_daily_totals_for(Date.new(2014, 7, 12))
+    result = @api.problem_report_daily_totals_for(request_date)
 
     assert_requested(stub_get)
     assert_equal response_body, result.to_hash
@@ -66,7 +60,7 @@ describe GdsApi::SupportApi do
 
   describe "GET /anonymous-feedback" do
     it "fetches anonymous feedback" do
-      stub_get = stub_anonymous_feedback(
+      stub_get = stub_support_api_anonymous_feedback(
         path_prefix: "/vat-rates",
         page: 55,
       )
@@ -84,7 +78,7 @@ describe GdsApi::SupportApi do
     it "fetches organisation summary" do
       slug = "hm-revenue-customs"
 
-      stub_get = stub_anonymous_feedback_organisation_summary(slug)
+      stub_get = stub_support_api_anonymous_feedback_organisation_summary(slug)
 
       @api.organisation_summary(slug)
 
@@ -95,7 +89,7 @@ describe GdsApi::SupportApi do
       slug = "hm-revenue-customs"
       ordering = "last_30_days"
 
-      stub_get = stub_anonymous_feedback_organisation_summary(slug, ordering)
+      stub_get = stub_support_api_anonymous_feedback_organisation_summary(slug, ordering)
 
       @api.organisation_summary(slug, ordering: ordering)
 
@@ -105,7 +99,7 @@ describe GdsApi::SupportApi do
 
   describe "POST /anonymous-feedback/export-requests" do
     it "makes a POST request to the support api" do
-      stub_post = stub_support_feedback_export_request_creation(notification_email: "foo@example.com")
+      stub_post = stub_support_api_feedback_export_request_creation(notification_email: "foo@example.com")
 
       @api.create_feedback_export_request(notification_email: "foo@example.com")
 
@@ -116,7 +110,7 @@ describe GdsApi::SupportApi do
   describe "POST /anonymous-feedback/global-export-requests" do
     it "makes a POST request to the support API" do
       params = { from_date: "1 June 2016", to_date: "8 June 2016", notification_email: "foo@example.com" }
-      stub_post = stub_support_global_export_request_creation(params)
+      stub_post = stub_support_api_global_export_request_creation(params)
 
       @api.create_global_export_request(params)
       assert_requested(stub_post)
@@ -126,7 +120,7 @@ describe GdsApi::SupportApi do
   describe "POST /page-improvements" do
     it "makes a POST request to the support API" do
       params = { description: "The title could be better." }
-      stub_post = stub_create_page_improvement(params)
+      stub_post = stub_support_api_create_page_improvement(params)
 
       @api.create_page_improvement(params)
 
@@ -136,7 +130,7 @@ describe GdsApi::SupportApi do
 
   describe "GET /anonymous-feedback/export-requests/:id" do
     it "fetches the export request details from the API" do
-      stub_get = stub_support_feedback_export_request(123)
+      stub_get = stub_support_api_feedback_export_request(123)
 
       @api.feedback_export_request(123)
 
@@ -146,7 +140,7 @@ describe GdsApi::SupportApi do
 
   describe "GET /organisations" do
     it "fetches a list of organisations" do
-      stub_get = stub_organisations_list
+      stub_get = stub_support_api_organisations_list
 
       @api.organisations_list
 
@@ -156,7 +150,7 @@ describe GdsApi::SupportApi do
 
   describe "GET /organisations/:slug" do
     it "fetches a list of organisations" do
-      stub_get = stub_organisation("foo")
+      stub_get = stub_support_api_organisation("foo")
 
       @api.organisation("foo")
 
@@ -167,7 +161,7 @@ describe GdsApi::SupportApi do
   describe "GET /anonymous-feedback/problem-reports" do
     it "fetches a list of problem reports" do
       params = { from_date: '2016-12-12', to_date: '2016-12-13', page: 1, exclude_reviewed: true }
-      stub_get = stub_support_problem_reports(params)
+      stub_get = stub_support_api_problem_reports(params)
 
       @api.problem_reports(params)
 
@@ -179,7 +173,7 @@ describe GdsApi::SupportApi do
     it "makes a PUT request to the support API" do
       params = { "1" => true, "2" => true }
 
-      stub_post = stub_support_mark_reviewed_for_spam(params)
+      stub_post = stub_support_api_mark_reviewed_for_spam(params)
 
       @api.mark_reviewed_for_spam(params)
 

--- a/test/support_test.rb
+++ b/test/support_test.rb
@@ -22,34 +22,10 @@ describe GdsApi::Support do
     assert_requested(stub_post)
   end
 
-  it "throws an exception when the support app isn't available" do
+  it "throws an exception when the support app isn't available while creating FOI requests" do
     support_isnt_available
 
     assert_raises(GdsApi::HTTPServerError) { @api.create_foi_request({}) }
-  end
-
-  it "can report a problem" do
-    request_details = { certain: "details" }
-
-    stub_post = stub_request(:post, "#{@base_api_url}/anonymous_feedback/problem_reports").
-      with(body: { "problem_report" => request_details }.to_json).
-      to_return(status: 201)
-
-    @api.create_problem_report(request_details)
-
-    assert_requested(stub_post)
-  end
-
-  it "can submit long-form anonymous feedback" do
-    request_details = { certain: "details" }
-
-    stub_post = stub_request(:post, "#{@base_api_url}/anonymous_feedback/long_form_contacts").
-      with(body: { "long_form_contact" => request_details }.to_json).
-      to_return(status: 201)
-
-    @api.create_anonymous_long_form_contact(request_details)
-
-    assert_requested(stub_post)
   end
 
   it "can create a named contact" do
@@ -64,32 +40,9 @@ describe GdsApi::Support do
     assert_requested(stub_post)
   end
 
-  it "throws an exception when the support app isn't available" do
+  it "throws an exception when the support app isn't available while creating named contacts" do
     support_isnt_available
 
-    assert_raises(GdsApi::HTTPServerError) { @api.create_problem_report({}) }
-  end
-
-  it "can pass service feedback" do
-    request_details = { "transaction-completed-values" => "1", "details" => "abc" }
-
-    stub_post = stub_request(:post, "#{@base_api_url}/anonymous_feedback/service_feedback").
-      with(body: { "service_feedback" => request_details }.to_json).
-      to_return(status: 201)
-
-    @api.create_service_feedback(request_details)
-
-    assert_requested(stub_post)
-  end
-
-  it "throws an exception when the support app isn't available" do
-    support_isnt_available
-
-    assert_raises(GdsApi::HTTPServerError) { @api.create_service_feedback({}) }
-  end
-
-  it "gets the correct feedback URL" do
-    assert_equal("#{@base_api_url}/anonymous_feedback?path=foo",
-                 @api.feedback_url('foo'))
+    assert_raises(GdsApi::HTTPServerError) { @api.create_named_contact({}) }
   end
 end


### PR DESCRIPTION
1. Remove dead end points from support that were moved into support-api in Oct 2014
2. Rename test helpers for support-api adapter to make it clearer they work on the support-api

More details in the individual commits.