### PR TITLE
Add new email-alert-api endpoints

### DIFF
--- a/lib/gds_api/email_alert_api.rb
+++ b/lib/gds_api/email_alert_api.rb
@@ -105,8 +105,41 @@ class GdsApi::EmailAlertApi < GdsApi::Base
   #  subscriber_count
   # }
   def get_subscribable(reference:)
-    get_json(
-      "#{endpoint}/subscribables/#{reference}"
+    get_json("#{endpoint}/subscribables/#{reference}")
+  end
+
+  # Get Subscriptions for a Subscriber
+  # #
+  # @param string Subscriber address
+  #
+  # @return [Hash] subscriber, subscriptions
+  def get_subscriptions(address:)
+    get_json("#{endpoint}/subscribers/#{address}/subscriptions")
+  end
+
+  # Patch a Subscriber
+  # #
+  # @param string Subscriber address
+  # @param string Subscriber new_address
+  #
+  # @return [Hash] subscriber
+  def change_subscriber(address:, new_address:)
+    patch_json(
+      "#{endpoint}/subscribers/#{address}",
+      new_address: new_address
+    )
+  end
+
+  # Patch a Subscription
+  # #
+  # @param string Subscription id
+  # @param string Subscription frequency
+  #
+  # @return [Hash] subscription
+  def change_subscription(id:, frequency:)
+    patch_json(
+      "#{endpoint}/subscriptions/#{id}",
+      frequency: frequency
     )
   end
 

--- a/lib/gds_api/email_alert_api.rb
+++ b/lib/gds_api/email_alert_api.rb
@@ -108,6 +108,23 @@ class GdsApi::EmailAlertApi < GdsApi::Base
     get_json("#{endpoint}/subscribables/#{reference}")
   end
 
+  # Get a Subscription
+  #
+  # @return [Hash] subscription: {
+  #  id
+  #  subscriber_list
+  #  subscriber
+  #  created_at
+  #  updated_at
+  #  ended_at
+  #  ended_reason
+  #  frequency
+  #  source
+  # }
+  def get_subscription(id)
+    get_json("#{endpoint}/subscriptions/#{id}")
+  end
+
   # Get Subscriptions for a Subscriber
   # #
   # @param string Subscriber address

--- a/lib/gds_api/test_helpers/email_alert_api.rb
+++ b/lib/gds_api/test_helpers/email_alert_api.rb
@@ -45,6 +45,14 @@ module GdsApi
           .to_return(status: 404)
       end
 
+      def email_alert_api_has_subscription(id, frequency)
+        stub_request(:get, subscription_url(id))
+          .to_return(
+            status: 200,
+            body: get_subscription_response(id, frequency).to_json,
+          )
+      end
+
       def email_alert_api_has_subscriber_list(attributes)
         stub_request(:get, subscriber_lists_url(attributes))
           .to_return(
@@ -275,8 +283,8 @@ module GdsApi
         EMAIL_ALERT_API_ENDPOINT + "/subscriptions"
       end
 
-      def subscription_url(subscription_id)
-        EMAIL_ALERT_API_ENDPOINT + "/subscriptions/#{subscription_id}"
+      def subscription_url(id)
+        EMAIL_ALERT_API_ENDPOINT + "/subscriptions/#{id}"
       end
 
       def subscribable_url(reference)

--- a/lib/gds_api/test_helpers/email_alert_api.rb
+++ b/lib/gds_api/test_helpers/email_alert_api.rb
@@ -6,6 +6,45 @@ module GdsApi
     module EmailAlertApi
       EMAIL_ALERT_API_ENDPOINT = Plek.find("email-alert-api")
 
+      def email_alert_api_has_updated_subscriber(old_address, new_address)
+        stub_request(:patch, subscriber_url(old_address))
+          .to_return(
+            status: 200,
+            body: get_subscriber_response(new_address).to_json,
+          )
+      end
+
+      def email_alert_api_does_not_have_updated_subscriber(address)
+        stub_request(:patch, subscriber_url(address))
+          .to_return(status: 404)
+      end
+
+      def email_alert_api_has_updated_subscription(subscription_id, frequency)
+        stub_request(:patch, subscription_url(subscription_id))
+          .to_return(
+            status: 200,
+            body: get_subscription_response(subscription_id, frequency).to_json,
+          )
+      end
+
+      def email_alert_api_does_not_have_updated_subscription(subscription_id)
+        stub_request(:patch, subscription_url(subscription_id))
+          .to_return(status: 404)
+      end
+
+      def email_alert_api_has_subscriber_subscriptions(address)
+        stub_request(:get, subscriber_subscriptions_url(address))
+          .to_return(
+            status: 200,
+            body: get_subscriber_subscriptions_response(address).to_json,
+          )
+      end
+
+      def email_alert_api_does_not_have_subscriber_subscriptions(address)
+        stub_request(:get, subscriber_subscriptions_url(address))
+          .to_return(status: 404)
+      end
+
       def email_alert_api_has_subscriber_list(attributes)
         stub_request(:get, subscriber_lists_url(attributes))
           .to_return(
@@ -34,12 +73,55 @@ module GdsApi
           )
       end
 
+      def get_subscriber_response(address)
+        {
+          "subscriber" => {
+            "id" => 1,
+            "address" => address
+          }
+        }
+      end
+
+      def get_subscription_response(subscription_id, frequency)
+        {
+          "subscription" => {
+            "subscriber_id" => 1,
+            "subscriber_list_id" => 1000,
+            "frequency" => frequency,
+            "id" => subscription_id,
+            "subscriber_list" => {
+              "id" => 1000,
+              "slug" => "some-thing"
+            }
+          }
+        }
+      end
+
+      def get_subscriber_subscriptions_response(address)
+        {
+          "subscriber" => {
+            "id" => 1,
+            "address" => address
+          },
+          "subscriptions" => [
+            {
+              "subscriber_id" => 1,
+              "subscriber_list_id" => 1000,
+              "frequency" => "daily",
+              "id" => "447135c3-07d6-4c3a-8a3b-efa49ef70e52",
+              "subscriber_list" => {
+                "id" => 1000,
+                "slug" => "some-thing"
+              }
+            }
+          ]
+        }
+      end
+
       def get_subscriber_list_response(attributes)
         {
           "subscriber_list" => {
             "id" => "447135c3-07d6-4c3a-8a3b-efa49ef70e52",
-            "subscription_url" => "https://stage-public.govdelivery.com/accounts/UKGOVUK/subscriber/new?topic_id=UKGOVUK_1234",
-            "gov_delivery_id" => "UKGOVUK_1234",
             "title" => "Some title",
           }.merge(attributes)
         }
@@ -193,8 +275,20 @@ module GdsApi
         EMAIL_ALERT_API_ENDPOINT + "/subscriptions"
       end
 
+      def subscription_url(subscription_id)
+        EMAIL_ALERT_API_ENDPOINT + "/subscriptions/#{subscription_id}"
+      end
+
       def subscribable_url(reference)
         EMAIL_ALERT_API_ENDPOINT + "/subscribables/#{reference}"
+      end
+
+      def subscriber_url(address)
+        EMAIL_ALERT_API_ENDPOINT + "/subscribers/#{address}"
+      end
+
+      def subscriber_subscriptions_url(address)
+        EMAIL_ALERT_API_ENDPOINT + "/subscribers/#{address}/subscriptions"
       end
     end
   end

--- a/test/email_alert_api_test.rb
+++ b/test/email_alert_api_test.rb
@@ -48,6 +48,22 @@ describe GdsApi::EmailAlertApi do
     end
   end
 
+  describe "subscriptions" do
+    describe "a subscription exists" do
+      before do
+        email_alert_api_has_subscription(1, "weekly")
+      end
+
+      it "returns the subscription attributes" do
+        subscription_attrs = api_client.get_subscription(1)
+          .to_hash
+          .fetch("subscription")
+
+        assert_equal("weekly", subscription_attrs.fetch("frequency"))
+      end
+    end
+  end
+
   describe "subscriber lists" do
     let(:expected_subscription_url) { "a subscription url" }
 

--- a/test/email_alert_api_test.rb
+++ b/test/email_alert_api_test.rb
@@ -354,4 +354,79 @@ describe GdsApi::EmailAlertApi do
       end
     end
   end
+
+  describe "change_subscriber when a subscriber exists" do
+    it "changes the subscriber's address" do
+      email_alert_api_has_updated_subscriber("test@example.com", "test2@example.com")
+      api_response = api_client.change_subscriber(
+        address: "test@example.com",
+        new_address: "test2@example.com"
+      )
+      assert_equal(200, api_response.code)
+      parsed_body = api_response.to_h
+      assert_equal("test2@example.com", parsed_body["subscriber"]["address"])
+    end
+  end
+
+  describe "change_subscriber when a subscriber doesn't exist" do
+    it "returns 404" do
+      email_alert_api_does_not_have_updated_subscriber("test@example.com")
+
+      assert_raises GdsApi::HTTPNotFound do
+        api_client.change_subscriber(
+          address: "test@example.com",
+          new_address: "test2@example.com"
+        )
+      end
+    end
+  end
+
+  describe "change_subscription when a subscription exists" do
+    it "changes the subscription's frequency" do
+      email_alert_api_has_updated_subscription(
+        "8ed841d1-3d20-4633-aaf4-df41deaaf51c",
+        "weekly"
+      )
+      api_response = api_client.change_subscription(
+        id: "8ed841d1-3d20-4633-aaf4-df41deaaf51c",
+        frequency: "weekly"
+      )
+      assert_equal(200, api_response.code)
+      parsed_body = api_response.to_h
+      assert_equal("weekly", parsed_body["subscription"]["frequency"])
+    end
+  end
+
+  describe "change_subscription when a subscription doesn't exist" do
+    it "returns 404" do
+      email_alert_api_does_not_have_updated_subscription("8ed841d1-3d20-4633-aaf4-df41deaaf51c")
+
+      assert_raises GdsApi::HTTPNotFound do
+        api_client.change_subscription(
+          id: "8ed841d1-3d20-4633-aaf4-df41deaaf51c",
+          frequency: "weekly"
+        )
+      end
+    end
+  end
+
+  describe "get_subscriptions when a subscriber exists" do
+    it "returns it" do
+      email_alert_api_has_subscriber_subscriptions("test@example.com")
+      api_response = api_client.get_subscriptions(address: "test@example.com")
+      assert_equal(200, api_response.code)
+      parsed_body = api_response.to_h
+      assert_equal("some-thing", parsed_body["subscriptions"][0]["subscriber_list"]["slug"])
+    end
+  end
+
+  describe "get_subscriptions when a subscriber doesn't exist" do
+    it "returns 404" do
+      email_alert_api_does_not_have_subscriber_subscriptions("test@example.com")
+
+      assert_raises GdsApi::HTTPNotFound do
+        api_client.get_subscriptions(address: "test@example.com")
+      end
+    end
+  end
 end


### PR DESCRIPTION
This commit adds three new email-alert-api endpoints to list a user’s subscriptions, change an email address and change a subscription’s frequency.