### PR TITLE
Remove deprecated GovDelivery methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Remove deprecated `notifications` and `notification` methods from `GdsApi::EmailAlertApi`.
+
 # 51.4.0
 
 * Add support for the /feedback-by-day endpoint in the Support API

--- a/lib/gds_api/email_alert_api.rb
+++ b/lib/gds_api/email_alert_api.rb
@@ -57,26 +57,6 @@ class GdsApi::EmailAlertApi < GdsApi::Base
     post_json("#{endpoint}/notifications", publication, headers)
   end
 
-  # Get notifications
-  #
-  # @option start_at [String] Optional GovDelivery bulletin id to page back through notifications
-  #
-  # @return [Hash] notifications
-  def notifications(start_at = nil)
-    url = "#{endpoint}/notifications"
-    url += "?start_at=#{start_at}" if start_at
-    get_json(url)
-  end
-
-  # Get notification
-  #
-  # @param id [String] GovDelivery bulletin id
-  #
-  # @return [Hash] notification
-  def notification(id)
-    get_json("#{endpoint}/notifications/#{id}")
-  end
-
   # Get topic matches
   #
   # @param attributes [Hash] tags, links, document_type,

--- a/test/email_alert_api_test.rb
+++ b/test/email_alert_api_test.rb
@@ -234,34 +234,6 @@ describe GdsApi::EmailAlertApi do
     end
   end
 
-  describe "notifications" do
-    it "retrieves notifications" do
-      stubbed_request = email_alert_api_has_notifications([
-        { "subject" => "Foo" }, { "subject" => "Bar" }
-      ])
-      api_client.notifications
-      assert_requested(stubbed_request)
-    end
-
-    it "uses the start_at param if present" do
-      stubbed_request = email_alert_api_has_notifications([
-        { "subject" => "Foo" }, { "subject" => "Bar" }
-      ], "101AA")
-      api_client.notifications("101AA")
-      assert_requested(stubbed_request)
-    end
-  end
-
-  describe "notification" do
-    before do
-      @stubbed_request = email_alert_api_has_notification("web_service_bulletin" => { "to_param" => "10001001" })
-    end
-    it "retrieves a notification by id" do
-      api_client.notification("10001001")
-      assert_requested(@stubbed_request)
-    end
-  end
-
   describe "unsubscribing" do
     describe "with an existing subscription" do
       it "returns a 204" do


### PR DESCRIPTION
These will be removed from email-alert-api shortly so we should start by removing them from gds-api-adapters.

[Trello Card](https://trello.com/c/iKEAnrN2/680-post-deploy-development-cleanup)