### PR TITLE
Add API endpoints used by info-frontend

### DIFF
--- a/lib/gds_api/performance_platform/data_out.rb
+++ b/lib/gds_api/performance_platform/data_out.rb
@@ -43,6 +43,89 @@ module GdsApi
       def service_feedback(transaction_page_slug)
         get_json("#{endpoint}/data/#{transaction_page_slug}/customer-satisfaction")
       end
+
+      # Fetching statistics data from the performance platform for a given page slug
+      #
+      # Makes a +GET+ request.
+      #
+      # @param slug [String] Points to the page for which we are requesting
+      # statistics.
+      # @param is_multipart [Boolean] Flag that marks whether the slug is multipart
+      # or not:
+      #
+      # - simple: `/european-health-insurance-card`
+      # - multipart: `/european-health-insurance-card/123`
+      #
+      # # @examples
+      #
+      #  1. Without multipart filtering:
+      #
+      #  performance_platform_data_out.search_terms('/european-health-insurance-card')
+      #
+      #  2. With multipart filtering:
+      #
+      #  performance_platform_data_out.searches('/european-health-insurance-card', true)
+      #  performance_platform_data_out.page_views('/european-health-insurance-card', true)
+      #  performance_platform_data_out.problem_reports('/european-health-insurance-card', true)
+
+      def search_terms(slug)
+        options = {
+            slug: slug,
+            transaction: 'searchTerms',
+            group_by: 'searchKeyword',
+            collect: 'searchUniques:sum'
+        }
+        statistics(options)
+      end
+
+      def searches(slug, is_multipart)
+        options = {
+            slug: slug,
+            transaction: 'searchTerms',
+            group_by: 'pagePath',
+            collect: 'searchUniques:sum'
+        }
+        statistics(options, is_multipart)
+      end
+
+      def page_views(slug, is_multipart)
+        options = {
+            slug: slug,
+            transaction: 'page-statistics',
+            group_by: 'pagePath',
+            collect: 'uniquePageviews:sum'
+        }
+        statistics(options, is_multipart)
+      end
+
+      def problem_reports(slug, is_multipart)
+        options = {
+            slug: slug,
+            transaction: 'page-contacts',
+            group_by: 'pagePath',
+            collect: 'total:sum'
+        }
+        statistics(options, is_multipart)
+      end
+
+      # This can be used as a free form call to the performance platform.
+      # The performance platform uses Backdrop and its query language for
+      # storing and querying data.
+      # Backdrop can be found here: https://github.com/alphagov/backdrop
+      def statistics(options, is_multipart = false)
+        params = {
+            group_by: options[:group_by],
+            collect: options[:collect],
+            duration: 42,
+            period: "day",
+            end_at: Date.today.to_time.getutc.iso8601
+        }
+
+        filter_param = is_multipart ? :filter_by_prefix : :filter_by
+        params[filter_param] = "pagePath:" + options[:slug]
+
+        get_json("#{endpoint}/data/govuk-info/#{options[:transaction]}#{query_string(params)}")
+      end
     end
   end
 end

--- a/lib/gds_api/test_helpers/performance_platform/data_out.rb
+++ b/lib/gds_api/test_helpers/performance_platform/data_out.rb
@@ -17,6 +17,81 @@ module GdsApi
         def stub_service_not_available
           stub_request(:any, /#{PP_DATA_OUT_ENDPOINT}\/.*/).to_return(status: 503)
         end
+
+        def stub_search_terms(slug, response_body = {})
+          options = {
+              slug: slug,
+              transaction: 'searchTerms',
+              group_by: 'searchKeyword',
+              collect: 'searchUniques:sum'
+          }
+          stub_statistics(options, false, response_body)
+        end
+
+        def stub_searches(slug, is_multipart, response_body = {})
+          options = {
+              slug: slug,
+              transaction: 'searchTerms',
+              group_by: 'pagePath',
+              collect: 'searchUniques:sum'
+          }
+          stub_statistics(options, is_multipart, response_body)
+        end
+
+        def stub_page_views(slug, is_multipart, response_body = {})
+          options = {
+              slug: slug,
+              transaction: 'page-statistics',
+              group_by: 'pagePath',
+              collect: 'uniquePageviews:sum'
+          }
+          stub_statistics(options, is_multipart, response_body)
+        end
+
+        def stub_problem_reports(slug, is_multipart, response_body = {})
+          options = {
+              slug: slug,
+              transaction: 'page-contacts',
+              group_by: 'pagePath',
+              collect: 'total:sum'
+          }
+          stub_statistics(options, is_multipart, response_body)
+        end
+
+        def stub_statistics(options, is_multipart, response_body = {})
+          params = {
+              group_by: options[:group_by],
+              collect: options[:collect],
+              duration: 42,
+              period: "day",
+              end_at: Date.today.to_time.getutc.iso8601
+          }
+
+          filter_param = is_multipart ? :filter_by_prefix : :filter_by
+          params[filter_param] = "pagePath:" + options[:slug]
+
+          stub_http_request(:get, "#{PP_DATA_OUT_ENDPOINT}/data/govuk-info/#{options[:transaction]}")
+              .with(query: params)
+              .to_return(status: 200, body: response_body.to_json)
+        end
+
+        def stub_search_404(slug)
+          stub_request(:get, "#{PP_DATA_OUT_ENDPOINT}/data/govuk-info/searchTerms").
+              with(query: hash_including(filter_by: slug)).
+              to_return(status: 404, headers: { content_type: "application/json" })
+        end
+
+        def stub_page_views_404(slug)
+          stub_request(:get, "#{PP_DATA_OUT_ENDPOINT}/data/govuk-info/page-statistics").
+              with(query: hash_including(filter_by: slug)).
+              to_return(status: 404, headers: { content_type: "application/json" })
+        end
+
+        def stub_problem_reports_404(slug)
+          stub_request(:get, "#{PP_DATA_OUT_ENDPOINT}/data/govuk-info/page-contacts").
+              with(query: hash_including(filter_by: slug)).
+              to_return(status: 404, headers: { content_type: "application/json" })
+        end
       end
     end
   end

--- a/test/pp_data_out_test.rb
+++ b/test/pp_data_out_test.rb
@@ -11,6 +11,7 @@ describe GdsApi::PerformancePlatform::DataOut do
   end
 
   let(:transaction_slug) { 'register-to-vote' }
+  let(:statistics_slug) { '/european-health-insurance-card' }
 
   it "calls the service feedback endpoint for a particular slug" do
     request_details = { "some" => "data" }
@@ -18,6 +19,49 @@ describe GdsApi::PerformancePlatform::DataOut do
     stub_post = stub_service_feedback(transaction_slug, request_details)
 
     @api.service_feedback(transaction_slug)
+
+    assert_requested(stub_post)
+  end
+
+  it "calls the performance platform search_terms endpoint for a list of unique search results" do
+    request_details = { "some" => "data" }
+
+    stub_post = stub_search_terms(statistics_slug, request_details)
+
+    @api.search_terms(statistics_slug)
+
+    assert_requested(stub_post)
+  end
+
+  it "calls the performance platform searches endpoint for a list of search results" do
+    request_details = { "some" => "data" }
+    is_multipart = false
+
+    stub_post = stub_searches(statistics_slug, is_multipart, request_details)
+
+    @api.searches(statistics_slug, is_multipart)
+
+    assert_requested(stub_post)
+  end
+
+  it "calls the performance platform page_views endpoint for a list of page statistics" do
+    request_details = { "some" => "data" }
+    is_multipart = false
+
+    stub_post = stub_page_views(statistics_slug, is_multipart, request_details)
+
+    @api.page_views(statistics_slug, is_multipart)
+
+    assert_requested(stub_post)
+  end
+
+  it "calls the performance platform problem_reports endpoint for a list of page contacts" do
+    request_details = { "some" => "data" }
+    is_multipart = false
+
+    stub_post = stub_problem_reports(statistics_slug, is_multipart, request_details)
+
+    @api.problem_reports(statistics_slug, is_multipart)
 
     assert_requested(stub_post)
   end


### PR DESCRIPTION
For: https://trello.com/c/9JNitfXS/173-spike-info-pages

This will add an api endpoint for info-frontend to make it possible for it
to talk to the Backdrop Read API.

This will enable us to bypass metadata-api for making these api calls, and
will ultimately allow us to retire metadata-api, since it it currently only
used for these api calls.

This commit will be followed with a commit in info-frontend to use these
endpoints.