### PR TITLE
Measure test coverage correctly

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,21 +1,22 @@
 require 'bundler'
 Bundler.setup :default, :development, :test
 
-require 'minitest/autorun'
-require 'rack/utils'
-require 'rack/test'
 require 'simplecov'
 require 'simplecov-rcov'
-require 'mocha/mini_test'
-require 'timecop'
-require 'gds-api-adapters'
-require 'govuk-content-schema-test-helpers'
 
 SimpleCov.start do
   add_filter "/test/"
   add_group "Test Helpers", "lib/gds_api/test_helpers"
   formatter SimpleCov::Formatter::RcovFormatter
 end
+
+require 'minitest/autorun'
+require 'rack/utils'
+require 'rack/test'
+require 'mocha/mini_test'
+require 'timecop'
+require 'gds-api-adapters'
+require 'govuk-content-schema-test-helpers'
 
 class Minitest::Test
   def teardown


### PR DESCRIPTION
Simplecov needs to be set up before invoking minitest/autorun,
otherwise the run will start without any coverage.

Before:
<img width="1273" alt="screen shot 2017-12-29 at 15 39 26" src="https://user-images.githubusercontent.com/18276/34440658-8bff39e8-ecae-11e7-8ab8-80af2b0fa506.png">

After:
<img width="1276" alt="screen shot 2017-12-29 at 15 39 44" src="https://user-images.githubusercontent.com/18276/34440661-8fc0c27c-ecae-11e7-8965-58dd247f1f96.png">
