### PR TITLE
Update the contract with publishing-api to expect a 409

### DIFF
--- a/test/publishing_api_v2_test.rb
+++ b/test/publishing_api_v2_test.rb
@@ -622,21 +622,21 @@ describe GdsApi::PublishingApiV2 do
             ),
           )
           .will_respond_with(
-            status: 400,
+            status: 409,
             body: {
               "error" => {
-                "code" => 400, "message" => Pact.term(generate: "Cannot publish an already published content item", matcher: /\S+/),
+                "code" => 409, "message" => Pact.term(generate: "Cannot publish an already published content item", matcher: /\S+/),
               },
             }
           )
       end
 
-      it "responds with 400" do
+      it "responds with 409" do
         error = assert_raises GdsApi::HTTPClientError do
           @api_client.publish(@content_id, "major")
         end
 
-        assert_equal 400, error.code
+        assert_equal 409, error.code
         assert_equal "Cannot publish an already published content item", error.error_details["error"]["message"]
       end
     end


### PR DESCRIPTION
When publishing-api rejects a call to the publish endpoint because of a missing draft, it now does this with a 409 code.

[Related Publishing API PR](https://github.com/alphagov/publishing-api/pull/980)