### PR TITLE
Add subscribe method to email-alert-api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+Unreleased
+
+* Add GdsApi::EmailAlertApi#subscribe to allow users to subscribe to emails
+
 # 50.1.0
 
 * Add GdsApi::EmailAlertApi#unsubscribe to allow users to unsubscribe from emails.

--- a/lib/gds_api/email_alert_api.rb
+++ b/lib/gds_api/email_alert_api.rb
@@ -97,6 +97,17 @@ class GdsApi::EmailAlertApi < GdsApi::Base
     post_json("#{endpoint}/unsubscribe/#{uuid}")
   end
 
+  # Subscribe
+  #
+  # @return [Hash] subscription_id
+  def subscribe(subscribable_id:, address:)
+    post_json(
+      "#{endpoint}/subscriptions",
+      subscribable_id: subscribable_id,
+      address: address,
+    )
+  end
+
 private
 
   def nested_query_string(params)

--- a/lib/gds_api/test_helpers/email_alert_api.rb
+++ b/lib/gds_api/test_helpers/email_alert_api.rb
@@ -105,8 +105,31 @@ module GdsApi
           .to_return(status: 404)
       end
 
+      def email_alert_api_creates_a_subscription(subscribable_id, address, returned_subscription_id)
+        stub_request(:post, subscribe_url)
+          .with(
+            body: { subscribable_id: subscribable_id, address: address }.to_json
+        ).to_return(status: 201, body: { subscription_id: returned_subscription_id }.to_json)
+      end
+
+      def email_alert_api_creates_an_existing_subscription(subscribable_id, address, returned_subscription_id)
+        stub_request(:post, subscribe_url)
+          .with(
+            body: { subscribable_id: subscribable_id, address: address }.to_json
+        ).to_return(status: 200, body: { subscription_id: returned_subscription_id }.to_json)
+      end
+
       def assert_unsubscribed(uuid)
         assert_requested(:post, unsubscribe_url(uuid), times: 1)
+      end
+
+      def assert_subscribed(subscribable_id, address)
+        assert_requested(:post, subscribe_url) do |req|
+          JSON.parse(req.body).symbolize_keys == {
+            subscribable_id: subscribable_id,
+            address: address
+          }
+        end
       end
 
     private
@@ -141,6 +164,10 @@ module GdsApi
 
       def unsubscribe_url(uuid)
         EMAIL_ALERT_API_ENDPOINT + "/unsubscribe/#{uuid}"
+      end
+
+      def subscribe_url
+        EMAIL_ALERT_API_ENDPOINT + "/subscriptions"
       end
     end
   end

--- a/test/email_alert_api_test.rb
+++ b/test/email_alert_api_test.rb
@@ -287,4 +287,38 @@ describe GdsApi::EmailAlertApi do
       end
     end
   end
+
+  describe "subscribing and a subscription is created" do
+    it "returns a 201 and the subscription id" do
+      subscribable_id = 5
+      address = "test@test.com"
+      created_subscription_id = 1
+
+      email_alert_api_creates_a_subscription(
+        subscribable_id,
+        address,
+        created_subscription_id
+      )
+      api_response = api_client.subscribe(subscribable_id: subscribable_id, address: address)
+      assert_equal(201, api_response.code)
+      assert_equal({ "subscription_id" => 1 }, api_response.to_h)
+    end
+  end
+
+  describe "subscribing and a subscription already exists" do
+    it "returns a 200 and the subscription id" do
+      subscribable_id = 5
+      address = "test@test.com"
+      existing_subscription_id = 1
+
+      email_alert_api_creates_an_existing_subscription(
+        subscribable_id,
+        address,
+        existing_subscription_id
+      )
+      api_response = api_client.subscribe(subscribable_id: subscribable_id, address: address)
+      assert_equal(200, api_response.code)
+      assert_equal({ "subscription_id" => 1 }, api_response.to_h)
+    end
+  end
 end


### PR DESCRIPTION
This PR adds a method to the email-alert-api client to support creating subscriptions. Also adds test helpers.

[Trello](https://trello.com/c/YtmHgU3b/408-add-page-to-email-alert-frontend-to-capture-a-users-email-address)