### PR TITLE
Add ability to disable JSON API cache from environment var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Add Environment variable which can disable caching of JSON API requests, `DISABLE_JSON_API_CACHE`
+
 # 50.8.0
 
 * Add V2 api endpoints for GdsAPI::Rummager#delete_document

--- a/lib/gds_api/json_client.rb
+++ b/lib/gds_api/json_client.rb
@@ -39,8 +39,9 @@ module GdsApi
       end
 
       @logger = options[:logger] || NullLogger.instance
+      disable_cache = options[:disable_cache] || ENV.fetch("DISABLE_JSON_API_CACHE", false)
 
-      if options[:disable_cache] || (options[:cache_size] == 0)
+      if disable_cache || (options[:cache_size] == 0)
         @cache = NullCache.new
       else
         cache_size = options[:cache_size] || DEFAULT_CACHE_SIZE

--- a/lib/gds_api/json_client.rb
+++ b/lib/gds_api/json_client.rb
@@ -41,7 +41,7 @@ module GdsApi
       @logger = options[:logger] || NullLogger.instance
       disable_cache = options[:disable_cache] || ENV.fetch("DISABLE_JSON_API_CACHE", false)
 
-      if disable_cache || (options[:cache_size] == 0)
+      if disable_cache || options[:cache_size] == 0 # rubocop:disable Style/NumericPredicate
         @cache = NullCache.new
       else
         cache_size = options[:cache_size] || DEFAULT_CACHE_SIZE

--- a/test/json_client_test.rb
+++ b/test/json_client_test.rb
@@ -195,6 +195,26 @@ class JsonClientTest < MiniTest::Spec
     end
   end
 
+  def test_should_allow_disabling_caching_via_environment_variable
+    url = "http://some.endpoint/some.json"
+    result = { "foo" => "bar" }
+    stub_request(:get, url).to_return(body: JSON.dump(result), status: 200)
+    ENV["DISABLE_JSON_API_CACHE"] = "true"
+
+    client = GdsApi::JsonClient.new
+
+    response_a = client.get_json(url)
+    response_b = client.get_json(url)
+
+    assert_requested :get, url, times: 2
+
+    [response_a, response_b].each do |r|
+      assert_equal result, r.to_hash
+    end
+  ensure
+    ENV.delete("DISABLE_JSON_API_CACHE")
+  end
+
   def test_should_respect_expiry_headers
     url = "http://some.endpoint/some.json"
     result = { "foo" => "bar" }


### PR DESCRIPTION
As part of the publishing end to end tests caching of GET requests to the content-store is preventing updated content from being displayed on frontends.