### PR TITLE
Fix Content-Type warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Avoid the following warning: Overriding "Content-Type" header "application/json" with "multipart/form-data; boundary=----RubyFormBoundaryX7Na6WDQqG3kLfD7" due to payload
+
 # 49.3.0
 
 * Use 1.5.0 minimum of [govuk-content-schema-test-helpers](https://github.com/alphagov/govuk-content-schema-test-helpers)

--- a/lib/gds_api/json_client.rb
+++ b/lib/gds_api/json_client.rb
@@ -59,9 +59,13 @@ module GdsApi
     end
 
     def self.default_request_with_json_body_headers
-      self.default_request_headers.merge(
+      self.default_request_headers.merge(self.json_body_headers)
+    end
+
+    def self.json_body_headers
+      {
         'Content-Type' => 'application/json',
-      )
+      }
     end
 
     DEFAULT_TIMEOUT_IN_SECONDS = 4
@@ -134,6 +138,9 @@ module GdsApi
     #                  from the Net::HTTPResponse
     def do_json_request(method, url, params = nil, additional_headers = {}, &create_response)
       begin
+        if params
+          additional_headers.merge!(self.class.json_body_headers)
+        end
         response = do_request_with_cache(method, url, (params.to_json if params), additional_headers)
       rescue RestClient::Exception => e
         # Attempt to parse the body as JSON if possible
@@ -242,20 +249,9 @@ module GdsApi
         url: url,
       }
 
-      case method
-      when :get, :delete
-        default_headers = self.class.default_request_headers
-      else
-        if params.respond_to?(:has_key?) && params[:multipart] == true
-          default_headers = self.class.default_request_headers
-        else
-          default_headers = self.class.default_request_with_json_body_headers
-        end
-      end
-
       method_params[:payload] = params
       method_params = with_timeout(method_params)
-      method_params = with_headers(method_params, default_headers, additional_headers)
+      method_params = with_headers(method_params, self.class.default_request_headers, additional_headers)
       method_params = with_auth_options(method_params)
       if URI.parse(url).is_a? URI::HTTPS
         method_params = with_ssl_options(method_params)

--- a/lib/gds_api/json_client.rb
+++ b/lib/gds_api/json_client.rb
@@ -246,7 +246,11 @@ module GdsApi
       when :get, :delete
         default_headers = self.class.default_request_headers
       else
-        default_headers = self.class.default_request_with_json_body_headers
+        if params.respond_to?(:has_key?) && params[:multipart] == true
+          default_headers = self.class.default_request_headers
+        else
+          default_headers = self.class.default_request_with_json_body_headers
+        end
       end
 
       method_params[:payload] = params

--- a/test/json_client_test.rb
+++ b/test/json_client_test.rb
@@ -762,6 +762,22 @@ class JsonClientTest < MiniTest::Spec
     assert_equal "hello", response["test"]
   end
 
+  def test_client_does_not_send_content_type_header_for_multipart_post
+    RestClient::Request.expects(:execute).with do |args|
+      args[:headers]['Content-Type'].nil?
+    end
+
+    @client.post_multipart('http://example.com', {})
+  end
+
+  def test_client_does_not_send_content_type_header_for_multipart_put
+    RestClient::Request.expects(:execute).with do |args|
+      args[:headers]['Content-Type'].nil?
+    end
+
+    @client.put_multipart('http://example.com', {})
+  end
+
   def test_client_can_post_multipart_responses
     url = "http://some.endpoint/some.json"
     stub_request(:post, url).


### PR DESCRIPTION
This change removes the following warning we were seeing when running the tests in this project, and when using the `AssetManager#create_asset`, `#create_whitehall_asset` and `#update_asset` methods in other project:

```
warning: Overriding "Content-Type" header "application/json" with "multipart/form-data; boundary=----RubyFormBoundaryX7Na6WDQqG3kLfD7" due to payload
```

Addresses issue #757.
