### PR TITLE
Mark certain HTTP exceptions as intermittent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# dev
+
+* Add `GdsApi::HTTPIntermittentServerError` and `GdsApi::HTTPIntermittentClientError` superclasses.
+* Add a `GdsApi::HTTPTooManyRequests` exception
+
 # 52.0.0
 
 * Remove deprecated `notifications` and `notification` methods from `GdsApi::EmailAlertApi`.

--- a/lib/gds_api/exceptions.rb
+++ b/lib/gds_api/exceptions.rb
@@ -31,6 +31,7 @@ module GdsApi
 
   # Superclass & fallback for all 4XX errors
   class HTTPClientError < HTTPErrorResponse; end
+  class HTTPIntermittentClientError < HTTPClientError; end
 
   class HTTPNotFound < HTTPClientError; end
   class HTTPGone < HTTPClientError; end
@@ -39,14 +40,16 @@ module GdsApi
   class HTTPForbidden < HTTPClientError; end
   class HTTPConflict < HTTPClientError; end
   class HTTPUnprocessableEntity < HTTPClientError; end
+  class HTTPTooManyRequests < HTTPIntermittentClientError; end
 
   # Superclass & fallback for all 5XX errors
   class HTTPServerError < HTTPErrorResponse; end
+  class HTTPIntermittentServerError < HTTPServerError; end
 
   class HTTPInternalServerError < HTTPServerError; end
-  class HTTPBadGateway < HTTPServerError; end
-  class HTTPUnavailable < HTTPServerError; end
-  class HTTPGatewayTimeout < HTTPServerError; end
+  class HTTPBadGateway < HTTPIntermittentServerError; end
+  class HTTPUnavailable < HTTPIntermittentServerError; end
+  class HTTPGatewayTimeout < HTTPIntermittentServerError; end
 
   module ExceptionHandling
     def build_specific_http_error(error, url, details = nil, request_body = nil)
@@ -71,6 +74,8 @@ module GdsApi
         GdsApi::HTTPPayloadTooLarge
       when 422
         GdsApi::HTTPUnprocessableEntity
+      when 429
+        GdsApi::HTTPTooManyRequests
       when (400..499)
         GdsApi::HTTPClientError
       when 500


### PR DESCRIPTION
Adding Intermittent subclasses of Server and Client errors allows a
client to better work out if a request should be retried or not, and
also whether we should log it to Sentry or not.

Also adds a specific exception class for 429 errors (rate limiting)

This will be used in `govuk_app_config` PR https://github.com/alphagov/govuk_app_config/pull/32 to count these errors in Graphite instead of sending them to Sentry.