### PR TITLE
Fixes url used for fetching search performance data

### DIFF
--- a/lib/gds_api/performance_platform/data_out.rb
+++ b/lib/gds_api/performance_platform/data_out.rb
@@ -71,7 +71,7 @@ module GdsApi
       def search_terms(slug)
         options = {
             slug: slug,
-            transaction: 'searchTerms',
+            transaction: 'search-terms',
             group_by: 'searchKeyword',
             collect: 'searchUniques:sum'
         }
@@ -81,7 +81,7 @@ module GdsApi
       def searches(slug, is_multipart)
         options = {
             slug: slug,
-            transaction: 'searchTerms',
+            transaction: 'search-terms',
             group_by: 'pagePath',
             collect: 'searchUniques:sum'
         }

--- a/lib/gds_api/test_helpers/performance_platform/data_out.rb
+++ b/lib/gds_api/test_helpers/performance_platform/data_out.rb
@@ -2,7 +2,7 @@ module GdsApi
   module TestHelpers
     module PerformancePlatform
       module DataOut
-        PP_DATA_OUT_ENDPOINT = "http://www.performance.service.gov.uk".freeze
+        PP_DATA_OUT_ENDPOINT = "https://www.performance.service.gov.uk".freeze
 
         def stub_service_feedback(slug, response_body = {})
           stub_http_request(:get, "#{PP_DATA_OUT_ENDPOINT}/data/#{slug}/customer-satisfaction").
@@ -21,7 +21,7 @@ module GdsApi
         def stub_search_terms(slug, response_body = {})
           options = {
               slug: slug,
-              transaction: 'searchTerms',
+              transaction: 'search-terms',
               group_by: 'searchKeyword',
               collect: 'searchUniques:sum'
           }
@@ -31,7 +31,7 @@ module GdsApi
         def stub_searches(slug, is_multipart, response_body = {})
           options = {
               slug: slug,
-              transaction: 'searchTerms',
+              transaction: 'search-terms',
               group_by: 'pagePath',
               collect: 'searchUniques:sum'
           }
@@ -76,7 +76,7 @@ module GdsApi
         end
 
         def stub_search_404(slug)
-          stub_request(:get, "#{PP_DATA_OUT_ENDPOINT}/data/govuk-info/searchTerms").
+          stub_request(:get, "#{PP_DATA_OUT_ENDPOINT}/data/govuk-info/search-terms").
               with(query: hash_including(filter_by: slug)).
               to_return(status: 404, headers: { content_type: "application/json" })
         end


### PR DESCRIPTION
For: https://trello.com/c/9JNitfXS/173-spike-info-pages

This is a follow up to releasing gds-api-adapters v.46.0.0, where four new endpoints where added in order to talk to the performance platform. See relevant commit here: https://github.com/alphagov/gds-api-adapters/commit/100a212d3a26e07acfa0f45a8ff85db45f64b154

 One of the new endpoints added in v46 was calling to
`https://www.performance.service.gov.uk/data/govuk-info/searchTerms`
instead of
`https://www.performance.service.gov.uk/data/govuk-info/search-terms`

This is a commit to replace `searchTerms` with `search-terms`