### PR TITLE
Bump version to 49.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
-# Unreleased
+# 49.4.0
 
 * Document new optional `legacy_etag` & `legacy_last_modified` attributes that
 can be passed into `GdsApi::AssetManager#create_whitehall_asset` within the
-`asset` Hash
+`asset` Hash (#760)
 
 # 49.3.1
 

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '49.3.1'.freeze
+  VERSION = '49.4.0'.freeze
 end


### PR DESCRIPTION
The only change is a documentation change (#760).

I've made this a minor version change as recommended by @cbaines in [this comment](https://github.com/alphagov/gds-api-adapters/pull/761#discussion_r142612301).