### PR TITLE
Test for `HTTPUnprocessableEntity` exceptions

### DIFF
--- a/test/publishing_api_test.rb
+++ b/test/publishing_api_test.rb
@@ -147,7 +147,7 @@ describe GdsApi::PublishingApi do
           },
         )
 
-      error = assert_raises GdsApi::HTTPClientError do
+      error = assert_raises GdsApi::HTTPUnprocessableEntity do
         @api_client.put_path(base_path, payload)
       end
       assert_equal "Unprocessable", error.error_details["error"]["message"]

--- a/test/publishing_api_v2_test.rb
+++ b/test/publishing_api_v2_test.rb
@@ -99,7 +99,7 @@ describe GdsApi::PublishingApiV2 do
       end
 
       it "responds with 422 Unprocessable Entity" do
-        error = assert_raises GdsApi::HTTPClientError do
+        error = assert_raises GdsApi::HTTPUnprocessableEntity do
           @api_client.put_content(@content_id, @content_item)
         end
         assert_equal "Conflict", error.error_details["error"]["message"]
@@ -138,7 +138,7 @@ describe GdsApi::PublishingApiV2 do
       end
 
       it "responds with 422 Unprocessable Entity" do
-        assert_raises GdsApi::HTTPClientError do
+        assert_raises GdsApi::HTTPUnprocessableEntity do
           @api_client.put_content(@content_id, @content_item)
         end
       end
@@ -597,7 +597,7 @@ describe GdsApi::PublishingApiV2 do
       end
 
       it "responds with 422" do
-        error = assert_raises GdsApi::HTTPClientError do
+        error = assert_raises GdsApi::HTTPUnprocessableEntity do
           @api_client.publish(@content_id, "")
         end
 
@@ -824,7 +824,7 @@ describe GdsApi::PublishingApiV2 do
       end
 
       it "responds with 422" do
-        error = assert_raises GdsApi::HTTPClientError do
+        error = assert_raises GdsApi::HTTPUnprocessableEntity do
           @api_client.unpublish(@content_id, type: "not-a-valid-type")
         end
 

--- a/test/rummager_test.rb
+++ b/test/rummager_test.rb
@@ -95,7 +95,7 @@ describe GdsApi::Rummager do
       status: [422, "Bad Request"],
       body: '"error":"Filtering by \"coffee\" is not allowed"',
     )
-    assert_raises(GdsApi::HTTPClientError) do
+    assert_raises(GdsApi::HTTPUnprocessableEntity) do
       GdsApi::Rummager.new("http://example.com").search(q: "query", filter_coffee: "tea")
     end
   end


### PR DESCRIPTION
ab320c552cb066ac9a07d5b6705ff69a82c34274 introduced a more specific version of `GdsApi::HTTPClientError` for 422 errors. This brings the test suite inline with those changes.