### PR TITLE
Bump version to 49.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 49.6.0
+
+* Add GdsApi::AssetManager#whitehall_asset method for retrieving Whitehall assets from Asset Manager.
+
 # 49.5.0
 
 * Allow rummager search to pass additional headers

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '49.5.0'.freeze
+  VERSION = '49.6.0'.freeze
 end


### PR DESCRIPTION
This is a minor version increase according to Semantic Versioning[1]
because it includes the addition of functionality in a
backwards-compatible manner.

[1]: http://semver.org/