### PR TITLE
add #get_paged_content_items to publishing_api_v2

### DIFF
--- a/lib/gds_api/publishing_api_v2.rb
+++ b/lib/gds_api/publishing_api_v2.rb
@@ -315,6 +315,28 @@ class GdsApi::PublishingApiV2 < GdsApi::Base
     get_json("#{endpoint}/v2/content#{query}")
   end
 
+  # Returns an Enumerator of content items for the provided
+  # query string parameters.
+  #
+  # @param params [Hash]
+  #
+  # @return [Enumerator] an enumerator of content items
+  #
+  # @see https://github.com/alphagov/publishing-api/blob/master/doc/api.md#get-v2content
+  def get_content_items_enum(params)
+    Enumerator.new do |yielder|
+      (1..Float::INFINITY).each do |index|
+        merged_params = params.merge(page: index)
+        page = get_content_items(merged_params).to_h
+        results = page.fetch('results', [])
+        results.each do |result|
+          yielder << result
+        end
+        break if page.fetch('pages') <= index
+      end
+    end
+  end
+
   # FIXME: Add documentation
   #
   # @see https://github.com/alphagov/publishing-api/blob/master/doc/api.md#get-v2linkables

--- a/test/publishing_api_v2_test.rb
+++ b/test/publishing_api_v2_test.rb
@@ -1278,6 +1278,71 @@ describe GdsApi::PublishingApiV2 do
     end
   end
 
+  describe "#get_paged_content_items" do
+    it "returns two content items" do
+      publishing_api
+        .given("there are four content items with document_type 'topic'")
+        .upon_receiving("get the first page request")
+        .with(
+          method: :get,
+          path: "/v2/content",
+          query: 'document_type=topic&fields%5B%5D=title&fields%5B%5D=base_path&page=1&per_page=2',
+          headers: GdsApi::JsonClient.default_request_headers.merge(
+            "Authorization" => "Bearer #{@bearer_token}"
+          ),
+        )
+        .will_respond_with(
+          status: 200,
+          body: {
+            total: 4,
+            pages: 2,
+            current_page: 1,
+            links: [{ href: "http://example.org/v2/content?document_type=topic&fields[]=title&fields[]=base_path&per_page=2&page=2",
+                     rel: "next" },
+                    { href: "http://example.org/v2/content?document_type=topic&fields[]=title&fields[]=base_path&per_page=2&page=1",
+                      rel: "self" }],
+            results: [
+              { title: 'title_1', base_path: '/path_1' },
+              { title: 'title_2', base_path: '/path_2' },
+            ]
+          }
+        )
+      publishing_api
+        .given("there are four content items with document_type 'topic'")
+        .upon_receiving("get the second page request")
+        .with(
+          method: :get,
+          path: "/v2/content",
+          query: 'document_type=topic&fields%5B%5D=title&fields%5B%5D=base_path&page=2&per_page=2',
+          headers: GdsApi::JsonClient.default_request_headers.merge(
+            "Authorization" => "Bearer #{@bearer_token}"
+          ),
+        )
+        .will_respond_with(
+          status: 200,
+          body: {
+            total: 4,
+            pages: 2,
+            current_page: 2,
+            links: [{ href: "http://example.org/v2/content?document_type=topic&fields[]=title&fields[]=base_path&per_page=2&page=1",
+                      rel: "previous" },
+                    { href: "http://example.org/v2/content?document_type=topic&fields[]=title&fields[]=base_path&per_page=2&page=2",
+                      rel: "self" }],
+            results: [
+              { title: 'title_3', base_path: '/path_3' },
+              { title: 'title_4', base_path: '/path_4' },
+            ]
+          },
+        )
+      assert_equal(@api_client.get_content_items_enum(document_type: 'topic', fields: %i[title base_path], per_page: 2).to_a,
+                  [{ 'title' => 'title_1', 'base_path' => '/path_1' },
+                   { 'title' => 'title_2', 'base_path' => '/path_2' },
+                   { 'title' => 'title_3', 'base_path' => '/path_3' },
+                   { 'title' => 'title_4', 'base_path' => '/path_4' }])
+    end
+  end
+
+
   describe "#get_content_items" do
     it "returns the content items of a certain document_type" do
       publishing_api


### PR DESCRIPTION
Adds a method to get content items from the publishing api as an enumerator.
This abstracts away the  paging mechanism and fetches new pages as more 
results are requested.

Use case: https://trello.com/c/ZIOFIqoT/162-bulk-tag-content-items-that-belongs-to-a-single-taxon

needs pact in: https://github.com/alphagov/publishing-api/pull/1073