### PR TITLE
Add document_type list and summary endpoints for support-api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+* Add GdsApi::SupportApi#document_type_list to retrieve list of formats for content items
+* Add GdsApi::SupportApi#document_type_summary to retrieve feedback associated with content items of a certain format.
+
 # 50.6.0
 
 * Add `with_drafts` optional parameter to GdsApi::PublishingApiV2#lookup_content_ids and GdsApi::PublishingApiV2#lookup_content_id

--- a/lib/gds_api/support_api.rb
+++ b/lib/gds_api/support_api.rb
@@ -65,6 +65,15 @@ class GdsApi::SupportApi < GdsApi::Base
     get_json("#{endpoint}/organisations/#{organisation_slug}")
   end
 
+  def document_type_list
+    get_json("#{endpoint}/anonymous-feedback/document-types")
+  end
+
+  def document_type_summary(document_type, options = {})
+    uri = "#{endpoint}/anonymous-feedback/document-types/#{document_type}" + query_string(options)
+    get_json(uri)
+  end
+
   def feedback_export_request(id)
     get_json("#{endpoint}/anonymous-feedback/export-requests/#{id}")
   end

--- a/lib/gds_api/test_helpers/support_api.rb
+++ b/lib/gds_api/test_helpers/support_api.rb
@@ -80,13 +80,22 @@ module GdsApi
       end
 
       def stub_support_api_organisations_list(response_body = nil)
-        response_body ||= [{
-          slug: "cabinet-office",
-          web_url: "https://www.gov.uk/government/organisations/cabinet-office",
-          title: "Cabinet Office",
-          acronym: "CO",
-          govuk_status: "live"
-        }]
+        response_body ||= [
+          {
+            slug: "cabinet-office",
+            web_url: "https://www.gov.uk/government/organisations/cabinet-office",
+            title: "Cabinet Office",
+            acronym: "CO",
+            govuk_status: "live"
+          },
+          {
+            slug: "gds",
+            web_url: "https://www.gov.uk/government/organisations/gds",
+            title: "Government Digital Service",
+            acronym: "GDS",
+            govuk_status: "live"
+          }
+        ]
 
         stub_http_request(:get, "#{SUPPORT_API_ENDPOINT}/organisations").
           to_return(status: 200, body: response_body.to_json)
@@ -103,6 +112,20 @@ module GdsApi
 
         stub_http_request(:get, "#{SUPPORT_API_ENDPOINT}/organisations/#{slug}").
           to_return(status: 200, body: response_body.to_json)
+      end
+
+      def stub_support_api_document_type_list(response_body = nil)
+        response_body ||= %w(case_study detailed_guide smart_answer)
+
+        stub_http_request(:get, "#{SUPPORT_API_ENDPOINT}/anonymous-feedback/document-types").
+            to_return(status: 200, body: response_body.to_json)
+      end
+
+      def stub_support_api_anonymous_feedback_doc_type_summary(document_type, ordering = nil, response_body = nil)
+        uri = "#{SUPPORT_API_ENDPOINT}/anonymous-feedback/document-types/#{document_type}"
+        uri << "?ordering=#{ordering}" if ordering
+        stub_http_request(:get, uri).
+            to_return(status: 200, body: response_body.to_json)
       end
 
       def stub_support_api_feedback_export_request(id, response_body = nil)

--- a/test/support_api_test.rb
+++ b/test/support_api_test.rb
@@ -61,12 +61,12 @@ describe GdsApi::SupportApi do
   describe "GET /anonymous-feedback" do
     it "fetches anonymous feedback" do
       stub_get = stub_support_api_anonymous_feedback(
-        path_prefix: "/vat-rates",
+        path_prefixes: ["/vat-rates"],
         page: 55,
       )
 
       @api.anonymous_feedback(
-        path_prefix: "/vat-rates",
+        path_prefixes: ["/vat-rates"],
         page: 55,
       )
 
@@ -153,6 +153,39 @@ describe GdsApi::SupportApi do
       stub_get = stub_support_api_organisation("foo")
 
       @api.organisation("foo")
+
+      assert_requested(stub_get)
+    end
+  end
+
+  describe "GET /anonymous-feedback/document-types" do
+    it "fetches a list of document types" do
+      stub_get = stub_support_api_document_type_list
+
+      @api.document_type_list
+
+      assert_requested(stub_get)
+    end
+  end
+
+  describe "GET /anonymous-feedback/document-types/:document_type" do
+    it "fetches document type summary" do
+      document_type = "smart_answer"
+
+      stub_get = stub_support_api_anonymous_feedback_doc_type_summary(document_type)
+
+      @api.document_type_summary(document_type)
+
+      assert_requested(stub_get)
+    end
+
+    it "accepts an ordering parameter" do
+      document_type = "smart_answer"
+      ordering = "last_30_days"
+
+      stub_get = stub_support_api_anonymous_feedback_doc_type_summary(document_type, ordering)
+
+      @api.document_type_summary(document_type, ordering: ordering)
 
       assert_requested(stub_get)
     end


### PR DESCRIPTION
Adds endpoints for fetching document type from support-api:

- the GET `document_type_list` endpoint of `support-api` which returns a list of document types. This will be shown in a dropdown to choose from in Feedex (`support` app) in order to filter feedback
- the GET `document_type_summary` endpoint of `support-api` which presents Feedex users with an overview of which pages have had the most feedback left recently on them (`feedback counts`)

As implemented in alphagov/support-api#121

For: https://trello.com/c/IB9P5EyE/266-introduce-new-browse-options-for-feedex