### PR TITLE
Bump to 52.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 52.5.0
 
 * Add `create_auth_token` to `GdsApi::EmailAlertApi`.
 

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '52.4.0'.freeze
+  VERSION = '52.5.0'.freeze
 end


### PR DESCRIPTION
* Add `create_auth_token` to `GdsApi::EmailAlertApi`.