### PR TITLE
Add frequency param to `assert_subscribed`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Add frequency param to `assert_subscribed` in Email alert api test helpers
+
 # 51.1.0
 
 * Include frequency as a parameter when subscribing to emails through Email alert api

--- a/lib/gds_api/test_helpers/email_alert_api.rb
+++ b/lib/gds_api/test_helpers/email_alert_api.rb
@@ -130,11 +130,12 @@ module GdsApi
         assert_requested(:post, unsubscribe_url(uuid), times: 1)
       end
 
-      def assert_subscribed(subscribable_id, address)
+      def assert_subscribed(subscribable_id, address, frequency = "immediately")
         assert_requested(:post, subscribe_url) do |req|
           JSON.parse(req.body).symbolize_keys == {
             subscribable_id: subscribable_id,
-            address: address
+            address: address,
+            frequency: frequency
           }
         end
       end


### PR DESCRIPTION
Introducing frequency to requests to email-alert-api means that when we
`assert_subscribed`, we should also include frequency as one of the
params to the post request.