### PR TITLE
Remove licence finder methods from Content API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 * Drop dead endpoints from support adapter
 * Rename test helpers for support-api to make it clearer they stub requests to support-api
+* Delete methods no longer needed by `licence-finder`: `licences_for_ids`,
+  `content_api_licence_hash`, `setup_content_api_licences_stubs` and
+  `content_api_has_licence`.
 
 # 45.0.0
 

--- a/lib/gds_api/content_api.rb
+++ b/lib/gds_api/content_api.rb
@@ -87,11 +87,6 @@ class GdsApi::ContentApi < GdsApi::Base
     get_json("#{base_url}/local_authorities.json?snac_code=#{CGI.escape(snac_code)}")
   end
 
-  def licences_for_ids(ids)
-    ids = ids.map(&:to_s).sort.join(',')
-    get_json("#{@endpoint}/licences.json?ids=#{ids}")
-  end
-
   def get_list(url)
     get_json(url) { |r|
       GdsApi::ListResponse.new(r, self, web_urls_relative_to: @web_urls_relative_to)

--- a/lib/gds_api/test_helpers/content_api.rb
+++ b/lib/gds_api/test_helpers/content_api.rb
@@ -341,60 +341,6 @@ module GdsApi
         end
       end
 
-      def content_api_licence_hash(licence_identifier, options = {})
-        details = {
-          title: "Publisher title",
-          slug: 'licence-slug',
-          licence_short_description: "Short description of licence"
-        }
-        details.merge!(options)
-
-        {
-          "title" => details[:title],
-          "id" => "http://example.org/#{details[:slug]}.json",
-          "web_url" => "http://www.test.gov.uk/#{details[:slug]}",
-          "format" => "licence",
-          "details" => {
-            "need_ids" => [],
-            "business_proposition" => false,
-            "alternative_title" => nil,
-            "overview" => nil,
-            "will_continue_on" => nil,
-            "continuation_link" => nil,
-            "licence_identifier" => licence_identifier,
-            "licence_short_description" => details[:licence_short_description],
-            "licence_overview" => nil,
-            "updated_at" => "2012-10-06T12:00:05+01:00"
-          },
-          "tags" => [],
-          "related" => []
-        }
-      end
-
-      def setup_content_api_licences_stubs
-        @stubbed_content_api_licences = []
-        stub_request(:get, %r{\A#{CONTENT_API_ENDPOINT}/licences}).to_return do |request|
-          if request.uri.query_values && request.uri.query_values["ids"]
-            ids = request.uri.query_values["ids"].split(',')
-            valid_licences = @stubbed_content_api_licences.select { |l| ids.include? l[:licence_identifier] }
-            {
-              body: {
-                'results' => valid_licences.map { |licence|
-                  content_api_licence_hash(licence[:licence_identifier], licence)
-                }
-              }.to_json
-            }
-          else
-            { body: { 'results' => [] }.to_json }
-          end
-        end
-      end
-
-      def content_api_has_licence(details)
-        raise "Need a licence identifier" if details[:licence_identifier].nil?
-        @stubbed_content_api_licences << details
-      end
-
       def content_api_has_artefacts_for_need_id(need_id, artefacts)
         url = "#{CONTENT_API_ENDPOINT}/for_need/#{CGI.escape(need_id.to_s)}.json"
         body = plural_response_base.merge(

--- a/test/content_api_test.rb
+++ b/test/content_api_test.rb
@@ -598,60 +598,6 @@ describe GdsApi::ContentApi do
     end
   end
 
-  describe "getting licence details" do
-    it "should get licence details" do
-      setup_content_api_licences_stubs
-
-      content_api_has_licence licence_identifier: "1234", title: 'Test Licence 1', slug: 'test-licence-1',
-        licence_short_description: 'A short description'
-      content_api_has_licence licence_identifier: "1235", title: 'Test Licence 2', slug: 'test-licence-2',
-        licence_short_description: 'A short description'
-      content_api_has_licence licence_identifier: "AB1234", title: 'Test Licence 3', slug: 'test-licence-3',
-        licence_short_description: 'A short description'
-
-      results = @api.licences_for_ids([1234, 'AB1234', 'something'])['results']
-      assert_equal 2, results.size
-      assert_equal(
-        %w(1234 AB1234),
-        results.map { |r| r['details']['licence_identifier'] }
-      )
-      assert_equal(
-        ['Test Licence 1', 'Test Licence 3'],
-        results.map { |item| item['title'] }.sort
-      )
-      assert_equal(
-        [
-          'http://www.test.gov.uk/test-licence-1',
-          'http://www.test.gov.uk/test-licence-3'
-        ],
-        results.map { |item| item['web_url'] }.sort
-      )
-      assert_equal(
-        'A short description',
-        results[0]['details']['licence_short_description']
-      )
-      assert_equal(
-        'A short description',
-        results[1]['details']['licence_short_description']
-      )
-    end
-
-    it "should return empty array with no licences" do
-      setup_content_api_licences_stubs
-
-      assert_equal [], @api.licences_for_ids([123, 124])['results']
-    end
-
-    it "should raise an error if publisher returns an error" do
-      stub_request(:get, %r[\A#{@base_api_url}/licences]).
-        to_return(status: [503, "Service temporarily unabailable"])
-
-      assert_raises GdsApi::HTTPServerError do
-        @api.licences_for_ids([123, 124])
-      end
-    end
-  end
-
   def api_response_for_results(results)
     {
       "_response_info" => {


### PR DESCRIPTION
We are no longer use the Content API in `licence-finder`. This PR
makes sure we remove helper methods related to `licence-finder` from the
Content API helpers as they are not needed anymore.

Trello: https://trello.com/c/vlqSHmTZ/76-make-licence-finder-use-something-else-to-fetch-licenses