### PR TITLE
Add support for /feedback-by-day endpoint.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 51.4.0
+
+* Add support for the /feedback-by-day endpoint in the Support API
+
 # 51.3.0
 
 * Add `locale` param to `get_expanded_links` in the Publishing API

--- a/lib/gds_api/support_api.rb
+++ b/lib/gds_api/support_api.rb
@@ -74,6 +74,11 @@ class GdsApi::SupportApi < GdsApi::Base
     get_json(uri)
   end
 
+  def feedback_by_day(date, page = 1, per_page = 100)
+    uri = "#{endpoint}/feedback-by-day/#{date.strftime('%Y-%m-%d')}?page=#{page}&per_page=#{per_page}"
+    get_json(uri)
+  end
+
   def feedback_export_request(id)
     get_json("#{endpoint}/anonymous-feedback/export-requests/#{id}")
   end

--- a/lib/gds_api/test_helpers/support_api.rb
+++ b/lib/gds_api/test_helpers/support_api.rb
@@ -30,6 +30,12 @@ module GdsApi
         post_stub.to_return(status: 202)
       end
 
+      def stub_support_api_feedback_by_day(date, page, per_page, response_body = { results: [] })
+        date_string = date.strftime("%Y-%m-%d")
+        get_stub = stub_http_request(:get, "#{SUPPORT_API_ENDPOINT}/feedback-by-day/#{date_string}?page=#{page}&per_page=#{per_page}")
+        get_stub.to_return(status: 200, body: response_body.to_json)
+      end
+
       def stub_support_api_global_export_request_creation(request_details = nil)
         post_stub = stub_http_request(:post, "#{SUPPORT_API_ENDPOINT}/anonymous-feedback/global-export-requests")
         post_stub.with(body: { global_export_request: request_details }) unless request_details.nil?

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '51.3.0'.freeze
+  VERSION = '51.4.0'.freeze
 end

--- a/test/support_api_test.rb
+++ b/test/support_api_test.rb
@@ -213,4 +213,22 @@ describe GdsApi::SupportApi do
       assert_requested(stub_post)
     end
   end
+
+  describe "GET /feedback-by-day/[date_str]" do
+    it "make a GET request to the support API with default" do
+      stub_get = stub_support_api_feedback_by_day(Date.today, 1, 100)
+
+      @api.feedback_by_day(Date.today)
+
+      assert_requested(stub_get)
+    end
+
+    it "make a GET request to the support API with page params" do
+      stub_get = stub_support_api_feedback_by_day(Date.today, 2, 200)
+
+      @api.feedback_by_day(Date.today, 2, 200)
+
+      assert_requested(stub_get)
+    end
+  end
 end


### PR DESCRIPTION
This is needed for content-performance-manager which
needs to get the number of feedback comments per document 
per day to store in the data warehouse.

The Trello card is [Expose Feedex numbers via Support API](https://trello.com/c/6nz6zXEE/113-5-expose-feedex-numbers-via-support-api)

There is a [related PR in support-api](https://github.com/alphagov/support-api/pull/174)