### PR TITLE
Make settting the update_type when publishing optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Make passing the `update_type` to the Publishing API on a publish optional.
+
 # 47.1.3
 
 * Fix Publishing API lookup_content_id and lookup_content_ids to send

--- a/lib/gds_api/publishing_api_v2.rb
+++ b/lib/gds_api/publishing_api_v2.rb
@@ -95,7 +95,7 @@ class GdsApi::PublishingApiV2 < GdsApi::Base
   # @option options [String] locale The language, defaults to 'en' in publishing-api.
   #
   # @see https://github.com/alphagov/publishing-api/blob/master/doc/api.md#post-v2contentcontent_idpublish
-  def publish(content_id, update_type, options = {})
+  def publish(content_id, update_type = nil, options = {})
     params = {
       update_type: update_type
     }


### PR DESCRIPTION
This parameter is being deprecated and instead we expect clients to send the update_type in the body of the content when doing a PUT request.

[Trello Card](https://trello.com/c/LnJlkb9e/987-5-deprecate-the-usage-of-updatetype-in-publish-for-publishing-api-and-update-usage-across-govuk)