### PR TITLE
Pass auth headers for rummager search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 49.5.0
+
+* Allow rummager search to pass additional headers
+
 # 49.4.0
 
 * Document new optional `legacy_etag` & `legacy_last_modified` attributes that

--- a/lib/gds_api/rummager.rb
+++ b/lib/gds_api/rummager.rb
@@ -9,9 +9,9 @@ module GdsApi
     # @param args [Hash] A valid search query. See Rummager documentation for options.
     #
     # @see https://github.com/alphagov/rummager/blob/master/docs/search-api.md
-    def search(args)
+    def search(args, additional_headers = {})
       request_url = "#{base_url}/search.json?#{Rack::Utils.build_nested_query(args)}"
-      get_json(request_url)
+      get_json(request_url, additional_headers)
     end
 
     # Advanced search.

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '49.4.0'.freeze
+  VERSION = '49.5.0'.freeze
 end

--- a/test/rummager_test.rb
+++ b/test/rummager_test.rb
@@ -132,6 +132,12 @@ describe GdsApi::Rummager do
     assert_requested :get, /order=-public_timestamp/
   end
 
+  it "#search can pass additional headers" do
+    GdsApi::Rummager.new("http://example.com").search({ q: "query" }, "authorization" => "token")
+
+    assert_requested :get, /.*/, headers: { "authorization" => "token" }
+  end
+
   it "#delete_content removes a document" do
     request = stub_request(:delete, "http://example.com/content?link=/foo/bar")
 


### PR DESCRIPTION
Add auth headers to rummager search 
This allows us to pass auth headers for the integration environment

https://trello.com/c/maUNAb1Y/168-get-the-search-performance-explorer-to-work-comparing-two-separate-hosts