### PR TITLE
Add GdsApi::AssetManager#create_whitehall_asset method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
+# 49.2.0
+
+* Add GdsApi::AssetManager#create_whitehall_asset method (#752)
+
 # 49.1.0
 
 * Remove trailing slash in call to get_link_changes
 
 # 49.0.0
 
-* Remove `GdsApi::GovUkDelivery` and helpers as `govuk-delivery` has been 
+* Remove `GdsApi::GovUkDelivery` and helpers as `govuk-delivery` has been
 retired in favour of `email-alert-api`
 * Add get_link_changes endpoint for publishing-api
 

--- a/lib/gds_api/asset_manager.rb
+++ b/lib/gds_api/asset_manager.rb
@@ -47,6 +47,76 @@ class GdsApi::AssetManager < GdsApi::Base
     post_multipart("#{base_url}/assets", asset: asset)
   end
 
+  # Creates a Whitehall asset given a hash with +file+ & +legacy_url_path+
+  # attributes
+  #
+  # Makes a +POST+ request to the asset manager api to create a Whitehall asset.
+  #
+  # The asset must be provided as a +Hash+ with a +file+ attribute that behaves
+  # like a +File+ object and a +legacy_url_path+ attribute. The +content-type+
+  # that the asset manager will subsequently serve will be based *only* on the
+  # file's extension (derived from +#path+). If you supply a +content-type+ via,
+  # for example +ActionDispatch::Http::UploadedFile+ or another multipart
+  # wrapper, it will be ignored.
+  #
+  # The +legacy_url_path+ attribute is used to specify the public URL path at
+  # which the asset should be served by the Asset Manager. This differs from
+  # `#create_asset` where Asset Manager itself determines the public URL path to
+  # be used and returns that to the publishing app in the response. This
+  # endpoint is intended to be an interim measure which will help us migrate
+  # assets from Whitehall into Asset Manager without needing to change the URLs.
+  # The end goal is for Asset Manager to determine the public URL path for all
+  # assets including Whitehall assets. At that point this endpoint will become
+  # redundant and should be removed.
+  #
+  # There may be restrictions on the format of the `legacy_url_path`. If the
+  # supplied path is not valid, a `GdsApi::HTTPUnprocessableEntity` exception
+  # will be raised.
+  #
+  # Note: this endpoint should only be used by the Whitehall Admin app and not
+  # by any other publishing apps.
+  #
+  # @param asset [Hash] The attributes for the asset to send to the api. Must
+  #   contain +file+, which behaves like a +File+, and +legacy_url_path+, a
+  #   +String+. All other attributes will be ignored.
+  #
+  # @return [GdsApi::Response] The wrapped http response from the api. Behaves
+  #   both as a +Hash+ and an +OpenStruct+, and responds to the following:
+  #     :id           the URL of the asset
+  #     :name         the filename of the asset that will be served
+  #     :content_type the content_type of the asset
+  #     :file_url     the URL from which the asset will be served when it has
+  #                   passed a virus scan
+  #     :state        One of 'unscanned', 'clean', or 'infected'. Unless the state is
+  #                   'clean' the asset at the :file_url will redirect to a
+  #                   placeholder
+  #
+  # @raise [HTTPErrorResponse] if the request returns an error
+  #
+  # @example Upload a file from disk
+  #   response = asset_manager.create_asset(
+  #     file: File.new('image.jpg', 'r'),
+  #     legacy_url_path: '/government/uploads/path/to/image.jpg'
+  #   )
+  #   response['id']           #=> "http://asset-manager.dev.gov.uk/assets/576bbc52759b74196b000012"
+  #   response['content_type'] #=> "image/jpeg"
+  # @example Upload a file from a Rails param, (typically a multipart wrapper)
+  #    params[:file] #=> #<ActionDispatch::Http::UploadedFile:0x007fc60b43c5c8
+  #                      # @content_type="application/foofle",
+  #                      # @original_filename="cma_case_image.jpg",
+  #                      # @tempfile="spec/support/images/cma_case_image.jpg">
+  #
+  #    # Though we sent a file with a +content_type+ of 'application/foofle',
+  #    # this was ignored
+  #    response = asset_manager.create_asset(
+  #      file: params[:file]
+  #      legacy_url_path: '/government/uploads/path/to/cma_case_image.jpg'
+  #    )
+  #    response['content_type'] #=> "image/jpeg"
+  def create_whitehall_asset(asset)
+    post_multipart("#{base_url}/whitehall_assets", asset: asset)
+  end
+
   # Updates an asset given a hash with one +file+ attribute
   #
   # Makes a +PUT+ request to the asset manager api to update an asset.

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '49.1.0'.freeze
+  VERSION = '49.2.0'.freeze
 end

--- a/test/asset_manager_test.rb
+++ b/test/asset_manager_test.rb
@@ -34,6 +34,18 @@ describe GdsApi::AssetManager do
     assert_requested(req)
   end
 
+  it "creates a Whitehall asset with a file" do
+    req = stub_request(:post, "#{base_api_url}/whitehall_assets").
+      with { |request|
+        request.body =~ %r{Content\-Disposition: form\-data; name="asset\[file\]"; filename="hello\.txt"\r\nContent\-Type: text/plain}
+      }.to_return(body: JSON.dump(asset_manager_response), status: 201)
+
+    response = api.create_whitehall_asset(file: file_fixture, legacy_url_path: '/government/uploads/path/to/hello.txt')
+
+    assert_equal asset_url, response['asset']['id']
+    assert_requested(req)
+  end
+
   it "returns not found when an asset does not exist" do
     asset_manager_does_not_have_an_asset("not-really-here")
 


### PR DESCRIPTION
We want to expose the new Asset Manager API endpoint for creating Whitehall assets.

The main difference between the existing `GdsApi::AssetManager#create_asset` method and this new method is that the client must specify a `legacy_url_path` as well as a `file`. The former is used to *tell* Asset Manager the public URL path at which it should make the asset available.

This is intended to be an interim measure to allow us to migrate Whitehall assets to Asset Manager without changing their URLs. In the fullness of time the plan is for Asset Manager to determine the public URL paths for *all* assets, including Whitehall assets, and at that point Whitehall will need to take notice of the `file_url` returned in the response from the Asset Manager API.

Note that this new method should *only* be used by the Whitehall Admin app, not any of the other publishing applications.

See alphagov/asset-manager#203 for more info.