### PR TITLE
Update link-checker-api to support new message format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Next release
+# 47.1.0
 
 * Update `link-checker-api` class to support new message format.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
+# Next release
+
+* Update `link-checker-api` class to support new message format.
+
 # 47.0.0
 
 * Remove support for `content-api`
 * Add `HTTPUnprocessableEntity` exceptions
-* Introduce 4 new endpoints for `backdrop read API` to be used by `info-frontend`. 
+* Introduce 4 new endpoints for `backdrop read API` to be used by `info-frontend`.
 
 # 46.0.0
 

--- a/lib/gds_api/link_checker_api.rb
+++ b/lib/gds_api/link_checker_api.rb
@@ -11,11 +11,13 @@ class GdsApi::LinkCheckerApi < GdsApi::Base
   #   be within before doing another check. (optional)
   # @return [LinkReport] A +SimpleDelegator+ of the +GdsApi::Response+ which
   #   responds to:
-  #     :uri           the URI of the link
-  #     :status        the status of the link, one of: ok, pending, broken, caution
-  #     :checked       the date the link was checked
-  #     :errors        a hash mapping short descriptions to arrays of long descriptions
-  #     :warnings      a hash mapping short descriptions to arrays of long descriptions
+  #     :uri              the URI of the link
+  #     :status           the status of the link, one of: ok, pending, broken, caution
+  #     :checked          the date the link was checked
+  #     :errors           a list of error descriptions
+  #     :warnings         a list of warning descriptions
+  #     :problem_summary  a short description of the most critical problem with the link
+  #     :suggested_fix    where possible, this provides a potential fix for the problem
   #
   # @raise [HTTPErrorResponse] if the request returns an error
   def check(uri, synchronous: nil, checked_within: nil)
@@ -100,12 +102,20 @@ class GdsApi::LinkCheckerApi < GdsApi::Base
       Time.iso8601(self["checked"])
     end
 
+    def problem_summary
+      self["problem_summary"]
+    end
+
+    def suggested_fix
+      self["suggested_fix"]
+    end
+
     def errors
-      self["errors"].each_with_object({}) { |(k, v), hash| hash[k.to_sym] = v }
+      self["errors"]
     end
 
     def warnings
-      self["warnings"].each_with_object({}) { |(k, v), hash| hash[k.to_sym] = v }
+      self["warnings"]
     end
   end
 

--- a/lib/gds_api/test_helpers/link_checker_api.rb
+++ b/lib/gds_api/test_helpers/link_checker_api.rb
@@ -5,13 +5,15 @@ module GdsApi
     module LinkCheckerApi
       LINK_CHECKER_API_ENDPOINT = Plek.current.find("link-checker-api")
 
-      def link_checker_api_link_report_hash(uri:, status: :ok, checked: nil, errors: {}, warnings: {})
+      def link_checker_api_link_report_hash(uri:, status: :ok, checked: nil, errors: [], warnings: [], problem_summary: nil, suggested_fix: nil)
         {
           uri: uri,
           status: status,
           checked: checked || Time.now.iso8601,
           errors: errors,
           warnings: warnings,
+          problem_summary: problem_summary,
+          suggested_fix: suggested_fix,
         }
       end
 
@@ -25,9 +27,9 @@ module GdsApi
         }
       end
 
-      def link_checker_api_check(uri:, status: :ok, checked: nil, errors: {}, warnings: {})
+      def link_checker_api_check(uri:, status: :ok, checked: nil, errors: [], warnings: [], problem_summary: nil, suggested_fix: nil)
         body = link_checker_api_link_report_hash(
-          uri: uri, status: status, checked: checked, errors: errors, warnings: warnings
+          uri: uri, status: status, checked: checked, errors: errors, warnings: warnings, problem_summary: problem_summary, suggested_fix: suggested_fix,
         ).to_json
 
         stub_request(:get, "#{LINK_CHECKER_API_ENDPOINT}/check")

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '47.0.0'.freeze
+  VERSION = '47.1.0'.freeze
 end


### PR DESCRIPTION
Shouldn't be merged until alphagov/link-checker-api#68.