### PR TITLE
Add govuk-delivery list enable/disable endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Add `enable_list` and `disable_list` endpoints for govuk-delivery.
+
 # 47.4.0
 
 * Add a `get_paged_editions` endpoint, which returns a lazy enumerator that pages

--- a/lib/gds_api/gov_uk_delivery.rb
+++ b/lib/gds_api/gov_uk_delivery.rb
@@ -32,6 +32,18 @@ class GdsApi::GovUkDelivery < GdsApi::Base
     post_url(url, data)
   end
 
+  def enable_list(gov_delivery_id)
+    data = { gov_delivery_id: gov_delivery_id }
+    url = "#{base_url}/lists/enable"
+    post_url(url, data)
+  end
+
+  def disable_list(gov_delivery_id)
+    data = { gov_delivery_id: gov_delivery_id }
+    url = "#{base_url}/lists/disable"
+    post_url(url, data)
+  end
+
 private
 
   def base_url

--- a/test/gov_uk_delivery_test.rb
+++ b/test/gov_uk_delivery_test.rb
@@ -42,6 +42,22 @@ describe GdsApi::GovUkDelivery do
     assert_requested stub
   end
 
+  it "can enable a list" do
+    expected_payload = { gov_delivery_id: 'TOPIC_1234' }
+    stub = stub_gov_uk_delivery_post_request('lists/enable', expected_payload).to_return(list_enabled_disabled_hash(enabled: true))
+
+    assert @api.enable_list('TOPIC_1234')
+    assert_requested stub
+  end
+
+  it "can disable a list" do
+    expected_payload = { gov_delivery_id: 'TOPIC_1234' }
+    stub = stub_gov_uk_delivery_post_request('lists/disable', expected_payload).to_return(list_enabled_disabled_hash(enabled: false))
+
+    assert @api.disable_list('TOPIC_1234')
+    assert_requested stub
+  end
+
   it "raises if the API 404s" do
     expected_payload = { feed_url: 'http://example.com/feed' }
     stub_gov_uk_delivery_get_request('list-url', expected_payload).to_return(not_found_hash)
@@ -63,5 +79,10 @@ describe GdsApi::GovUkDelivery do
 
   def created_response_json_hash(data)
     { body: data.to_json, status: 201 }
+  end
+
+  def list_enabled_disabled_hash(enabled:)
+    body = { success: true, topic_id: 'TOPIC_1234', url: '', disabled: !enabled }.to_json
+    { body: body, status: 200 }
   end
 end


### PR DESCRIPTION
This commit adds the new govuk-delivery list enable/disable endpoints so they can be used by email-alert-api when switching lists between govuk-delivery and email-alert-api.

Trello: https://trello.com/c/CaD3UZFZ/69-make-sure-toggling-enabled-disabled-across-systems-works-quickly-and-reliably-1