### PR TITLE
Fix URI::regexp and URI.escape deprecation message

### DIFF
--- a/lib/gds_api/base.rb
+++ b/lib/gds_api/base.rb
@@ -41,7 +41,7 @@ class GdsApi::Base
 
   def initialize(endpoint_url, options = {})
     options[:endpoint_url] = endpoint_url
-    raise InvalidAPIURL unless endpoint_url =~ URI::regexp
+    raise InvalidAPIURL unless endpoint_url =~ URI::RFC3986_Parser::RFC3986_URI
     base_options = { logger: self.class.logger }
     default_options = base_options.merge(GdsApi::Base.default_options || {})
     @options = default_options.merge(options)

--- a/lib/gds_api/imminence.rb
+++ b/lib/gds_api/imminence.rb
@@ -31,7 +31,7 @@ class GdsApi::Imminence < GdsApi::Base
   end
 
   def areas_for_postcode(postcode)
-    url = "#{@endpoint}/areas/#{URI.encode(postcode)}.json"
+    url = "#{@endpoint}/areas/#{ERB::Util.url_encode(postcode)}.json"
     get_json(url)
   end
 

--- a/test/imminence_api_test.rb
+++ b/test/imminence_api_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 require "gds_api/imminence"
 
 class ImminenceApiTest < Minitest::Test
-  ROOT = "https://imminence.test.alphagov.co.uk".freeze
+  ROOT = Plek.current.find("imminence")
   LATITUDE = 52.1327584352089
   LONGITUDE = -0.4702813074674147
 


### PR DESCRIPTION
`URI::regexp` has been deprecated in favour of `URI::RFC3986_Parser::RFC3986_URI` and `URI.escape` is also deprecated.