### PR TITLE
Resurrect `GdsApi::Support#feedback_url`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Resurrect `feedback_url` for Support (removed in 46.0.0)
 * Remove need-api helper
   Need API is being retired
 

--- a/lib/gds_api/support.rb
+++ b/lib/gds_api/support.rb
@@ -9,6 +9,10 @@ class GdsApi::Support < GdsApi::Base
     post_json("#{base_url}/named_contacts", named_contact: request_details)
   end
 
+  def feedback_url(slug)
+    "#{base_url}/anonymous_feedback?path=#{slug}"
+  end
+
 private
 
   def base_url

--- a/test/support_test.rb
+++ b/test/support_test.rb
@@ -45,4 +45,9 @@ describe GdsApi::Support do
 
     assert_raises(GdsApi::HTTPServerError) { @api.create_named_contact({}) }
   end
+
+  it "gets the correct feedback URL" do
+    assert_equal("#{@base_api_url}/anonymous_feedback?path=foo",
+                 @api.feedback_url('foo'))
+  end
 end


### PR DESCRIPTION
For: https://trello.com/c/tMl51xNJ/29-update-maslow

We removed this in 1a3694ff3f797dc1906ce598d5228a7e5c3fd20e as we thought
nothing used it and it referred to a path the support app didn't respond
to.  Both of these facts turned out to be false; maslow uses it to link
to the feedback for pages that are covered by a need, and the app does
respond to that url.