### PR TITLE
Stop sending update_type on special route publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Send the update_type of special routes on put content rather than publish
+
 # 47.2.0
 
 * Make passing the `update_type` to the Publishing API on a publish optional.

--- a/lib/gds_api/publishing_api/special_route_publisher.rb
+++ b/lib/gds_api/publishing_api/special_route_publisher.rb
@@ -29,10 +29,12 @@ module GdsApi
           ],
           publishing_app: options.fetch(:publishing_app),
           rendering_app: options.fetch(:rendering_app),
-          public_updated_at: time.now.iso8601)
+          public_updated_at: time.now.iso8601,
+          update_type: options.fetch(:update_type, "major")
+        )
 
         publishing_api.patch_links(options.fetch(:content_id), links: options[:links]) if options[:links]
-        publishing_api.publish(options.fetch(:content_id), 'major')
+        publishing_api.publish(options.fetch(:content_id))
         put_content_response
       end
 

--- a/test/publishing_api/special_route_publisher_test.rb
+++ b/test/publishing_api/special_route_publisher_test.rb
@@ -48,11 +48,12 @@ describe GdsApi::PublishingApi::SpecialRoutePublisher do
           publishing_app: special_route[:publishing_app],
           rendering_app: special_route[:rendering_app],
           public_updated_at: Time.now.iso8601,
+          update_type: "major",
         }
 
         assert_requested(:put, "#{endpoint}/v2/content/#{content_id}", body: expected_payload)
         assert_valid_special_route(expected_payload)
-        assert_publishing_api_publish(content_id, update_type: 'major')
+        assert_publishing_api_publish(content_id)
       end
     end
 
@@ -62,7 +63,7 @@ describe GdsApi::PublishingApi::SpecialRoutePublisher do
       assert_requested(:put, "#{endpoint}/v2/content/#{content_id}") do |req|
         JSON.parse(req.body)["document_type"] == "other_document_type"
       end
-      assert_publishing_api_publish(content_id, update_type: 'major')
+      assert_publishing_api_publish(content_id)
     end
 
     it "publishes customized schema_name" do


### PR DESCRIPTION
Sending it on publish has been deprecated in favour of including it when sending a put content.

[Trello Card](https://trello.com/c/LnJlkb9e/987-5-deprecate-the-usage-of-updatetype-in-publish-for-publishing-api-and-update-usage-across-govuk)