### PR TITLE
Release v48.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 48.0.0
 
 * Resurrect `feedback_url` for Support (removed in 46.0.0)
 * Remove need-api helper

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '47.9.1'.freeze
+  VERSION = '48.0.0'.freeze
 end


### PR DESCRIPTION
Includes:

 * (breaking change) Removing the need api adapter (#745)
 * Re-adding Support#feedback_url (#747)

Supersedes #746 