### PR TITLE
Add V2 api endpoints for rummager

### DIFF
--- a/lib/gds_api/rummager.rb
+++ b/lib/gds_api/rummager.rb
@@ -28,23 +28,19 @@ module GdsApi
     class V2 < SimpleDelegator
       class InvalidIndex < StandardError; end
 
-      def add_document(type, id, document, index_name)
+      def add_document(id, document, index_name)
         raise(InvalidIndex, index_name) unless index_name == 'metasearch'
         post_json(
           "#{base_url}/v2/metasearch/documents",
           document.merge(
-            _type: type,
             _id: id,
           )
         )
       end
 
-      def delete_document(type, id, index_name)
+      def delete_document(id, index_name)
         raise(InvalidIndex, index_name) unless index_name == 'metasearch'
-        delete_json(
-          "#{base_url}/v2/metasearch/documents/#{id}",
-          _type: type,
-        )
+        delete_json("#{base_url}/v2/metasearch/documents/#{id}")
       end
     end
 

--- a/test/rummager_test.rb
+++ b/test/rummager_test.rb
@@ -186,4 +186,54 @@ describe GdsApi::Rummager do
 
     assert_requested(request)
   end
+
+  it "#delete_document using V1 API" do
+    request = stub_request(:delete, "http://example.com/documents/123")
+
+    GdsApi::Rummager.new("http://example.com").delete_document("edition", 123)
+
+    assert_requested(request)
+  end
+
+  it "#delete_document using V2 API" do
+    request = stub_request(:delete, "http://example.com/v2/metasearch/documents/123")
+
+    GdsApi::Rummager.new("http://example.com", api_version: "V2").delete_document("edition", 123, "metasearch")
+
+    assert_requested(request)
+  end
+
+  it "#delete_document using V2 API - can't delete from non-metasearch index" do
+    assert_raises GdsApi::Rummager::V2::InvalidIndex do
+      GdsApi::Rummager.new("http://example.com", api_version: "V2").delete_document("edition", 123, "government")
+    end
+  end
+
+  it "can't use an unknown api version" do
+    assert_raises GdsApi::Rummager::UnknownAPIVersion do
+      GdsApi::Rummager.new("http://example.com", api_version: "V0")
+    end
+  end
+
+  it "#add_document using V1 API" do
+    request = stub_request(:post, "http://example.com/documents")
+
+    GdsApi::Rummager.new("http://example.com").add_document("edition", 123, {})
+
+    assert_requested(request)
+  end
+
+  it "#add_document using V2 API" do
+    request = stub_request(:post, "http://example.com/v2/metasearch/documents")
+
+    GdsApi::Rummager.new("http://example.com", api_version: "V2").add_document("edition", 123, {}, "metasearch")
+
+    assert_requested(request)
+  end
+
+  it "#add_document using V2 API - can't insert into non-metasearch index" do
+    assert_raises GdsApi::Rummager::V2::InvalidIndex do
+      GdsApi::Rummager.new("http://example.com", api_version: "V2").add_document("edition", 123, {}, "government")
+    end
+  end
 end

--- a/test/rummager_test.rb
+++ b/test/rummager_test.rb
@@ -198,14 +198,14 @@ describe GdsApi::Rummager do
   it "#delete_document using V2 API" do
     request = stub_request(:delete, "http://example.com/v2/metasearch/documents/123")
 
-    GdsApi::Rummager.new("http://example.com", api_version: "V2").delete_document("edition", 123, "metasearch")
+    GdsApi::Rummager.new("http://example.com", api_version: "V2").delete_document(123, "metasearch")
 
     assert_requested(request)
   end
 
   it "#delete_document using V2 API - can't delete from non-metasearch index" do
     assert_raises GdsApi::Rummager::V2::InvalidIndex do
-      GdsApi::Rummager.new("http://example.com", api_version: "V2").delete_document("edition", 123, "government")
+      GdsApi::Rummager.new("http://example.com", api_version: "V2").delete_document(123, "government")
     end
   end
 
@@ -226,14 +226,14 @@ describe GdsApi::Rummager do
   it "#add_document using V2 API" do
     request = stub_request(:post, "http://example.com/v2/metasearch/documents")
 
-    GdsApi::Rummager.new("http://example.com", api_version: "V2").add_document("edition", 123, {}, "metasearch")
+    GdsApi::Rummager.new("http://example.com", api_version: "V2").add_document(123, {}, "metasearch")
 
     assert_requested(request)
   end
 
   it "#add_document using V2 API - can't insert into non-metasearch index" do
     assert_raises GdsApi::Rummager::V2::InvalidIndex do
-      GdsApi::Rummager.new("http://example.com", api_version: "V2").add_document("edition", 123, {}, "government")
+      GdsApi::Rummager.new("http://example.com", api_version: "V2").add_document(123, {}, "government")
     end
   end
 end


### PR DESCRIPTION
This add a new add_document and delete_document implementation when the
api_version is set to V2. This new implementation is locked to only allow
editing of data in the metasearch index.

https://trello.com/c/K5zkvpfi/537-delete-best-bet-query-and-items-not-working-in-search-admin