### PR TITLE
Bump version to 49.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 49.3.1
 
 * Avoid the following warning: Overriding "Content-Type" header "application/json" with "multipart/form-data; boundary=----RubyFormBoundaryX7Na6WDQqG3kLfD7" due to payload
 

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '49.3.0'.freeze
+  VERSION = '49.3.1'.freeze
 end


### PR DESCRIPTION
I think that fixing a warning counts as a backwards-compatible bug fix so I've incremented the PATCH version as per [Semantic Versioning 2.0.0][1].

[1]: http://semver.org/