### PR TITLE
Add API call for LinkChange in Publishing Api

### DIFF
--- a/lib/gds_api/publishing_api_v2.rb
+++ b/lib/gds_api/publishing_api_v2.rb
@@ -205,6 +205,27 @@ class GdsApi::PublishingApiV2 < GdsApi::Base
     get_json(links_url(content_id))
   end
 
+  # Returns an array of changes to links.
+  #
+  # The link changes can be filtered by link_type, source content_id,
+  # target content_id and user. A maximum of 250 changes will be
+  # returned.
+  #
+  # @param link_types [Array] Array of link_types to filter by.
+  # @param source_content_ids [Array] Array of source content ids to filter by.
+  # @param target_content_ids [Array] Array of target content ids to filter by.
+  # @param users [Array] User UIDs to filter by.
+  # @example
+  #
+  #   publishing_api.get_links_changes(
+  #     link_types: ['taxons'],
+  #     target_content_ids: ['a544d48b-1e9e-47fb-b427-7a987c658c14']
+  #   )
+  #
+  def get_links_changes(params)
+    get_json(links_changes_url(params))
+  end
+
   # Get expanded links
   #
   # Return the expanded links of the item.
@@ -384,6 +405,11 @@ private
   def links_url(content_id)
     validate_content_id(content_id)
     "#{endpoint}/v2/links/#{content_id}"
+  end
+
+  def links_changes_url(params = {})
+    query = query_string(params)
+    "#{endpoint}/v2/links/changes/#{query}"
   end
 
   def publish_url(content_id)

--- a/test/publishing_api_v2_test.rb
+++ b/test/publishing_api_v2_test.rb
@@ -1225,6 +1225,59 @@ describe GdsApi::PublishingApiV2 do
     end
   end
 
+  describe "#get_links_changes" do
+    let(:link_changes) {
+      { 'link_changes' => [
+        {
+          'source' => { 'title' => 'Edition Title A1',
+                        'base_path' => '/base/path/a1',
+                        'content_id' => 'aaaaaaaa-aaaa-1aaa-aaaa-aaaaaaaaaaaa' },
+          'target' => { 'title' => 'Edition Title B1',
+                        'base_path' => '/base/path/b1',
+                        'content_id' => 'bbbbbbbb-bbbb-1bbb-bbbb-bbbbbbbbbbbb' },
+          'link_type' => 'taxons',
+          'change' => 'add',
+          'user_uid' => '11111111-1111-1111-1111-111111111111',
+          'created_at' => "2017-01-01T09:00:00.100Z"
+        },
+        {
+          'source' => { 'title' => 'Edition Title A2',
+                        'base_path' => '/base/path/a2',
+                        'content_id' => 'aaaaaaaa-aaaa-2aaa-aaaa-aaaaaaaaaaaa' },
+          'target' => { 'title' => 'Edition Title B2',
+                        'base_path' => '/base/path/b2',
+                        'content_id' => 'bbbbbbbb-bbbb-2bbb-bbbb-bbbbbbbbbbbb' },
+          'link_type' => 'taxons',
+          'change' => 'remove',
+          'user_uid' => '22222222-2222-2222-2222-222222222222',
+          'created_at' => "2017-01-01T09:00:00.100Z"
+        }
+      ] }
+    }
+
+    it "returns the changes for a single link_type" do
+      publishing_api
+        .given("there are two link changes with a link_type of 'taxons'")
+        .upon_receiving("a get links changes request for changes with a link_type of 'taxons'")
+        .with(
+          method: :get,
+          path: "/v2/links/changes",
+          query: "link_types%5B%5D=taxons",
+          headers: GdsApi::JsonClient.default_request_headers.merge(
+            "Authorization" => "Bearer #{@bearer_token}"
+          ),
+        )
+        .will_respond_with(
+          status: 200,
+          body: link_changes
+        )
+
+      response = @api_client.get_links_changes(link_types: ["taxons"])
+      assert_equal 200, response.code
+      assert_equal link_changes, response.to_hash
+    end
+  end
+
   describe "#get_content_items" do
     it "returns the content items of a certain document_type" do
       publishing_api


### PR DESCRIPTION
trello: https://trello.com/c/nYBkNBDc/294-switch-to-using-the-link-changes-endpoint-through-the-gds-api-adapters-gem

depends on: https://github.com/alphagov/publishing-api/pull/1039