### PR TITLE
Helper method to determine destination of redirect

### DIFF
--- a/lib/gds_api/content_store.rb
+++ b/lib/gds_api/content_store.rb
@@ -1,3 +1,5 @@
+require "plek"
+
 require_relative 'base'
 require_relative 'exceptions'
 
@@ -18,9 +20,99 @@ class GdsApi::ContentStore < GdsApi::Base
     raise "`ContentStore#content_item!` is deprecated. Use `ContentStore#content_item` instead"
   end
 
+  # Returns an array tuple of destination url with status code e.g
+  # ["https://www.gov.uk/destination", 301]
+  def self.redirect_for_path(content_item, request_path, request_query = "")
+    RedirectResolver.call(content_item, request_path, request_query)
+  end
+
 private
 
   def content_item_url(base_path)
     "#{endpoint}/content#{base_path}"
   end
+
+  class RedirectResolver
+    def initialize(content_item, request_path, request_query = "")
+      @content_item = content_item
+      @request_path = request_path
+      @request_query = request_query.to_s
+    end
+
+    def self.call(*args)
+      new(*args).call
+    end
+
+    def call
+      redirect = redirect_for_path(request_path)
+      raise UnresolvedRedirect, "Could not find a matching redirect" unless redirect
+
+      destination_uri = URI.parse(
+        resolve_destination(redirect, request_path, request_query)
+      )
+
+      url = if destination_uri.absolute?
+              destination_uri.to_s
+            else
+              "#{Plek.new.website_root}#{destination_uri}"
+            end
+
+      [url, status_code(redirect)]
+    end
+
+    private_class_method :new
+
+  private
+
+    attr_reader :content_item, :request_path, :request_query
+
+    def redirect_for_path(path)
+      redirects_by_segments.find do |r|
+        next true if r["path"] == path
+        route_prefix_match?(r["path"], path) if r["type"] == "prefix"
+      end
+    end
+
+    def redirects_by_segments
+      redirects = content_item["redirects"] || []
+      redirects.sort_by { |r| r["path"].split("/").count * -1 }
+    end
+
+    def route_prefix_match?(prefix_path, path_to_match)
+      prefix_regex = %r{^#{Regexp.escape(prefix_path)}/}
+      path_to_match.match prefix_regex
+    end
+
+    def resolve_destination(redirect, path, query)
+      return redirect["destination"] unless redirect["segments_mode"] == "preserve"
+
+      if redirect["type"] == "prefix"
+        prefix_destination(redirect, path, query)
+      else
+        redirect["destination"] + (query.empty? ? "" : "?#{query}")
+      end
+    end
+
+    def prefix_destination(redirect, path, query)
+      uri = URI.parse(redirect["destination"])
+      start_char = redirect["path"].length
+      suffix = path[start_char..-1]
+
+      if uri.path == "" && suffix[0] != "/"
+        uri.path = "/#{suffix}"
+      else
+        uri.path += suffix
+      end
+
+      uri.query = query if uri.query.nil? && !query.empty?
+
+      uri.to_s
+    end
+
+    def status_code(redirect)
+      redirect["redirect_type"] == "temporary" ? 302 : 301
+    end
+  end
+
+  class UnresolvedRedirect < GdsApi::BaseError; end
 end

--- a/test/content_store_test.rb
+++ b/test/content_store_test.rb
@@ -52,4 +52,164 @@ describe GdsApi::ContentStore do
       end
     end
   end
+
+  describe ".redirect_for_path" do
+    before do
+      @content_item = content_item_for_base_path("/test").merge("redirects" => [])
+    end
+
+    def create_redirect(
+      path:,
+      destination: "/destination",
+      type: "exact",
+      segments_mode: "ignore",
+      redirect_type: "permanent"
+    )
+      {
+        "path" => path,
+        "destination" => destination,
+        "type" => type,
+        "segments_mode" => segments_mode,
+        "redirect_type" => redirect_type,
+      }
+    end
+
+    it "raises when there are no redirects on the content item" do
+      @content_item["redirects"] = []
+
+      assert_raises GdsApi::ContentStore::UnresolvedRedirect do
+        GdsApi::ContentStore.redirect_for_path(@content_item, "/test")
+      end
+    end
+
+    it "raises when no redirects match the request path" do
+      @content_item["redirects"] = [
+        create_redirect(path: "/not-going-to-match")
+      ]
+
+      assert_raises GdsApi::ContentStore::UnresolvedRedirect do
+        GdsApi::ContentStore.redirect_for_path(@content_item, "/test")
+      end
+    end
+
+    it "creates an absolute URL when a redirect redirects internally" do
+      @content_item["redirects"] = [
+        create_redirect(path: "/a", destination: "/b")
+      ]
+
+      destination, = GdsApi::ContentStore.redirect_for_path(@content_item, "/a")
+      assert_equal "http://www.dev.gov.uk/b", destination
+    end
+
+    it "returns an absolute URL redirect unmodified" do
+      @content_item["redirects"] = [
+        create_redirect(path: "/a", destination: "https://example.com/b")
+      ]
+
+      destination, = GdsApi::ContentStore.redirect_for_path(@content_item, "/a")
+      assert_equal "https://example.com/b", destination
+    end
+
+    it "includes a 301 status code for a permanent redirect" do
+      @content_item["redirects"] = [
+        create_redirect(path: "/a", redirect_type: "permanent")
+      ]
+
+      _, status_code = GdsApi::ContentStore.redirect_for_path(@content_item, "/a")
+      assert_equal 301, status_code
+    end
+
+    it "includes a 301 status code for a temporary redirect" do
+      @content_item["redirects"] = [
+        create_redirect(path: "/a", redirect_type: "temporary")
+      ]
+
+      _, status_code = GdsApi::ContentStore.redirect_for_path(@content_item, "/a")
+      assert_equal 302, status_code
+    end
+
+    it "returns an absolute URL redirect unmodified" do
+      @content_item["redirects"] = [
+        create_redirect(path: "/a", destination: "https://example.com/b")
+      ]
+
+      destination, = GdsApi::ContentStore.redirect_for_path(@content_item, "/a")
+      assert_equal "https://example.com/b", destination
+    end
+
+    describe "when a redirect has segment_mode ignore" do
+      it "ignores query string for an exact route" do
+        @content_item["redirects"] = [
+          create_redirect(path: "/a", destination: "/b", segments_mode: "ignore")
+        ]
+
+        destination, = GdsApi::ContentStore.redirect_for_path(@content_item, "/a", "query=1")
+        assert_equal "http://www.dev.gov.uk/b", destination
+      end
+
+      it "ignores segments for a prefix route" do
+        @content_item["redirects"] = [
+          create_redirect(
+            path: "/a", destination: "/b", segments_mode: "ignore", type: "prefix"
+          )
+        ]
+
+        destination, = GdsApi::ContentStore.redirect_for_path(@content_item, "/a/b")
+        assert_equal "http://www.dev.gov.uk/b", destination
+      end
+    end
+
+    describe "when a redirect has segment_mode preserve" do
+      it "maintains a query string for an exact route" do
+        @content_item["redirects"] = [
+          create_redirect(path: "/a", destination: "/b", segments_mode: "preserve")
+        ]
+
+        destination, = GdsApi::ContentStore.redirect_for_path(@content_item, "/a", "query=1")
+        assert_equal "http://www.dev.gov.uk/b?query=1", destination
+      end
+
+      it "maintains segments for a prefix route" do
+        @content_item["redirects"] = [
+          create_redirect(
+            path: "/path", destination: "/destination", segments_mode: "preserve", type: "prefix"
+          )
+        ]
+
+        destination, = GdsApi::ContentStore.redirect_for_path(@content_item, "/path/segment", "query=0")
+        assert_equal "http://www.dev.gov.uk/destination/segment?query=0", destination
+      end
+
+      it "maintains segments for an absolute prefix route" do
+        @content_item["redirects"] = [
+          create_redirect(
+            path: "/path", destination: "http://example.com/destination", segments_mode: "preserve", type: "prefix"
+          )
+        ]
+
+        destination, = GdsApi::ContentStore.redirect_for_path(@content_item, "/path/segment")
+        assert_equal "http://example.com/destination/segment", destination
+      end
+    end
+
+    it "matches identical path in multiple exact redirects" do
+      @content_item["redirects"] = [
+        create_redirect(path: "/a", destination: "/x", type: "exact"),
+        create_redirect(path: "/a/b", destination: "/x/y", type: "exact"),
+      ]
+
+      destination, = GdsApi::ContentStore.redirect_for_path(@content_item, "/a/b")
+      assert_equal "http://www.dev.gov.uk/x/y", destination
+    end
+
+    it "matches most relevant in multiple prefix matches" do
+      @content_item["redirects"] = [
+        create_redirect(path: "/a", destination: "/x", type: "prefix", segments_mode: "preserve"),
+        create_redirect(path: "/a/b", destination: "/x/y", type: "prefix", segments_mode: "preserve"),
+      ]
+
+      destination, = GdsApi::ContentStore.redirect_for_path(@content_item, "/a/b/c")
+      assert_equal "http://www.dev.gov.uk/x/y/c", destination
+    end
+  end
 end


### PR DESCRIPTION
This adds in the ability for the GdsApi::ContentStore class to be able to be given a content_item and return the redirect destination and status code. 

This has been added to GDS API Adapters as this would allow this method to be used across multiple apps if needed.

As this replicates some of routers logic it does feel contentious and is at risk of being inconsistent if router is ever to change it's redirect logic

## Why is this needed

The reason for this is to work around an atomicity issue we have with router and frontend apps. Which is outlined here: https://github.com/alphagov/government-frontend/issues/437 for gone responses. Unlike gone responses a redirect requires logic to determine the destination.

This issue is flagged in sentry for government-frontend a few hundred times: https://sentry.io/govuk/app-government-frontend/?query=is%3Aunresolved++redirect

This issue is more acute with [publishing-e2e-tests](https://github.com/alphagov/publishing-e2e-tests) where it can frequently cause a test fail

## What are the alternatives 

- The main alternative is to continue as we are and to return users a 500 response when this situation occurs. End-to-end tests could be modified for that. We could stop sending sentry errors (though this doesn't feel great)
- It doesn't seem practical to try introduce atomicity into router and content-store

## Related PRs for implementation

- [ ] https://github.com/alphagov/government-frontend/pull/727
- [ ] https://github.com/alphagov/govuk-content-schemas/pull/710
- [ ] https://github.com/alphagov/content-store/pull/369