### PR TITLE
Add get_links_for_content_ids method to publishing_api client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Add the HTTPPayloadTooLarge exception
+
 * Add `get_links_for_content_ids` endpoint to Publishing API
 
 * Add more specific exceptions for HTTPInternalServerError (500), HTTPBadGateway (502), HTTPUnavailable (503), HTTPGatewayTimeout (504) exceptions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Add `get_links_for_content_ids` endpoint to Publishing API
+
 * Add more specific exceptions for HTTPInternalServerError (500), HTTPBadGateway (502), HTTPUnavailable (503), HTTPGatewayTimeout (504) exceptions.
 
 # 47.8.0

--- a/lib/gds_api/exceptions.rb
+++ b/lib/gds_api/exceptions.rb
@@ -23,6 +23,7 @@ module GdsApi
 
   class HTTPNotFound < HTTPClientError; end
   class HTTPGone < HTTPClientError; end
+  class HTTPPayloadTooLarge < HTTPClientError; end
   class HTTPUnauthorized < HTTPClientError; end
   class HTTPForbidden < HTTPClientError; end
   class HTTPConflict < HTTPClientError; end
@@ -55,6 +56,8 @@ module GdsApi
         GdsApi::HTTPConflict
       when 410
         GdsApi::HTTPGone
+      when 413
+        GdsApi::HTTPPayloadTooLarge
       when 422
         GdsApi::HTTPUnprocessableEntity
       when (400..499)

--- a/lib/gds_api/publishing_api_v2.rb
+++ b/lib/gds_api/publishing_api_v2.rb
@@ -347,6 +347,32 @@ class GdsApi::PublishingApiV2 < GdsApi::Base
     end
   end
 
+  # Returns a mapping of content_ids => links hashes
+  #
+  # @param content_ids [Array]
+  #
+  # @return [Hash] a mapping of content_id => links
+  #
+  # @example
+  #
+  #   publishing_api.get_links_for_content_ids([
+  #     "e1067450-7d13-45ff-ada4-5e3dd4025fb7",
+  #     "72ed754c-4c82-415f-914a-ab6760454cb4"
+  #   ])
+  #
+  #   #=> {
+  #     "e1067450-7d13-45ff-ada4-5e3dd4025fb7" => {
+  #       links: {
+  #         taxons: ["13bba81c-b2b1-4b13-a3de-b24748977198"]},
+  #         ... (and more attributes)
+  #       version: 10},
+  #     "72ed754c-4c82-415f-914a-ab6760454cb4" => { ..etc }
+  #   }
+  #
+  def get_links_for_content_ids(content_ids)
+    post_json("#{endpoint}/v2/links/by-content-id", content_ids: content_ids).to_hash
+  end
+
 private
 
   def content_url(content_id, params = {})

--- a/test/publishing_api_v2_test.rb
+++ b/test/publishing_api_v2_test.rb
@@ -1576,6 +1576,48 @@ describe GdsApi::PublishingApiV2 do
       end
     end
   end
+
+  describe "#get_links_by_content_id" do
+    it "returns the links for some content_ids" do
+      content_id_with_links = "bed722e6-db68-43e5-9079-063f623335a7"
+      content_id_no_links = "f40a63ce-ac0c-4102-84d1-f1835cb7daac"
+
+      response_hash = {
+        content_id_with_links => {
+          "links" => {
+            "taxons" => ["20583132-1619-4c68-af24-77583172c070"]
+          },
+          "version" => 2
+        },
+        content_id_no_links => {
+          "links" => {},
+          "version" => 0
+        }
+      }
+
+      publishing_api
+        .given("taxon links exist for content_id bed722e6-db68-43e5-9079-063f623335a7")
+        .upon_receiving("a bulk_links request")
+        .with(
+          method: :post,
+          path: "/v2/links/by-content-id",
+          body: {
+            content_ids: [content_id_with_links, content_id_no_links]
+          },
+          headers: {
+            "Content-Type" => "application/json",
+          },
+        )
+        .will_respond_with(
+          status: 200,
+          body: response_hash,
+        )
+
+      result = @api_client.get_links_for_content_ids([content_id_with_links, content_id_no_links])
+      assert_equal(response_hash, result)
+    end
+  end
+
   describe "#get_linked_items" do
     describe "if the content item does not exist" do
       before do


### PR DESCRIPTION
This change introduces a new method for retrieving `links` hashes for multiple content_items at once from `publishing_api`.

It's dependant on [this PR](https://github.com/alphagov/publishing-api/pull/1017)

[Trello](https://trello.com/c/H3BqIPWc/190-current-tags-are-visible-in-the-bulk-tagging-tool)