### PR TITLE
Release major version 46.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 46.0.0
 
 * Drop dead endpoints from support adapter
 * Rename test helpers for support-api to make it clearer they stub requests to support-api

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '45.0.0'.freeze
+  VERSION = '46.0.0'.freeze
 end


### PR DESCRIPTION
The reason for a major version bump is that we have deleted
functionality. More details in the CHANGELOG file.

Trello: https://trello.com/c/vlqSHmTZ/76-make-licence-finder-use-something-else-to-fetch-licenses