### PR TITLE
Add email-alert-api unsubscribe_all endpoint

### DIFF
--- a/lib/gds_api/email_alert_api.rb
+++ b/lib/gds_api/email_alert_api.rb
@@ -68,13 +68,22 @@ class GdsApi::EmailAlertApi < GdsApi::Base
     get_json("#{endpoint}/topic-matches.json?#{query_string}")
   end
 
-  # Unsubscribe
+  # Unsubscribe subscriber from subscription
   # #
   # @param uuid Subscription uuid
   #
-  # @return [Hash] deleted
+  # @return null
   def unsubscribe(uuid)
     post_json("#{endpoint}/unsubscribe/#{uuid}")
+  end
+
+  # Unsubscribe subscriber from everything
+  # #
+  # @param integer Subscriber id
+  #
+  # @return null
+  def unsubscribe_subscriber(id)
+    delete_json("#{endpoint}/subscribers/#{id}")
   end
 
   # Subscribe

--- a/lib/gds_api/test_helpers/email_alert_api.rb
+++ b/lib/gds_api/test_helpers/email_alert_api.rb
@@ -196,6 +196,16 @@ module GdsApi
           .to_return(status: 404)
       end
 
+      def email_alert_api_unsubscribes_a_subscriber(subscriber_id)
+        stub_request(:delete, unsubscribe_subscriber_url(subscriber_id))
+          .to_return(status: 204)
+      end
+
+      def email_alert_api_has_no_subscriber(subscriber_id)
+        stub_request(:delete, unsubscribe_subscriber_url(subscriber_id))
+          .to_return(status: 404)
+      end
+
       def email_alert_api_creates_a_subscription(subscribable_id, address, frequency, returned_subscription_id)
         stub_request(:post, subscribe_url)
           .with(
@@ -278,6 +288,10 @@ module GdsApi
 
       def unsubscribe_url(uuid)
         EMAIL_ALERT_API_ENDPOINT + "/unsubscribe/#{uuid}"
+      end
+
+      def unsubscribe_subscriber_url(id)
+        EMAIL_ALERT_API_ENDPOINT + "/subscribers/#{id}"
       end
 
       def subscribe_url

--- a/test/email_alert_api_test.rb
+++ b/test/email_alert_api_test.rb
@@ -250,7 +250,7 @@ describe GdsApi::EmailAlertApi do
     end
   end
 
-  describe "unsubscribing" do
+  describe "unsubscribing from a topic" do
     describe "with an existing subscription" do
       it "returns a 204" do
         uuid = SecureRandom.uuid
@@ -271,6 +271,32 @@ describe GdsApi::EmailAlertApi do
 
         assert_raises GdsApi::HTTPNotFound do
           api_client.unsubscribe(uuid)
+        end
+      end
+    end
+  end
+
+  describe "unsubscribing from everything" do
+    describe "with an existing subscriber" do
+      it "returns a 204" do
+        subscriber_id = SecureRandom.random_number(10)
+        email_alert_api_unsubscribes_a_subscriber(subscriber_id)
+        api_response = api_client.unsubscribe_subscriber(subscriber_id)
+
+        assert_equal(
+          api_response.code,
+          204
+        )
+      end
+    end
+
+    describe "without an existing subscriber" do
+      it "returns a 404" do
+        subscriber_id = SecureRandom.random_number(10)
+        email_alert_api_has_no_subscriber(subscriber_id)
+
+        assert_raises GdsApi::HTTPNotFound do
+          api_client.unsubscribe_subscriber(subscriber_id)
         end
       end
     end


### PR DESCRIPTION
This commit adds the `unsubscribe_all` endpoint from email-alert-api which accepts a subscriber ID and unsubscribes them from all their subscriptions.