### PR TITLE
Include with_drafts param for /lookup-by-base-path endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Add `with_drafts` optional parameter to GdsApi::PublishingApiV2#lookup_content_ids and GdsApi::PublishingApiV2#lookup_content_id
+
 # 50.5.0
 
 * Add #email_alert_api_refuses_to_create_subscription test helper for

--- a/lib/gds_api/publishing_api_v2.rb
+++ b/lib/gds_api/publishing_api_v2.rb
@@ -43,6 +43,7 @@ class GdsApi::PublishingApiV2 < GdsApi::Base
   # @param base_paths [Array]
   # @param exclude_document_types [Array] (optional)
   # @param exclude_unpublishing_types [Array] (optional)
+  # @param with_drafts [Boolean] (optional)
   # @return [Hash] a hash, keyed by `base_path` with `content_id` as value
   # @example
   #
@@ -50,10 +51,11 @@ class GdsApi::PublishingApiV2 < GdsApi::Base
   #   # => { "/foo" => "51ac4247-fd92-470a-a207-6b852a97f2db", "/bar" => "261bd281-f16c-48d5-82d2-9544019ad9ca" }
   #
   # @see https://github.com/alphagov/publishing-api/blob/master/doc/api.md#post-lookup-by-base-path
-  def lookup_content_ids(base_paths:, exclude_document_types: nil, exclude_unpublishing_types: nil)
+  def lookup_content_ids(base_paths:, exclude_document_types: nil, exclude_unpublishing_types: nil, with_drafts: false)
     options = { base_paths: base_paths }
     options[:exclude_document_types] = exclude_document_types if exclude_document_types
     options[:exclude_unpublishing_types] = exclude_unpublishing_types if exclude_unpublishing_types
+    options[:with_drafts] = with_drafts if with_drafts
     response = post_json("#{endpoint}/lookup-by-base-path", options)
     response.to_hash
   end
@@ -66,6 +68,7 @@ class GdsApi::PublishingApiV2 < GdsApi::Base
   # @param base_path [String]
   # @param exclude_document_types [Array] (optional)
   # @param exclude_unpublishing_types [Array] (optional)
+  # @param with_drafts [Boolean] (optional)
   #
   # @return [UUID] the `content_id` for the `base_path`
   #
@@ -75,11 +78,12 @@ class GdsApi::PublishingApiV2 < GdsApi::Base
   #   # => "51ac4247-fd92-470a-a207-6b852a97f2db"
   #
   # @see https://github.com/alphagov/publishing-api/blob/master/doc/api.md#post-lookup-by-base-path
-  def lookup_content_id(base_path:, exclude_document_types: nil, exclude_unpublishing_types: nil)
+  def lookup_content_id(base_path:, exclude_document_types: nil, exclude_unpublishing_types: nil, with_drafts: false)
     lookups = lookup_content_ids(
       base_paths: [base_path],
       exclude_document_types: exclude_document_types,
-      exclude_unpublishing_types: exclude_unpublishing_types
+      exclude_unpublishing_types: exclude_unpublishing_types,
+      with_drafts: with_drafts,
     )
     lookups[base_path]
   end

--- a/test/publishing_api_v2/lookup_test.rb
+++ b/test/publishing_api_v2/lookup_test.rb
@@ -35,6 +35,33 @@ describe GdsApi::PublishingApiV2 do
 
       assert_equal "08f86d00-e95f-492f-af1d-470c5ba4752e", content_id
     end
+
+    it "returns the content_id of a draft document for a base_path" do
+      publishing_api
+        .given("there is a draft content item with base_path /foo")
+        .upon_receiving("a /lookup-by-base-path-request")
+        .with(
+          method: :post,
+          path: "/lookup-by-base-path",
+          body: {
+            base_paths: ["/foo"],
+            with_drafts: true,
+          },
+          headers: {
+            "Content-Type" => "application/json",
+          },
+        )
+        .will_respond_with(
+          status: 200,
+          body: {
+            "/foo" => "cbb460a7-60de-4a74-b5be-0b27c6d6af9b"
+          }
+        )
+
+      content_id = @api_client.lookup_content_id(base_path: "/foo", with_drafts: true)
+
+      assert_equal "cbb460a7-60de-4a74-b5be-0b27c6d6af9b", content_id
+    end
   end
 
   describe "#lookup_content_ids" do


### PR DESCRIPTION
Update the lookup_content_ids and lookup_content_id to take the new
optional parameter `with_draft` [1].

[1] https://github.com/alphagov/publishing-api/pull/1076