### PR TITLE
Create auth token method for Email Alert API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Add `create_auth_token` to `GdsApi::EmailAlertApi`.
+
 # 52.4.0
 
 * Add `unsubscribe_subscriber` to `GdsApi::EmailAlertApi`.

--- a/lib/gds_api/email_alert_api.rb
+++ b/lib/gds_api/email_alert_api.rb
@@ -169,6 +169,23 @@ class GdsApi::EmailAlertApi < GdsApi::Base
     )
   end
 
+  # Create an authentication token for a subscriber
+  #
+  # @param [string]       address       Email address of subscriber to create token for
+  # @param [string]       destination   Path on GOV.UK that subscriber will be emailed
+  # @param [string, nil]  redirect      Path on GOV.UK to be encoded into the token for redirecting
+  #
+  # @return [Hash]  subscriber
+  #
+  def create_auth_token(address:, destination:, redirect: nil)
+    post_json(
+      "#{endpoint}/subscribers/auth-token",
+      address: address,
+      destination: destination,
+      redirect: redirect,
+    )
+  end
+
 private
 
   def nested_query_string(params)

--- a/lib/gds_api/email_alert_api.rb
+++ b/lib/gds_api/email_alert_api.rb
@@ -69,19 +69,19 @@ class GdsApi::EmailAlertApi < GdsApi::Base
   end
 
   # Unsubscribe subscriber from subscription
-  # #
-  # @param uuid Subscription uuid
   #
-  # @return null
+  # @param [string] Subscription uuid
+  #
+  # @return [nil]
   def unsubscribe(uuid)
     post_json("#{endpoint}/unsubscribe/#{uuid}")
   end
 
   # Unsubscribe subscriber from everything
-  # #
-  # @param integer Subscriber id
   #
-  # @return null
+  # @param [integer] Subscriber id
+  #
+  # @return [nil]
   def unsubscribe_subscriber(id)
     delete_json("#{endpoint}/subscribers/#{id}")
   end
@@ -135,8 +135,8 @@ class GdsApi::EmailAlertApi < GdsApi::Base
   end
 
   # Get Subscriptions for a Subscriber
-  # #
-  # @param integer Subscriber id
+  #
+  # @param [integer] Subscriber id
   #
   # @return [Hash] subscriber, subscriptions
   def get_subscriptions(id:)
@@ -144,9 +144,9 @@ class GdsApi::EmailAlertApi < GdsApi::Base
   end
 
   # Patch a Subscriber
-  # #
-  # @param integer Subscriber id
-  # @param string Subscriber new_address
+  #
+  # @param [integer] Subscriber id
+  # @param [string] Subscriber new_address
   #
   # @return [Hash] subscriber
   def change_subscriber(id:, new_address:)
@@ -157,9 +157,9 @@ class GdsApi::EmailAlertApi < GdsApi::Base
   end
 
   # Patch a Subscription
-  # #
-  # @param string Subscription id
-  # @param string Subscription frequency
+  #
+  # @param [string] Subscription id
+  # @param [string] Subscription frequency
   #
   # @return [Hash] subscription
   def change_subscription(id:, frequency:)

--- a/lib/gds_api/test_helpers/email_alert_api.rb
+++ b/lib/gds_api/test_helpers/email_alert_api.rb
@@ -7,7 +7,7 @@ module GdsApi
       EMAIL_ALERT_API_ENDPOINT = Plek.find("email-alert-api")
 
       def email_alert_api_has_updated_subscriber(id, new_address)
-        stub_request(:patch, subscriber_url(id))
+        stub_request(:patch, "#{EMAIL_ALERT_API_ENDPOINT}/subscribers/#{id}")
           .to_return(
             status: 200,
             body: get_subscriber_response(id, new_address).to_json,
@@ -15,12 +15,12 @@ module GdsApi
       end
 
       def email_alert_api_does_not_have_updated_subscriber(id)
-        stub_request(:patch, subscriber_url(id))
+        stub_request(:patch, "#{EMAIL_ALERT_API_ENDPOINT}/subscribers/#{id}")
           .to_return(status: 404)
       end
 
       def email_alert_api_has_updated_subscription(subscription_id, frequency)
-        stub_request(:patch, subscription_url(subscription_id))
+        stub_request(:patch, "#{EMAIL_ALERT_API_ENDPOINT}/subscriptions/#{subscription_id}")
           .to_return(
             status: 200,
             body: get_subscription_response(subscription_id, frequency).to_json,
@@ -28,12 +28,12 @@ module GdsApi
       end
 
       def email_alert_api_does_not_have_updated_subscription(subscription_id)
-        stub_request(:patch, subscription_url(subscription_id))
+        stub_request(:patch, "#{EMAIL_ALERT_API_ENDPOINT}/subscriptions/#{subscription_id}")
           .to_return(status: 404)
       end
 
       def email_alert_api_has_subscriber_subscriptions(id, address)
-        stub_request(:get, subscriber_subscriptions_url(id))
+        stub_request(:get, "#{EMAIL_ALERT_API_ENDPOINT}/subscribers/#{id}/subscriptions")
           .to_return(
             status: 200,
             body: get_subscriber_subscriptions_response(id, address).to_json,
@@ -41,12 +41,12 @@ module GdsApi
       end
 
       def email_alert_api_does_not_have_subscriber_subscriptions(id)
-        stub_request(:get, subscriber_subscriptions_url(id))
+        stub_request(:get, "#{EMAIL_ALERT_API_ENDPOINT}/subscribers/#{id}/subscriptions")
           .to_return(status: 404)
       end
 
       def email_alert_api_has_subscription(id, frequency, title: "Some title")
-        stub_request(:get, subscription_url(id))
+        stub_request(:get, "#{EMAIL_ALERT_API_ENDPOINT}/subscriptions/#{id}")
           .to_return(
             status: 200,
             body: get_subscription_response(id, frequency, title).to_json,
@@ -54,7 +54,7 @@ module GdsApi
       end
 
       def email_alert_api_has_subscriber_list(attributes)
-        stub_request(:get, subscriber_lists_url(attributes))
+        stub_request(:get, build_subscriber_lists_url(attributes))
           .to_return(
             status: 200,
             body: get_subscriber_list_response(attributes).to_json,
@@ -62,12 +62,12 @@ module GdsApi
       end
 
       def email_alert_api_does_not_have_subscriber_list(attributes)
-        stub_request(:get, subscriber_lists_url(attributes))
+        stub_request(:get, build_subscriber_lists_url(attributes))
           .to_return(status: 404)
       end
 
       def email_alert_api_creates_subscriber_list(attributes)
-        stub_request(:post, subscriber_lists_url)
+        stub_request(:post, build_subscriber_lists_url)
           .to_return(
             status: 201,
             body: get_subscriber_list_response(attributes).to_json,
@@ -75,11 +75,132 @@ module GdsApi
       end
 
       def email_alert_api_refuses_to_create_subscriber_list
-        stub_request(:post, subscriber_lists_url)
+        stub_request(:post, build_subscriber_lists_url)
+          .to_return(status: 422)
+      end
+
+      def email_alert_api_accepts_alert
+        stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/notifications")
+          .to_return(status: 202, body: {}.to_json)
+      end
+
+      def stub_any_email_alert_api_call
+        stub_request(:any, %r{\A#{EMAIL_ALERT_API_ENDPOINT}})
+      end
+
+      def assert_email_alert_sent(attributes = nil)
+        if attributes
+          matcher = ->(request) do
+            payload = JSON.parse(request.body)
+            payload.select { |k, _| attributes.key?(k) } == attributes
+          end
+        end
+
+        assert_requested(:post, "#{EMAIL_ALERT_API_ENDPOINT}/notifications", times: 1, &matcher)
+      end
+
+      def email_alert_api_has_notifications(notifications, start_at = nil)
+        url = "#{EMAIL_ALERT_API_ENDPOINT}/notifications"
+        url += "?start_at=#{start_at}" if start_at
+        url_regexp = Regexp.new("^#{Regexp.escape(url)}$")
+
+        stub_request(:get, url_regexp)
           .to_return(
-            status: 422,
+            status: 200,
+            body: notifications.to_json
           )
       end
+
+      def email_alert_api_has_notification(notification)
+        url = "#{EMAIL_ALERT_API_ENDPOINT}/notifications/#{notification['web_service_bulletin']['to_param']}"
+
+        stub_request(:get, url).to_return(
+          status: 200,
+          body: notification.to_json
+        )
+      end
+
+      def email_alert_api_unsubscribes_a_subscription(uuid)
+        stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/unsubscribe/#{uuid}")
+          .with(body: "{}")
+          .to_return(status: 204)
+      end
+
+      def email_alert_api_has_no_subscription_for_uuid(uuid)
+        stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/unsubscribe/#{uuid}")
+          .with(body: "{}")
+          .to_return(status: 404)
+      end
+
+      def email_alert_api_unsubscribes_a_subscriber(subscriber_id)
+        stub_request(:delete, "#{EMAIL_ALERT_API_ENDPOINT}/subscribers/#{subscriber_id}")
+          .to_return(status: 204)
+      end
+
+      def email_alert_api_has_no_subscriber(subscriber_id)
+        stub_request(:delete, "#{EMAIL_ALERT_API_ENDPOINT}/subscribers/#{subscriber_id}")
+          .to_return(status: 404)
+      end
+
+      def email_alert_api_creates_a_subscription(subscribable_id, address, frequency, returned_subscription_id)
+        stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscriptions")
+          .with(
+            body: { subscribable_id: subscribable_id, address: address, frequency: frequency }.to_json
+        ).to_return(status: 201, body: { subscription_id: returned_subscription_id }.to_json)
+      end
+
+      def email_alert_api_creates_an_existing_subscription(subscribable_id, address, frequency, returned_subscription_id)
+        stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscriptions")
+          .with(
+            body: { subscribable_id: subscribable_id, address: address, frequency: frequency }.to_json
+        ).to_return(status: 200, body: { subscription_id: returned_subscription_id }.to_json)
+      end
+
+      def email_alert_api_refuses_to_create_subscription(subscribable_id, address, frequency)
+        stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscriptions")
+          .with(
+            body: { subscribable_id: subscribable_id, address: address, frequency: frequency }.to_json
+        ).to_return(status: 422)
+      end
+
+      def email_alert_api_creates_an_auth_token(subscriber_id, address)
+        stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscribers/auth-token")
+          .to_return(
+            status: 201,
+            body: get_subscriber_response(subscriber_id, address).to_json
+          )
+      end
+
+      def assert_unsubscribed(uuid)
+        assert_requested(:post, "#{EMAIL_ALERT_API_ENDPOINT}/unsubscribe/#{uuid}", times: 1)
+      end
+
+      def assert_subscribed(subscribable_id, address, frequency = "immediately")
+        assert_requested(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscriptions") do |req|
+          JSON.parse(req.body).symbolize_keys == {
+            subscribable_id: subscribable_id,
+            address: address,
+            frequency: frequency
+          }
+        end
+      end
+
+      def email_alert_api_has_subscribable(reference:, returned_attributes:)
+        stub_request(:get, "#{EMAIL_ALERT_API_ENDPOINT}/subscribables/#{reference}")
+          .to_return(
+            status: 200,
+            body: {
+              subscribable: returned_attributes
+            }.to_json
+        )
+      end
+
+      def email_alert_api_does_not_have_subscribable(reference:)
+        stub_request(:get, "#{EMAIL_ALERT_API_ENDPOINT}/subscribables/#{reference}")
+          .to_return(status: 404)
+      end
+
+    private
 
       def get_subscriber_response(id, address)
         {
@@ -136,137 +257,11 @@ module GdsApi
         }
       end
 
-      def email_alert_api_accepts_alert
-        stub_request(:post, notifications_url)
-          .to_return(
-            status: 202,
-            body: {}.to_json,
-          )
-      end
-
       def post_alert_response
         {}
       end
 
-      def stub_any_email_alert_api_call
-        stub_request(:any, %r{\A#{EMAIL_ALERT_API_ENDPOINT}})
-      end
-
-      def assert_email_alert_sent(attributes = nil)
-        if attributes
-          matcher = ->(request) do
-            payload = JSON.parse(request.body)
-            payload.select { |k, _| attributes.key?(k) } == attributes
-          end
-        end
-
-        assert_requested(:post, notifications_url, times: 1, &matcher)
-      end
-
-      def email_alert_api_has_notifications(notifications, start_at = nil)
-        url = notifications_url
-        url += "?start_at=#{start_at}" if start_at
-        url_regexp = Regexp.new("^#{Regexp.escape(url)}$")
-
-        stub_request(:get, url_regexp)
-          .to_return(
-            status: 200,
-            body: notifications.to_json
-          )
-      end
-
-      def email_alert_api_has_notification(notification)
-        url = "#{notifications_url}/#{notification['web_service_bulletin']['to_param']}"
-
-        stub_request(:get, url).to_return(
-          status: 200,
-          body: notification.to_json
-        )
-      end
-
-      def email_alert_api_unsubscribes_a_subscription(uuid)
-        stub_request(:post, unsubscribe_url(uuid))
-          .with(body: "{}")
-          .to_return(status: 204)
-      end
-
-      def email_alert_api_has_no_subscription_for_uuid(uuid)
-        stub_request(:post, unsubscribe_url(uuid))
-          .with(body: "{}")
-          .to_return(status: 404)
-      end
-
-      def email_alert_api_unsubscribes_a_subscriber(subscriber_id)
-        stub_request(:delete, unsubscribe_subscriber_url(subscriber_id))
-          .to_return(status: 204)
-      end
-
-      def email_alert_api_has_no_subscriber(subscriber_id)
-        stub_request(:delete, unsubscribe_subscriber_url(subscriber_id))
-          .to_return(status: 404)
-      end
-
-      def email_alert_api_creates_a_subscription(subscribable_id, address, frequency, returned_subscription_id)
-        stub_request(:post, subscribe_url)
-          .with(
-            body: { subscribable_id: subscribable_id, address: address, frequency: frequency }.to_json
-        ).to_return(status: 201, body: { subscription_id: returned_subscription_id }.to_json)
-      end
-
-      def email_alert_api_creates_an_existing_subscription(subscribable_id, address, frequency, returned_subscription_id)
-        stub_request(:post, subscribe_url)
-          .with(
-            body: { subscribable_id: subscribable_id, address: address, frequency: frequency }.to_json
-        ).to_return(status: 200, body: { subscription_id: returned_subscription_id }.to_json)
-      end
-
-      def email_alert_api_refuses_to_create_subscription(subscribable_id, address, frequency)
-        stub_request(:post, subscribe_url)
-          .with(
-            body: { subscribable_id: subscribable_id, address: address, frequency: frequency }.to_json
-        ).to_return(status: 422)
-      end
-
-      def email_alert_api_creates_an_auth_token(subscriber_id, address)
-        stub_request(:post, auth_token_url)
-          .to_return(
-            status: 201,
-            body: get_subscriber_response(subscriber_id, address).to_json
-          )
-      end
-
-      def assert_unsubscribed(uuid)
-        assert_requested(:post, unsubscribe_url(uuid), times: 1)
-      end
-
-      def assert_subscribed(subscribable_id, address, frequency = "immediately")
-        assert_requested(:post, subscribe_url) do |req|
-          JSON.parse(req.body).symbolize_keys == {
-            subscribable_id: subscribable_id,
-            address: address,
-            frequency: frequency
-          }
-        end
-      end
-
-      def email_alert_api_has_subscribable(reference:, returned_attributes:)
-        stub_request(:get, subscribable_url(reference))
-          .to_return(
-            status: 200,
-            body: {
-              subscribable: returned_attributes
-            }.to_json
-        )
-      end
-
-      def email_alert_api_does_not_have_subscribable(reference:)
-        stub_request(:get, subscribable_url(reference))
-          .to_return(status: 404)
-      end
-
-    private
-
-      def subscriber_lists_url(attributes = nil)
+      def build_subscriber_lists_url(attributes = nil)
         if attributes
           tags = attributes["tags"]
           links = attributes["links"]
@@ -286,44 +281,8 @@ module GdsApi
           query = Rack::Utils.build_nested_query(params)
         end
 
-        url = EMAIL_ALERT_API_ENDPOINT + "/subscriber-lists"
+        url = "#{EMAIL_ALERT_API_ENDPOINT}/subscriber-lists"
         query ? "#{url}?#{query}" : url
-      end
-
-      def notifications_url
-        EMAIL_ALERT_API_ENDPOINT + "/notifications"
-      end
-
-      def unsubscribe_url(uuid)
-        EMAIL_ALERT_API_ENDPOINT + "/unsubscribe/#{uuid}"
-      end
-
-      def unsubscribe_subscriber_url(id)
-        EMAIL_ALERT_API_ENDPOINT + "/subscribers/#{id}"
-      end
-
-      def subscribe_url
-        EMAIL_ALERT_API_ENDPOINT + "/subscriptions"
-      end
-
-      def subscription_url(id)
-        EMAIL_ALERT_API_ENDPOINT + "/subscriptions/#{id}"
-      end
-
-      def subscribable_url(reference)
-        EMAIL_ALERT_API_ENDPOINT + "/subscribables/#{reference}"
-      end
-
-      def subscriber_url(id)
-        EMAIL_ALERT_API_ENDPOINT + "/subscribers/#{id}"
-      end
-
-      def subscriber_subscriptions_url(id)
-        EMAIL_ALERT_API_ENDPOINT + "/subscribers/#{id}/subscriptions"
-      end
-
-      def auth_token_url
-        EMAIL_ALERT_API_ENDPOINT + "/subscribers/auth-token"
       end
     end
   end

--- a/lib/gds_api/test_helpers/email_alert_api.rb
+++ b/lib/gds_api/test_helpers/email_alert_api.rb
@@ -227,6 +227,14 @@ module GdsApi
         ).to_return(status: 422)
       end
 
+      def email_alert_api_creates_an_auth_token(subscriber_id, address)
+        stub_request(:post, auth_token_url)
+          .to_return(
+            status: 201,
+            body: get_subscriber_response(subscriber_id, address).to_json
+          )
+      end
+
       def assert_unsubscribed(uuid)
         assert_requested(:post, unsubscribe_url(uuid), times: 1)
       end
@@ -312,6 +320,10 @@ module GdsApi
 
       def subscriber_subscriptions_url(id)
         EMAIL_ALERT_API_ENDPOINT + "/subscribers/#{id}/subscriptions"
+      end
+
+      def auth_token_url
+        EMAIL_ALERT_API_ENDPOINT + "/subscribers/auth-token"
       end
     end
   end

--- a/test/email_alert_api_test.rb
+++ b/test/email_alert_api_test.rb
@@ -471,4 +471,12 @@ describe GdsApi::EmailAlertApi do
       end
     end
   end
+
+  describe "create an auth token" do
+    it "returns 201" do
+      email_alert_api_creates_an_auth_token(1, "test@example.com")
+      api_response = api_client.create_auth_token(address: 1, destination: "/test")
+      assert_equal(201, api_response.code)
+    end
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -28,14 +28,14 @@ require 'pact/consumer/minitest'
 module PactTest
   include Pact::Consumer::Minitest
 
-  def before_suite
+  def before_setup
     # Pact does its own stubbing of network connections, so we want to
     # prevent WebMock interfering when pact is being used.
     ::WebMock.allow_net_connect!
     super
   end
 
-  def after_suite
+  def after_teardown
     super
     ::WebMock.disable_net_connect!
   end


### PR DESCRIPTION
Trello: https://trello.com/c/6YmlH3Mq/725-add-token-based-login-for-the-subscription-management-interface-to-email-alert-frontend

This adds a convenience method and a stub for the POST
/subscribers/auth-token method on Email Alert API.

This is DNM until https://github.com/alphagov/email-alert-api/pull/560 has been merged and deployed.