### PR TITLE
Raise specific errors for 5XX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Add more specific exceptions for HTTPInternalServerError (500), HTTPBadGateway (502), HTTPUnavailable (503), HTTPGatewayTimeout (504) exceptions.
+
 # 47.8.0
 
 * Add `email_alert_api.topic_matches`

--- a/lib/gds_api/exceptions.rb
+++ b/lib/gds_api/exceptions.rb
@@ -61,8 +61,6 @@ module GdsApi
 
   class InvalidUrl < BaseError; end
 
-  class NoBearerToken < BaseError; end
-
   module ExceptionHandling
     def build_specific_http_error(error, url, details = nil, request_body = nil)
       message = "URL: #{url}\nResponse body:\n#{error.http_body}\n\nRequest body:\n#{request_body}"

--- a/lib/gds_api/exceptions.rb
+++ b/lib/gds_api/exceptions.rb
@@ -1,16 +1,10 @@
 module GdsApi
   # Abstract error class
-  class BaseError < StandardError
-  end
+  class BaseError < StandardError; end
 
-  class EndpointNotFound < BaseError
-  end
-
-  class TimedOutException < BaseError
-  end
-
-  class InvalidUrl < BaseError
-  end
+  class EndpointNotFound < BaseError; end
+  class TimedOutException < BaseError; end
+  class InvalidUrl < BaseError; end
 
   # Superclass for all 4XX and 5XX errors
   class HTTPErrorResponse < BaseError
@@ -25,42 +19,22 @@ module GdsApi
   end
 
   # Superclass & fallback for all 4XX errors
-  class HTTPClientError < HTTPErrorResponse
-  end
+  class HTTPClientError < HTTPErrorResponse; end
 
-  class HTTPNotFound < HTTPClientError
-  end
-
-  class HTTPGone < HTTPClientError
-  end
-
-  class HTTPUnauthorized < HTTPClientError
-  end
-
-  class HTTPForbidden < HTTPClientError
-  end
-
-  class HTTPConflict < HTTPClientError
-  end
-
-  class HTTPUnprocessableEntity < HTTPClientError
-  end
+  class HTTPNotFound < HTTPClientError; end
+  class HTTPGone < HTTPClientError; end
+  class HTTPUnauthorized < HTTPClientError; end
+  class HTTPForbidden < HTTPClientError; end
+  class HTTPConflict < HTTPClientError; end
+  class HTTPUnprocessableEntity < HTTPClientError; end
 
   # Superclass & fallback for all 5XX errors
-  class HTTPServerError < HTTPErrorResponse
-  end
+  class HTTPServerError < HTTPErrorResponse; end
 
-  class HTTPInternalServerError < HTTPServerError
-  end
-
-  class HTTPBadGateway < HTTPServerError
-  end
-
-  class HTTPUnavailable < HTTPServerError
-  end
-
-  class HTTPGatewayTimeout < HTTPServerError
-  end
+  class HTTPInternalServerError < HTTPServerError; end
+  class HTTPBadGateway < HTTPServerError; end
+  class HTTPUnavailable < HTTPServerError; end
+  class HTTPGatewayTimeout < HTTPServerError; end
 
   module ExceptionHandling
     def build_specific_http_error(error, url, details = nil, request_body = nil)

--- a/lib/gds_api/exceptions.rb
+++ b/lib/gds_api/exceptions.rb
@@ -9,9 +9,6 @@ module GdsApi
   class TimedOutException < BaseError
   end
 
-  class TooManyRedirects < BaseError
-  end
-
   # Superclass for all 4XX and 5XX errors
   class HTTPErrorResponse < BaseError
     attr_accessor :code, :error_details

--- a/lib/gds_api/exceptions.rb
+++ b/lib/gds_api/exceptions.rb
@@ -1,4 +1,5 @@
 module GdsApi
+  # Abstract error class
   class BaseError < StandardError
   end
 
@@ -11,6 +12,7 @@ module GdsApi
   class TooManyRedirects < BaseError
   end
 
+  # Superclass for all 4XX and 5XX errors
   class HTTPErrorResponse < BaseError
     attr_accessor :code, :error_details
 

--- a/lib/gds_api/exceptions.rb
+++ b/lib/gds_api/exceptions.rb
@@ -64,17 +64,6 @@ module GdsApi
   class NoBearerToken < BaseError; end
 
   module ExceptionHandling
-    def ignoring(exception_or_exceptions)
-      yield
-    rescue *exception_or_exceptions
-      # Discard the exception
-      nil
-    end
-
-    def ignoring_missing(&block)
-      ignoring([HTTPNotFound, HTTPGone], &block)
-    end
-
     def build_specific_http_error(error, url, details = nil, request_body = nil)
       message = "URL: #{url}\nResponse body:\n#{error.http_body}\n\nRequest body:\n#{request_body}"
       code = error.http_code

--- a/lib/gds_api/exceptions.rb
+++ b/lib/gds_api/exceptions.rb
@@ -9,6 +9,9 @@ module GdsApi
   class TimedOutException < BaseError
   end
 
+  class InvalidUrl < BaseError
+  end
+
   # Superclass for all 4XX and 5XX errors
   class HTTPErrorResponse < BaseError
     attr_accessor :code, :error_details
@@ -23,22 +26,6 @@ module GdsApi
 
   # Superclass & fallback for all 4XX errors
   class HTTPClientError < HTTPErrorResponse
-  end
-
-  # Superclass & fallback for all 5XX errors
-  class HTTPServerError < HTTPErrorResponse
-  end
-
-  class HTTPInternalServerError < HTTPServerError
-  end
-
-  class HTTPBadGateway < HTTPServerError
-  end
-
-  class HTTPUnavailable < HTTPServerError
-  end
-
-  class HTTPGatewayTimeout < HTTPServerError
   end
 
   class HTTPNotFound < HTTPClientError
@@ -59,7 +46,21 @@ module GdsApi
   class HTTPUnprocessableEntity < HTTPClientError
   end
 
-  class InvalidUrl < BaseError; end
+  # Superclass & fallback for all 5XX errors
+  class HTTPServerError < HTTPErrorResponse
+  end
+
+  class HTTPInternalServerError < HTTPServerError
+  end
+
+  class HTTPBadGateway < HTTPServerError
+  end
+
+  class HTTPUnavailable < HTTPServerError
+  end
+
+  class HTTPGatewayTimeout < HTTPServerError
+  end
 
   module ExceptionHandling
     def build_specific_http_error(error, url, details = nil, request_body = nil)

--- a/lib/gds_api/exceptions.rb
+++ b/lib/gds_api/exceptions.rb
@@ -22,10 +22,24 @@ module GdsApi
     end
   end
 
+  # Superclass & fallback for all 4XX errors
   class HTTPClientError < HTTPErrorResponse
   end
 
+  # Superclass & fallback for all 5XX errors
   class HTTPServerError < HTTPErrorResponse
+  end
+
+  class HTTPInternalServerError < HTTPServerError
+  end
+
+  class HTTPBadGateway < HTTPServerError
+  end
+
+  class HTTPUnavailable < HTTPServerError
+  end
+
+  class HTTPGatewayTimeout < HTTPServerError
   end
 
   class HTTPNotFound < HTTPClientError
@@ -84,6 +98,14 @@ module GdsApi
         GdsApi::HTTPUnprocessableEntity
       when (400..499)
         GdsApi::HTTPClientError
+      when 500
+        GdsApi::HTTPInternalServerError
+      when 502
+        GdsApi::HTTPBadGateway
+      when 503
+        GdsApi::HTTPUnavailable
+      when 504
+        GdsApi::HTTPGatewayTimeout
       when (500..599)
         GdsApi::HTTPServerError
       else


### PR DESCRIPTION
This adds more specific exceptions for `HTTPInternalServerError` (500), `HTTPBadGateway` (502), `HTTPUnavailable` (503), `HTTPGatewayTimeout` (504) exceptions.

Does some cleanup & formatting as well, so best reviewed per commit.