### PR TITLE
Add method to get Whitehall Assets

### DIFF
--- a/lib/gds_api/asset_manager.rb
+++ b/lib/gds_api/asset_manager.rb
@@ -127,6 +127,18 @@ class GdsApi::AssetManager < GdsApi::Base
     post_multipart("#{base_url}/whitehall_assets", asset: asset)
   end
 
+  # Fetches a Whitehall asset given the legacy URL path
+  #
+  # @param legacy_url_path [String] The Whitehall asset identifier.
+  # @return [GdsApi::Response] A response object containing the parsed JSON
+  #   response. If the asset cannot be found, +GdsApi::HTTPNotFound+ will be
+  #   raised.
+  #
+  # @raise [HTTPErrorResponse] if the request returns an error
+  def whitehall_asset(legacy_url_path)
+    get_json("#{base_url}/whitehall_assets/#{legacy_url_path}")
+  end
+
   # Updates an asset given a hash with one +file+ attribute
   #
   # Makes a +PUT+ request to the asset manager api to update an asset.

--- a/lib/gds_api/test_helpers/asset_manager.rb
+++ b/lib/gds_api/test_helpers/asset_manager.rb
@@ -10,12 +10,28 @@ module GdsApi
           .to_return(body: response.to_json, status: 200)
       end
 
+      def asset_manager_has_a_whitehall_asset(legacy_url_path, atts)
+        response = atts.merge("_response_info" => { "status" => "ok" })
+
+        stub_request(:get, "#{ASSET_MANAGER_ENDPOINT}/whitehall_assets/#{legacy_url_path}")
+          .to_return(body: response.to_json, status: 200)
+      end
+
       def asset_manager_does_not_have_an_asset(id)
         response = {
           "_response_info" => { "status" => "not found" }
         }
 
         stub_request(:get, "#{ASSET_MANAGER_ENDPOINT}/assets/#{id}")
+          .to_return(body: response.to_json, status: 404)
+      end
+
+      def asset_manager_does_not_have_a_whitehall_asset(legacy_url_path)
+        response = {
+          "_response_info" => { "status" => "not found" }
+        }
+
+        stub_request(:get, "#{ASSET_MANAGER_ENDPOINT}/whitehall_assets/#{legacy_url_path}")
           .to_return(body: response.to_json, status: 404)
       end
 

--- a/test/asset_manager_test.rb
+++ b/test/asset_manager_test.rb
@@ -54,6 +54,14 @@ describe GdsApi::AssetManager do
     end
   end
 
+  it "raises not found when a Whitehall asset does not exist" do
+    asset_manager_does_not_have_a_whitehall_asset("/path/to/non-existent-asset.png")
+
+    assert_raises GdsApi::HTTPNotFound do
+      api.whitehall_asset("/path/to/non-existent-asset.png")
+    end
+  end
+
   describe "an asset exists" do
     before do
       asset_manager_has_an_asset(
@@ -82,6 +90,21 @@ describe GdsApi::AssetManager do
       assert_equal "photo.jpg", asset['name']
       assert_equal "image/jpeg", asset['content_type']
       assert_equal "http://fooey.gov.uk/media/photo.jpg", asset['file_url']
+    end
+  end
+
+  describe "a Whitehall asset exists" do
+    before do
+      asset_manager_has_a_whitehall_asset(
+        "/government/uploads/photo.jpg",
+        "id" => "asset-id"
+      )
+    end
+
+    it "retrieves an asset" do
+      asset = api.whitehall_asset("/government/uploads/photo.jpg")
+
+      assert_equal "asset-id", asset['id']
     end
   end
 


### PR DESCRIPTION
This adds a method for the behaviour added to Asset Manager in
https://github.com/alphagov/asset-manager/pull/264.