### PR TITLE
Document optional legacy attributes for GdsApi::AssetManager#create_whitehall_asset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+* Document new optional `legacy_etag` & `legacy_last_modified` attributes that
+can be passed into `GdsApi::AssetManager#create_whitehall_asset` within the
+`asset` Hash
+
 # 49.3.1
 
 * Avoid the following warning: Overriding "Content-Type" header "application/json" with "multipart/form-data; boundary=----RubyFormBoundaryX7Na6WDQqG3kLfD7" due to payload

--- a/lib/gds_api/asset_manager.rb
+++ b/lib/gds_api/asset_manager.rb
@@ -48,7 +48,7 @@ class GdsApi::AssetManager < GdsApi::Base
   end
 
   # Creates a Whitehall asset given a hash with +file+ & +legacy_url_path+
-  # attributes
+  # (required) and +legacy_etag+ & +legacy_last_modified+ (optional) attributes
   #
   # Makes a +POST+ request to the asset manager api to create a Whitehall asset.
   #
@@ -73,12 +73,22 @@ class GdsApi::AssetManager < GdsApi::Base
   # supplied path is not valid, a `GdsApi::HTTPUnprocessableEntity` exception
   # will be raised.
   #
+  # The optional +legacy_etag+ & +legacy_last_modified+ attributes allow the
+  # client to specify the values that should be used in the `ETag` &
+  # `Last-Modified` response headers when the asset is requested via its public
+  # URL. They are only intended to be used for migrating existing Whitehall
+  # assets to Asset Manager so that we can avoid wholesale cache invalidation.
+  # New Whitehall assets should not specify values for these attributes; Asset
+  # Manager will generate suitable values.
+  #
   # Note: this endpoint should only be used by the Whitehall Admin app and not
   # by any other publishing apps.
   #
   # @param asset [Hash] The attributes for the asset to send to the api. Must
   #   contain +file+, which behaves like a +File+, and +legacy_url_path+, a
-  #   +String+. All other attributes will be ignored.
+  #   +String+. May contain +legacy_etag+, a +String+, and
+  #   +legacy_last_modified+, a +Time+ object. All other attributes will be
+  #   ignored.
   #
   # @return [GdsApi::Response] The wrapped http response from the api. Behaves
   #   both as a +Hash+ and an +OpenStruct+, and responds to the following:


### PR DESCRIPTION
In alphagov/asset-manager#242, the Asset Manager API will be changed to accept these optional attributes. The idea is that they will only be used to move *existing* Whitehall assets into Asset Manager in order to avoid wholesale cache invalidation. They should not be used when creating *new* Whitehall assets.

Note that I didn't need to change any of the code to support this, because the `asset` Hash parameter already allowed arbitrary attributes to be passed into the `GdsApi::AssetManager#create_whitehall_asset` method.

I plan to hold off merging this until alphagov/asset-manager#242 is merged.
