### PR TITLE
Add frequency param to email subscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Include frequency as a parameter when subscribing to emails through Email alert api
+
 # 51.0.0
 
 * **Breaking Change:** Require a minimum of Ruby 2.3

--- a/lib/gds_api/email_alert_api.rb
+++ b/lib/gds_api/email_alert_api.rb
@@ -100,11 +100,12 @@ class GdsApi::EmailAlertApi < GdsApi::Base
   # Subscribe
   #
   # @return [Hash] subscription_id
-  def subscribe(subscribable_id:, address:)
+  def subscribe(subscribable_id:, address:, frequency: "immediately")
     post_json(
       "#{endpoint}/subscriptions",
       subscribable_id: subscribable_id,
       address: address,
+      frequency: frequency,
     )
   end
 

--- a/lib/gds_api/test_helpers/email_alert_api.rb
+++ b/lib/gds_api/test_helpers/email_alert_api.rb
@@ -105,24 +105,24 @@ module GdsApi
           .to_return(status: 404)
       end
 
-      def email_alert_api_creates_a_subscription(subscribable_id, address, returned_subscription_id)
+      def email_alert_api_creates_a_subscription(subscribable_id, address, frequency, returned_subscription_id)
         stub_request(:post, subscribe_url)
           .with(
-            body: { subscribable_id: subscribable_id, address: address }.to_json
+            body: { subscribable_id: subscribable_id, address: address, frequency: frequency }.to_json
         ).to_return(status: 201, body: { subscription_id: returned_subscription_id }.to_json)
       end
 
-      def email_alert_api_creates_an_existing_subscription(subscribable_id, address, returned_subscription_id)
+      def email_alert_api_creates_an_existing_subscription(subscribable_id, address, frequency, returned_subscription_id)
         stub_request(:post, subscribe_url)
           .with(
-            body: { subscribable_id: subscribable_id, address: address }.to_json
+            body: { subscribable_id: subscribable_id, address: address, frequency: frequency }.to_json
         ).to_return(status: 200, body: { subscription_id: returned_subscription_id }.to_json)
       end
 
-      def email_alert_api_refuses_to_create_subscription(subscribable_id, address)
+      def email_alert_api_refuses_to_create_subscription(subscribable_id, address, frequency)
         stub_request(:post, subscribe_url)
           .with(
-            body: { subscribable_id: subscribable_id, address: address }.to_json
+            body: { subscribable_id: subscribable_id, address: address, frequency: frequency }.to_json
         ).to_return(status: 422)
       end
 

--- a/test/email_alert_api_test.rb
+++ b/test/email_alert_api_test.rb
@@ -289,19 +289,42 @@ describe GdsApi::EmailAlertApi do
   end
 
   describe "subscribing and a subscription is created" do
-    it "returns a 201 and the subscription id" do
-      subscribable_id = 5
-      address = "test@test.com"
-      created_subscription_id = 1
+    describe "with a frequency specified" do
+      it "returns a 201 and the subscription id" do
+        subscribable_id = 5
+        address = "test@test.com"
+        created_subscription_id = 1
+        frequency = "daily"
 
-      email_alert_api_creates_a_subscription(
-        subscribable_id,
-        address,
-        created_subscription_id
-      )
-      api_response = api_client.subscribe(subscribable_id: subscribable_id, address: address)
-      assert_equal(201, api_response.code)
-      assert_equal({ "subscription_id" => 1 }, api_response.to_h)
+        email_alert_api_creates_a_subscription(
+          subscribable_id,
+          address,
+          frequency,
+          created_subscription_id
+        )
+        api_response = api_client.subscribe(subscribable_id: subscribable_id, address: address, frequency: frequency)
+        assert_equal(201, api_response.code)
+        assert_equal({ "subscription_id" => 1 }, api_response.to_h)
+      end
+    end
+
+    describe "without a frequency specified" do
+      it "returns a 201 and the subscription id" do
+        subscribable_id = 6
+        address = "test@test.com"
+        created_subscription_id = 1
+        frequency = "immediately"
+
+        email_alert_api_creates_a_subscription(
+          subscribable_id,
+          address,
+          frequency,
+          created_subscription_id
+        )
+        api_response = api_client.subscribe(subscribable_id: subscribable_id, address: address)
+        assert_equal(201, api_response.code)
+        assert_equal({ "subscription_id" => 1 }, api_response.to_h)
+      end
     end
   end
 
@@ -310,13 +333,15 @@ describe GdsApi::EmailAlertApi do
       subscribable_id = 5
       address = "test@test.com"
       existing_subscription_id = 1
+      frequency = "immediately"
 
       email_alert_api_creates_an_existing_subscription(
         subscribable_id,
         address,
+        frequency,
         existing_subscription_id
       )
-      api_response = api_client.subscribe(subscribable_id: subscribable_id, address: address)
+      api_response = api_client.subscribe(subscribable_id: subscribable_id, address: address, frequency: frequency)
       assert_equal(200, api_response.code)
       assert_equal({ "subscription_id" => 1 }, api_response.to_h)
     end
@@ -324,10 +349,10 @@ describe GdsApi::EmailAlertApi do
 
   describe "subscribing with an invalid address" do
     it "raises an unprocessable entity error" do
-      email_alert_api_refuses_to_create_subscription(123, "invalid")
+      email_alert_api_refuses_to_create_subscription(123, "invalid", "weekly")
 
       assert_raises GdsApi::HTTPUnprocessableEntity do
-        api_client.subscribe(subscribable_id: 123, address: "invalid")
+        api_client.subscribe(subscribable_id: 123, address: "invalid", frequency: "weekly")
       end
     end
   end


### PR DESCRIPTION
Email alert api now accepts frequency (immediately, daily, weekly)
as a parameter through the `subscription/new` endpoint.
As a result, we should pass frequency through the api adapters.

[Trello](https://trello.com/c/ltl3PIhp/532-add-subscription-type-parameters-to-gds-api-adapters)