### PR TITLE
Release patch version 47.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 47.1.1
+
+* Fixes url used for fetching search metrics from `backdrop read API`
+
 # 47.1.0
 
 * Update `link-checker-api` class to support new message format.

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '47.1.0'.freeze
+  VERSION = '47.1.1'.freeze
 end


### PR DESCRIPTION
This is a small patch release to correct one of the urls used to fetch search metrics from `backdrop read API`. The endpoint is being used by `info-frontend`.