### PR TITLE
Add the ‘email_alert_api_refuses_to_create_subscription’ helper

### DIFF
--- a/lib/gds_api/test_helpers/email_alert_api.rb
+++ b/lib/gds_api/test_helpers/email_alert_api.rb
@@ -119,6 +119,13 @@ module GdsApi
         ).to_return(status: 200, body: { subscription_id: returned_subscription_id }.to_json)
       end
 
+      def email_alert_api_refuses_to_create_subscription(subscribable_id, address)
+        stub_request(:post, subscribe_url)
+          .with(
+            body: { subscribable_id: subscribable_id, address: address }.to_json
+        ).to_return(status: 422)
+      end
+
       def assert_unsubscribed(uuid)
         assert_requested(:post, unsubscribe_url(uuid), times: 1)
       end

--- a/test/email_alert_api_test.rb
+++ b/test/email_alert_api_test.rb
@@ -322,6 +322,16 @@ describe GdsApi::EmailAlertApi do
     end
   end
 
+  describe "subscribing with an invalid address" do
+    it "raises an unprocessable entity error" do
+      email_alert_api_refuses_to_create_subscription(123, "invalid")
+
+      assert_raises GdsApi::HTTPUnprocessableEntity do
+        api_client.subscribe(subscribable_id: 123, address: "invalid")
+      end
+    end
+  end
+
   describe "get_subscribable when one exists" do
     it "returns it" do
       email_alert_api_has_subscribable(


### PR DESCRIPTION
https://trello.com/c/amAa5HkV/444-handle-error-cases-for-capturing-a-users-email-address

This will be used to test that
email-alert-frontend guards against validation
errors that could be raised in email-alert-api
when creating a subscription.