### PR TITLE
Bump version to 49.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+# 49.7.0
 
 * Add GdsApi::LinkCheckerApi#upsert_resource_monitor method for creating/updating a collection of monitored links for an application.
 

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '49.6.0'.freeze
+  VERSION = '49.7.0'.freeze
 end


### PR DESCRIPTION
Add support to LinkCheckerApi#upsert_resource_monitor

—

This is a minor version increase according to Semantic Versioning[1]
because it includes the addition of functionality in a
backwards-compatible manner.

[1]: http://semver.org/