### PR TITLE
Bump version to 50.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 50.9.1
 
 * Percent encode URLs when requesting Whitehall assets from Asset Manager API
 

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '50.9.0'.freeze
+  VERSION = '50.9.1'.freeze
 end


### PR DESCRIPTION
It's a patch release because the only change is a "backwards-compatible
bug fix"[1].

[1]: https://semver.org/