### PR TITLE
Revert "Group exceptions in Sentry by type"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Avoid grouping Sentry errors by exception type
+
 # 52.2.1
 
 * Add a title parameter to the `get_subscription_response` stub for Email Alert API.

--- a/lib/gds_api/exceptions.rb
+++ b/lib/gds_api/exceptions.rb
@@ -1,17 +1,6 @@
 module GdsApi
   # Abstract error class
-  class BaseError < StandardError
-    # Give Sentry extra context about this event
-    # https://docs.sentry.io/clients/ruby/context/
-    def raven_context
-      {
-        # Make Sentry group exceptions by type instead of message, so all
-        # exceptions like `GdsApi::TimedOutException` will get grouped as one
-        # error and not an error per URL.
-        fingerprint: [self.class.name],
-      }
-    end
-  end
+  class BaseError < StandardError; end
 
   class EndpointNotFound < BaseError; end
   class TimedOutException < BaseError; end

--- a/test/exceptions_test.rb
+++ b/test/exceptions_test.rb
@@ -1,9 +1,0 @@
-require 'test_helper'
-
-class GdsApiBaseTest < Minitest::Test
-  def test_fingerprints_per_exception_type
-    exception = GdsApi::HTTPBadGateway.new(200)
-
-    assert_equal ["GdsApi::HTTPBadGateway"], exception.raven_context[:fingerprint]
-  end
-end


### PR DESCRIPTION
This reverts commit cadedca67c1f431132503f65279c7a49ae89d303 (previously in PR #742).

I think this grouping is a little too aggressive and I'm wondering whether it might be better to remove it until we can come up with something a little better.

To illustrate the problem: this grouping means that we currently have about 12,000 instances of [the `GdsApi::HTTPUnprocessableEntity` exception in Whitehall][1]. These 12,000 exceptions will be a combination of requests to different services (at least asset-manager, publishing-api and rummager - there may be others but they're hard to find in the noise), for different reasons (e.g. an asset isn't in the expected state in asset-manager or there's a base_path conflict in publishing-api), from Rails and from Sidekiq, and for different environments (integration, staging and production).

All of which means that I don't think viewing these exceptions in Sentry is particularly useful. My preference would be for each URL to appear as a separate exception (which is the default behaviour, I believe) and for us to use Sentry's merging functionality to group them if they really are the same. [Sentry makes it easy to merge issues but impossible to unmerge][2].

[1]: https://sentry.io/govuk/app-whitehall/issues/343661139/
[2]: https://help.sentry.io/hc/en-us/articles/115000151633-Can-I-unmerge-if-I-have-accidentally-merged-issues-together-