### PR TITLE
Fix inaccuracies in subscription show response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Make the subscription response for Email Alert API closer to reality.
+
 # 52.5.0
 
 * Add `create_auth_token` to `GdsApi::EmailAlertApi`.

--- a/lib/gds_api/test_helpers/email_alert_api.rb
+++ b/lib/gds_api/test_helpers/email_alert_api.rb
@@ -23,7 +23,7 @@ module GdsApi
         stub_request(:patch, "#{EMAIL_ALERT_API_ENDPOINT}/subscriptions/#{subscription_id}")
           .to_return(
             status: 200,
-            body: get_subscription_response(subscription_id, frequency).to_json,
+            body: get_subscription_response(subscription_id, frequency: frequency).to_json,
           )
       end
 
@@ -45,11 +45,25 @@ module GdsApi
           .to_return(status: 404)
       end
 
-      def email_alert_api_has_subscription(id, frequency, title: "Some title")
+      def email_alert_api_has_subscription(
+        id,
+        frequency,
+        title: "Some title",
+        subscriber_id: 1,
+        subscriber_list_id: 1000,
+        ended: false
+      )
         stub_request(:get, "#{EMAIL_ALERT_API_ENDPOINT}/subscriptions/#{id}")
           .to_return(
             status: 200,
-            body: get_subscription_response(id, frequency, title).to_json,
+            body: get_subscription_response(
+              id,
+              frequency: frequency,
+              title: title,
+              subscriber_id: subscriber_id,
+              subscriber_list_id: subscriber_list_id,
+              ended: ended,
+            ).to_json,
           )
       end
 
@@ -211,15 +225,27 @@ module GdsApi
         }
       end
 
-      def get_subscription_response(id, frequency, title = "Some title")
+      def get_subscription_response(
+        id,
+        frequency: "daily",
+        title: "Some title",
+        subscriber_id: 1,
+        subscriber_list_id: 1000,
+        ended: false
+      )
         {
           "subscription" => {
-            "subscriber_id" => 1,
-            "subscriber_list_id" => 1000,
-            "frequency" => frequency,
             "id" => id,
+            "frequency" => frequency,
+            "source" => "user_signed_up",
+            "ended_at" => ended ? Time.now.rfc3339 : nil,
+            "ended_reason" => ended ? "unsubscribed" : nil,
+            "subscriber" => {
+              "id" => subscriber_id,
+              "address" => "test@example.com",
+            },
             "subscriber_list" => {
-              "id" => 1000,
+              "id" => subscriber_list_id,
               "slug" => "some-thing",
               "title" => title,
             }


### PR DESCRIPTION
This changes the subscription show response as it was inaccurate and
meant tests could pass or code could work (d'oh).

This response is still not fully valid as lots more fields are returned
that this, however changing all of this seems inconsistent with other
stubbed responses here which are quite minimal.

It includes additional options so that tests can represent more
scenarios.