### PR TITLE
Add GdsApi::EmailAlertApi#unsubscribe

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -40,4 +40,3 @@ desc "Run the linter against changed files"
 task :lint do
   sh "bundle exec govuk-lint-ruby --diff --cached --format clang"
 end
-

--- a/lib/gds_api/email_alert_api.rb
+++ b/lib/gds_api/email_alert_api.rb
@@ -88,6 +88,15 @@ class GdsApi::EmailAlertApi < GdsApi::Base
     get_json("#{endpoint}/topic-matches.json?#{query_string}")
   end
 
+  # Unsubscribe
+  # #
+  # @param uuid Subscription uuid
+  #
+  # @return [Hash] deleted
+  def unsubscribe(uuid)
+    post_json("#{endpoint}/unsubscribe/#{uuid}")
+  end
+
 private
 
   def nested_query_string(params)

--- a/lib/gds_api/test_helpers/email_alert_api.rb
+++ b/lib/gds_api/test_helpers/email_alert_api.rb
@@ -93,6 +93,22 @@ module GdsApi
         )
       end
 
+      def email_alert_api_unsubscribes_a_subscription(uuid)
+        stub_request(:post, unsubscribe_url(uuid))
+          .with(body: "{}")
+          .to_return(status: 204)
+      end
+
+      def email_alert_api_has_no_subscription_for_uuid(uuid)
+        stub_request(:post, unsubscribe_url(uuid))
+          .with(body: "{}")
+          .to_return(status: 404)
+      end
+
+      def assert_unsubscribed(uuid)
+        assert_requested(:post, unsubscribe_url(uuid), times: 1)
+      end
+
     private
 
       def subscriber_lists_url(attributes = nil)
@@ -121,6 +137,10 @@ module GdsApi
 
       def notifications_url
         EMAIL_ALERT_API_ENDPOINT + "/notifications"
+      end
+
+      def unsubscribe_url(uuid)
+        EMAIL_ALERT_API_ENDPOINT + "/unsubscribe/#{uuid}"
       end
     end
   end

--- a/test/email_alert_api_test.rb
+++ b/test/email_alert_api_test.rb
@@ -261,4 +261,30 @@ describe GdsApi::EmailAlertApi do
       assert_requested(@stubbed_request)
     end
   end
+
+  describe "unsubscribing" do
+    describe "with an existing subscription" do
+      it "returns a 204" do
+        uuid = SecureRandom.uuid
+        email_alert_api_unsubscribes_a_subscription(uuid)
+        api_response = api_client.unsubscribe(uuid)
+
+        assert_equal(
+          api_response.code,
+          204
+        )
+      end
+    end
+
+    describe "without an existing subscription" do
+      it "returns a 404" do
+        uuid = SecureRandom.uuid
+        email_alert_api_has_no_subscription_for_uuid(uuid)
+
+        assert_raises GdsApi::HTTPNotFound do
+          api_client.unsubscribe(uuid)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Add unsubscribe endpoint for Email Alert Api to allow Email Alert
Frontend to complete unsubscribe requests.

Relies on [PR 251](https://github.com/alphagov/email-alert-api/pull/251) in Email Alert Api being finalised and merged.

This PR currently assumes that Email Alert Api will return JSON, but if it does not, then we should update the tests here to reflect the actual returned body.

[Trello card](https://trello.com/c/Ba7F7Iny/389-add-functionality-to-email-alert-frontend-to-support-unsubscriptions)