### PR TITLE
Add support for the publishing-api get editions endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
-* Send the update_type of special routes on put content rather than publish
+* Send the update_type of special routes on put content rather than publish.
+* Update `publishing-api` class to support the new get editions endpoint.
 
 # 47.2.0
 

--- a/lib/gds_api/publishing_api_v2.rb
+++ b/lib/gds_api/publishing_api_v2.rb
@@ -312,6 +312,18 @@ class GdsApi::PublishingApiV2 < GdsApi::Base
     get_json("#{endpoint}/v2/linked/#{content_id}#{query}")
   end
 
+  # Returns a paginated list of editions for the provided query string
+  # parameters.
+  #
+  # @param params [Hash]
+  #
+  # @return [GdsApi::Response] a paginated list of editions
+  #
+  # @see https://github.com/alphagov/publishing-api/blob/master/doc/api.md#get-v2editions
+  def get_editions(params = {})
+    get_json(get_editions_url(params))
+  end
+
 private
 
   def content_url(content_id, params = {})
@@ -338,6 +350,11 @@ private
   def discard_url(content_id)
     validate_content_id(content_id)
     "#{endpoint}/v2/content/#{content_id}/discard-draft"
+  end
+
+  def get_editions_url(params)
+    query = query_string(params)
+    "#{endpoint}/v2/editions#{query}"
   end
 
   def merge_optional_keys(params, options, optional_keys)

--- a/lib/gds_api/test_helpers/publishing_api_v2.rb
+++ b/lib/gds_api/test_helpers/publishing_api_v2.rb
@@ -509,6 +509,40 @@ module GdsApi
           )
       end
 
+      # Stub GET /v2/editions to return a set of editions
+      #
+      # @example
+      #
+      #   publishing_api_get_editions(
+      #     vehicle_recalls_and_faults,   # this is a variable containing an array of editions
+      #     fields: fields,   #example: let(:fields) { %i[base_path content_id public_updated_at title publication_state] }
+      #     per_page: 50
+      #   )
+      # @param items [Array]
+      # @param params [Hash]
+      def publishing_api_get_editions(editions, params = {})
+        url = PUBLISHING_API_V2_ENDPOINT + "/editions"
+
+        results = editions.map do |edition|
+          next edition unless params[:fields]
+          edition.select { |k| params[:fields].include?(k) }
+        end
+
+        per_page = (params[:per_page] || 100).to_i
+        results = results.take(per_page)
+
+        body = {
+          results: results,
+          links: [
+            { rel: "self", href: "#{PUBLISHING_API_V2_ENDPOINT}/editions" },
+          ],
+        }
+
+        stub_request(:get, url)
+          .with(query: params)
+          .to_return(status: 200, body: body.to_json, headers: {})
+      end
+
     private
 
       def stub_publishing_api_put(*args)

--- a/test/test_helpers/publishing_api_v2_test.rb
+++ b/test/test_helpers/publishing_api_v2_test.rb
@@ -241,4 +241,25 @@ describe GdsApi::TestHelpers::PublishingApiV2 do
       assert_publishing_api_discard_draft("some-content-id")
     end
   end
+
+  describe '#publishing_api_get_editions' do
+    it "stubs the get editions api call" do
+      editions = [
+        { "content_id" => "id-1", "title" => "title 1" },
+        { "content_id" => "id-2", "title" => "title 2" },
+      ]
+
+      publishing_api_get_editions(
+        editions,
+        fields: ["title"]
+      )
+
+      api_response = publishing_api.get_editions(fields: [:title])
+
+      assert_equal(
+        api_response["results"],
+        [{ "title" => "title 1" }, { "title" => "title 2" }]
+      )
+    end
+  end
 end


### PR DESCRIPTION
This is a new endpoint added to support pagination over editions.

[Trello Card](https://trello.com/c/iAdftXss/962-help-content-tools-get-content-out-of-publishing-api-faster-more-get-content-woes-3)