### PR TITLE
Release major version 47.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
-# NEXT RELEASE
+# 47.0.0
 
 * Remove support for `content-api`
+* Add `HTTPUnprocessableEntity` exceptions
+* Introduce 4 new endpoints for `backdrop read API` to be used by `info-frontend`. 
 
 # 46.0.0
 

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '46.0.0'.freeze
+  VERSION = '47.0.0'.freeze
 end


### PR DESCRIPTION
The reason for a major version bump is because we are removing support for content-api. We are also introducing 4 new endpoints that talk to backdrop read API.