### PR TITLE
Group exceptions in Sentry by type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Group Sentry errors by exception type
+
 # 47.9.0
 
 * Add the HTTPPayloadTooLarge exception

--- a/lib/gds_api/exceptions.rb
+++ b/lib/gds_api/exceptions.rb
@@ -1,6 +1,17 @@
 module GdsApi
   # Abstract error class
-  class BaseError < StandardError; end
+  class BaseError < StandardError
+    # Give Sentry extra context about this event
+    # https://docs.sentry.io/clients/ruby/context/
+    def raven_context
+      {
+        # Make Sentry group exceptions by type instead of message, so all
+        # exceptions like `GdsApi::TimedOutException` will get grouped as one
+        # error and not an error per URL.
+        fingerprint: [self.class.name],
+      }
+    end
+  end
 
   class EndpointNotFound < BaseError; end
   class TimedOutException < BaseError; end

--- a/test/exceptions_test.rb
+++ b/test/exceptions_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class GdsApiBaseTest < Minitest::Test
+  def test_fingerprints_per_exception_type
+    exception = GdsApi::HTTPBadGateway.new(200)
+
+    assert_equal ["GdsApi::HTTPBadGateway"], exception.raven_context[:fingerprint]
+  end
+end


### PR DESCRIPTION
This makes Sentry group exceptions by type instead of message, so all exceptions like `GdsApi::TimedOutException` will get grouped as one error and not an error per URL.

https://docs.sentry.io/learn/rollups/#custom-grouping