### PR TITLE
Change subscription management endpoints to use IDs

### DIFF
--- a/lib/gds_api/email_alert_api.rb
+++ b/lib/gds_api/email_alert_api.rb
@@ -127,22 +127,22 @@ class GdsApi::EmailAlertApi < GdsApi::Base
 
   # Get Subscriptions for a Subscriber
   # #
-  # @param string Subscriber address
+  # @param integer Subscriber id
   #
   # @return [Hash] subscriber, subscriptions
-  def get_subscriptions(address:)
-    get_json("#{endpoint}/subscribers/#{address}/subscriptions")
+  def get_subscriptions(id:)
+    get_json("#{endpoint}/subscribers/#{id}/subscriptions")
   end
 
   # Patch a Subscriber
   # #
-  # @param string Subscriber address
+  # @param integer Subscriber id
   # @param string Subscriber new_address
   #
   # @return [Hash] subscriber
-  def change_subscriber(address:, new_address:)
+  def change_subscriber(id:, new_address:)
     patch_json(
-      "#{endpoint}/subscribers/#{address}",
+      "#{endpoint}/subscribers/#{id}",
       new_address: new_address
     )
   end

--- a/lib/gds_api/test_helpers/email_alert_api.rb
+++ b/lib/gds_api/test_helpers/email_alert_api.rb
@@ -6,16 +6,16 @@ module GdsApi
     module EmailAlertApi
       EMAIL_ALERT_API_ENDPOINT = Plek.find("email-alert-api")
 
-      def email_alert_api_has_updated_subscriber(old_address, new_address)
-        stub_request(:patch, subscriber_url(old_address))
+      def email_alert_api_has_updated_subscriber(id, new_address)
+        stub_request(:patch, subscriber_url(id))
           .to_return(
             status: 200,
-            body: get_subscriber_response(new_address).to_json,
+            body: get_subscriber_response(id, new_address).to_json,
           )
       end
 
-      def email_alert_api_does_not_have_updated_subscriber(address)
-        stub_request(:patch, subscriber_url(address))
+      def email_alert_api_does_not_have_updated_subscriber(id)
+        stub_request(:patch, subscriber_url(id))
           .to_return(status: 404)
       end
 
@@ -32,16 +32,16 @@ module GdsApi
           .to_return(status: 404)
       end
 
-      def email_alert_api_has_subscriber_subscriptions(address)
-        stub_request(:get, subscriber_subscriptions_url(address))
+      def email_alert_api_has_subscriber_subscriptions(id, address)
+        stub_request(:get, subscriber_subscriptions_url(id))
           .to_return(
             status: 200,
-            body: get_subscriber_subscriptions_response(address).to_json,
+            body: get_subscriber_subscriptions_response(id, address).to_json,
           )
       end
 
-      def email_alert_api_does_not_have_subscriber_subscriptions(address)
-        stub_request(:get, subscriber_subscriptions_url(address))
+      def email_alert_api_does_not_have_subscriber_subscriptions(id)
+        stub_request(:get, subscriber_subscriptions_url(id))
           .to_return(status: 404)
       end
 
@@ -81,10 +81,10 @@ module GdsApi
           )
       end
 
-      def get_subscriber_response(address)
+      def get_subscriber_response(id, address)
         {
           "subscriber" => {
-            "id" => 1,
+            "id" => id,
             "address" => address
           }
         }
@@ -106,10 +106,10 @@ module GdsApi
         }
       end
 
-      def get_subscriber_subscriptions_response(address)
+      def get_subscriber_subscriptions_response(id, address)
         {
           "subscriber" => {
-            "id" => 1,
+            "id" => id,
             "address" => address
           },
           "subscriptions" => [
@@ -292,12 +292,12 @@ module GdsApi
         EMAIL_ALERT_API_ENDPOINT + "/subscribables/#{reference}"
       end
 
-      def subscriber_url(address)
-        EMAIL_ALERT_API_ENDPOINT + "/subscribers/#{address}"
+      def subscriber_url(id)
+        EMAIL_ALERT_API_ENDPOINT + "/subscribers/#{id}"
       end
 
-      def subscriber_subscriptions_url(address)
-        EMAIL_ALERT_API_ENDPOINT + "/subscribers/#{address}/subscriptions"
+      def subscriber_subscriptions_url(id)
+        EMAIL_ALERT_API_ENDPOINT + "/subscribers/#{id}/subscriptions"
       end
     end
   end

--- a/test/email_alert_api_test.rb
+++ b/test/email_alert_api_test.rb
@@ -373,9 +373,9 @@ describe GdsApi::EmailAlertApi do
 
   describe "change_subscriber when a subscriber exists" do
     it "changes the subscriber's address" do
-      email_alert_api_has_updated_subscriber("test@example.com", "test2@example.com")
+      email_alert_api_has_updated_subscriber(1, "test2@example.com")
       api_response = api_client.change_subscriber(
-        address: "test@example.com",
+        id: 1,
         new_address: "test2@example.com"
       )
       assert_equal(200, api_response.code)
@@ -386,11 +386,11 @@ describe GdsApi::EmailAlertApi do
 
   describe "change_subscriber when a subscriber doesn't exist" do
     it "returns 404" do
-      email_alert_api_does_not_have_updated_subscriber("test@example.com")
+      email_alert_api_does_not_have_updated_subscriber(1)
 
       assert_raises GdsApi::HTTPNotFound do
         api_client.change_subscriber(
-          address: "test@example.com",
+          id: 1,
           new_address: "test2@example.com"
         )
       end
@@ -428,8 +428,8 @@ describe GdsApi::EmailAlertApi do
 
   describe "get_subscriptions when a subscriber exists" do
     it "returns it" do
-      email_alert_api_has_subscriber_subscriptions("test@example.com")
-      api_response = api_client.get_subscriptions(address: "test@example.com")
+      email_alert_api_has_subscriber_subscriptions(1, "test@example.com")
+      api_response = api_client.get_subscriptions(id: 1)
       assert_equal(200, api_response.code)
       parsed_body = api_response.to_h
       assert_equal("some-thing", parsed_body["subscriptions"][0]["subscriber_list"]["slug"])
@@ -438,10 +438,10 @@ describe GdsApi::EmailAlertApi do
 
   describe "get_subscriptions when a subscriber doesn't exist" do
     it "returns 404" do
-      email_alert_api_does_not_have_subscriber_subscriptions("test@example.com")
+      email_alert_api_does_not_have_subscriber_subscriptions(1)
 
       assert_raises GdsApi::HTTPNotFound do
-        api_client.get_subscriptions(address: "test@example.com")
+        api_client.get_subscriptions(id: 1)
       end
     end
   end


### PR DESCRIPTION
This commit changes the two endpoints created for email-alert-frontend to accept a subscriber ID rather than an email address since we’ll be using the ID as an email address can change. The endpoints are not currently in use so they can be changed.