### PR TITLE
Require test helper in publishing API tests

### DIFF
--- a/test/publishing_api_v2_test.rb
+++ b/test/publishing_api_v2_test.rb
@@ -1,5 +1,6 @@
 require 'test_helper'
 require 'gds_api/publishing_api_v2'
+require 'gds_api/test_helpers/publishing_api_v2'
 require 'json'
 
 describe GdsApi::PublishingApiV2 do


### PR DESCRIPTION
We're using the test helpers but but explicitly requiring them, causing intermittent test failures.