### PR TITLE
Percent encode the legacy_url_path when requesting Whitehall assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Percent encode URLs when requesting Whitehall assets from Asset Manager API
+
 # 50.9.0
 
 * Add Environment variable which can disable caching of JSON API requests, `DISABLE_JSON_API_CACHE`

--- a/gds-api-adapters.gemspec
+++ b/gds-api-adapters.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'lrucache', '~> 0.1.1'
   s.add_dependency 'rest-client', '~> 2.0'
   s.add_dependency 'rack-cache'
+  s.add_dependency 'addressable'
 
   s.add_development_dependency 'govuk-content-schema-test-helpers', '~> 1.5'
   s.add_development_dependency 'mocha', "~> 1.3.0"

--- a/lib/gds_api/asset_manager.rb
+++ b/lib/gds_api/asset_manager.rb
@@ -136,7 +136,7 @@ class GdsApi::AssetManager < GdsApi::Base
   #
   # @raise [HTTPErrorResponse] if the request returns an error
   def whitehall_asset(legacy_url_path)
-    get_json("#{base_url}/whitehall_assets/#{legacy_url_path}")
+    get_json("#{base_url}/whitehall_assets/#{Addressable::URI.encode(legacy_url_path)}")
   end
 
   # Updates an asset given a hash with one +file+ attribute

--- a/test/asset_manager_test.rb
+++ b/test/asset_manager_test.rb
@@ -108,6 +108,21 @@ describe GdsApi::AssetManager do
     end
   end
 
+  describe "a Whitehall asset with a legacy_url_path containing non-ascii characters exists" do
+    before do
+      asset_manager_has_a_whitehall_asset(
+        "/government/uploads/phot%C3%B8.jpg",
+        "id" => "asset-id"
+      )
+    end
+
+    it "retrieves an asset" do
+      asset = api.whitehall_asset("/government/uploads/photø.jpg")
+
+      assert_equal "asset-id", asset['id']
+    end
+  end
+
   it "deletes an asset for the given id" do
     req = stub_request(:delete, "#{base_api_url}/assets/#{asset_id}").
       to_return(body: JSON.dump(asset_manager_response), status: 200)


### PR DESCRIPTION
We've found a number of Whitehall assets whose filenames (and therefore
their legacy_url_path) contain non-ascii characters.

We need to URI encode the legacy_url_path to avoid `RestClient`, and
then the gds-api-adapters, from raising an InvalidUrl exception (as per
this example in Sentry[1]). Addresses issue #384.

I've used the Addressable Gem to avoid the Rubocop violation warning
that I saw when making a similar change to Asset Manager in
https://github.com/alphagov/asset-manager/pull/396.

[1]: https://sentry.io/govuk/app-whitehall/issues/429050852/