### PR TITLE
Version bump to 49.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 49.0.0
+
+* Remove `GdsApi::GovUkDelivery` and helpers as `govuk-delivery` has been 
+retired in favour of `email-alert-api`
+* Add get_link_changes endpoint for publishing-api
+
 # 48.0.0
 
 * Resurrect `feedback_url` for Support (removed in 46.0.0)

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '48.0.0'.freeze
+  VERSION = '49.0.0'.freeze
 end


### PR DESCRIPTION
Support for govuk-delivery removed as it has been retired.