### PR TITLE
Update dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 * Use 1.5.0 minimum of [govuk-content-schema-test-helpers](https://github.com/alphagov/govuk-content-schema-test-helpers)
+* Remove gem_publisher dependency since rake task is no longer used to publish gem
 
 # 49.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Use 1.5.0 minimum of [govuk-content-schema-test-helpers](https://github.com/alphagov/govuk-content-schema-test-helpers)
+
 # 49.2.0
 
 * Add GdsApi::AssetManager#create_whitehall_asset method (#752)

--- a/Rakefile
+++ b/Rakefile
@@ -41,9 +41,3 @@ task :lint do
   sh "bundle exec govuk-lint-ruby --diff --cached --format clang"
 end
 
-require "gem_publisher"
-desc "Publish gem to rubygems.org if necessary"
-task :publish_gem do |_t|
-  gem = GemPublisher.publish_if_updated("gds-api-adapters.gemspec", :rubygems)
-  puts "Published #{gem}" if gem
-end

--- a/gds-api-adapters.gemspec
+++ b/gds-api-adapters.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'rest-client', '~> 2.0'
   s.add_dependency 'rack-cache'
 
-  s.add_development_dependency 'gem_publisher', '~> 1.5.0'
   s.add_development_dependency 'govuk-content-schema-test-helpers', '~> 1.5'
   s.add_development_dependency 'mocha', "> 1.0.0"
   s.add_development_dependency "minitest", "> 5.0.0"

--- a/gds-api-adapters.gemspec
+++ b/gds-api-adapters.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rack-cache'
 
   s.add_development_dependency 'gem_publisher', '~> 1.5.0'
-  s.add_development_dependency 'govuk-content-schema-test-helpers', '~> 1.4.0'
+  s.add_development_dependency 'govuk-content-schema-test-helpers', '~> 1.5'
   s.add_development_dependency 'mocha', "> 1.0.0"
   s.add_development_dependency "minitest", "> 5.0.0"
   s.add_development_dependency 'pry'


### PR DESCRIPTION
Use most up to date govuk-content-schema-test-helpers and remove unnecessary gem_publisher gem.