### PR TITLE
Bump version to 50.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 50.7.0
 
 * Add GdsApi::SupportApi#document_type_list to retrieve list of formats for content items
 * Add GdsApi::SupportApi#document_type_summary to retrieve feedback associated with content items of a certain format.

--- a/gds-api-adapters.gemspec
+++ b/gds-api-adapters.gemspec
@@ -35,6 +35,9 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'simplecov-rcov'
   s.add_development_dependency 'timecop', '~> 0.9.1'
   s.add_development_dependency 'webmock', '~> 3.1.1'
+  # Versions of webrick > 1.3.1 only work with ruby >= 2.3.
+  # We specify webrick to be 1.3.1 here because in our CI builds we are testing with ruby versions 2.1 and 2.2.
+  s.add_development_dependency 'webrick', '1.3.1'
 
   s.add_development_dependency 'pact', '1.19.2'
   s.add_development_dependency 'pact-mock_service', '2.6.2'

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '50.6.0'.freeze
+  VERSION = '50.7.0'.freeze
 end


### PR DESCRIPTION
## Background

When attempting to bump `gds-api-adapters` in [this PR](https://github.com/alphagov/gds-api-adapters/pull/788) we ran into a problem with webrick [failing to be installed](https://ci.integration.publishing.service.gov.uk/job/gds-api-adapters/job/version-5-7-0/4/console).

This was because two new webrick versions [have been launched (1.4.0, 1.4.1)](https://rubygems.org/gems/webrick/versions/1.3.1). 

These new versions expect ruby > 2.3.0, but we test for ruby version 2.1 and 2.2 [when building `gds-api-adapters`](https://github.com/alphagov/gds-api-adapters/blob/master/Jenkinsfile#L6) so this will fail to build. 

To solve this, we've locked the version of webrick to 1.3.1 by adding it to the gem's .gemspec file

For this card: https://trello.com/c/IB9P5EyE/266-introduce-new-browse-options-for-feedex
