### PR TITLE
Change disable cache env var name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Change name of `DISABLE_JSON_API_CACHE` environment variable to `GDS_API_DISABLE_CACHE`
+
 # 50.9.1
 
 * Percent encode URLs when requesting Whitehall assets from Asset Manager API

--- a/lib/gds_api/json_client.rb
+++ b/lib/gds_api/json_client.rb
@@ -39,7 +39,7 @@ module GdsApi
       end
 
       @logger = options[:logger] || NullLogger.instance
-      disable_cache = options[:disable_cache] || ENV.fetch("DISABLE_JSON_API_CACHE", false)
+      disable_cache = options[:disable_cache] || ENV.fetch("GDS_API_DISABLE_CACHE", false)
 
       if disable_cache || options[:cache_size] == 0 # rubocop:disable Style/NumericPredicate
         @cache = NullCache.new

--- a/test/json_client_test.rb
+++ b/test/json_client_test.rb
@@ -199,7 +199,7 @@ class JsonClientTest < MiniTest::Spec
     url = "http://some.endpoint/some.json"
     result = { "foo" => "bar" }
     stub_request(:get, url).to_return(body: JSON.dump(result), status: 200)
-    ENV["DISABLE_JSON_API_CACHE"] = "true"
+    ENV["GDS_API_DISABLE_CACHE"] = "true"
 
     client = GdsApi::JsonClient.new
 
@@ -212,7 +212,7 @@ class JsonClientTest < MiniTest::Spec
       assert_equal result, r.to_hash
     end
   ensure
-    ENV.delete("DISABLE_JSON_API_CACHE")
+    ENV.delete("GDS_API_DISABLE_CACHE")
   end
 
   def test_should_respect_expiry_headers


### PR DESCRIPTION
Since this env var gets set in applications it follows a precedent to
prefix this with GDS_API to indicate it's for a specific library.

The rest of the environment variable has been made more generic as there
is only one kind of cache and the anticipation is that if you needed
this env var you'd want to disable this and future types of cache.