### PR TITLE
Enhance the special route publisher to check first

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -12,6 +12,7 @@ Rake::TestTask.new("test") do |t|
   t.libs << "test"
   t.test_files = FileList["test/**/*_test.rb"]
   t.verbose = true
+  t.warning = false
 end
 task default: :test
 

--- a/lib/gds_api/publishing_api/special_route_publisher.rb
+++ b/lib/gds_api/publishing_api/special_route_publisher.rb
@@ -10,31 +10,30 @@ module GdsApi
       end
 
       def publish(options)
-        logger.info("Publishing #{options.fetch(:type)} route #{options.fetch(:base_path)}, routing to #{options.fetch(:rendering_app)}")
+        content_id = options.fetch(:content_id)
+        edition = content_hash(options)
 
-        put_content_response = publishing_api.put_content(
-          options.fetch(:content_id),
-          base_path: options.fetch(:base_path),
-          document_type: options.fetch(:document_type, "special_route"),
-          schema_name: options.fetch(:schema_name, "special_route"),
-          title: options.fetch(:title),
-          description: options.fetch(:description, ""),
-          locale: "en",
-          details: {},
-          routes: [
-            {
-              path: options.fetch(:base_path),
-              type: options.fetch(:type),
-            }
-          ],
-          publishing_app: options.fetch(:publishing_app),
-          rendering_app: options.fetch(:rendering_app),
-          public_updated_at: time.now.iso8601,
-          update_type: options.fetch(:update_type, "major")
-        )
+        # This means that the get_content call made in
+        # publishing_necessary? will describe the published edition,
+        # and not a draft in case one has been left over (e.g. if
+        # previously the SpecialRoutePublisher crashed before calling
+        # publish).
+        discard_draft_if_one_exists(content_id)
 
-        publishing_api.patch_links(options.fetch(:content_id), links: options[:links]) if options[:links]
-        publishing_api.publish(options.fetch(:content_id))
+        if publishing_necessary?(content_id, edition)
+          logger.info("Publishing #{edition[:type]} route #{edition[:base_path]}, routing to #{edition[:rendering_app]}")
+
+          put_content_response = publishing_api.put_content(content_id, edition)
+          publishing_api.publish(content_id)
+        else
+          put_content_response = nil
+          logger.info("Skipping unnecessary publishing of #{edition[:base_path]}")
+        end
+
+        if patching_links_necessary?(content_id, options[:links])
+          publishing_api.patch_links(content_id, links: options[:links])
+        end
+
         put_content_response
       end
 
@@ -44,6 +43,78 @@ module GdsApi
 
       def time
         (Time.respond_to?(:zone) && Time.zone) || Time
+      end
+
+      def discard_draft_if_one_exists(content_id)
+        publishing_api.discard_draft(content_id)
+      rescue HTTPNotFound
+        nil # The draft didn't exist, so just continue
+      end
+
+      def publishing_necessary?(content_id, new_edition)
+        begin
+          current_edition_hash =
+            publishing_api
+              .get_content(content_id)
+              .to_h
+              .reject { |k, _v| k == 'content_id' }
+        rescue HTTPNotFound
+          return true
+        end
+
+        fields_which_differ = current_edition_hash.reject do |key, current_value|
+          new_edition.fetch(key) == current_value
+        end
+
+        !fields_which_differ.empty?
+      end
+
+      def patching_links_necessary?(content_id, links)
+        return false unless links
+
+        begin
+          existing_links =
+            publishing_api
+              .get_links(content_id)
+              .to_h
+              .fetch('links', {})
+        rescue HTTPNotFound
+          return true
+        end
+
+        differing_link_types = links.reject do |link_type, new_values|
+          new_values.sort == existing_links.fetch(link_type.to_s, []).sort
+        end
+
+        if differing_link_types.empty?
+          logger.info("Not updating links for #{content_id}, as there is no change")
+
+          false
+        else
+          true
+        end
+      end
+
+      def content_hash(options)
+        {
+          'base_path' => options.fetch(:base_path),
+          'document_type' => options.fetch(:document_type, "special_route"),
+          'schema_name' => options.fetch(:schema_name, "special_route"),
+          'title' => options.fetch(:title),
+          'description' => options.fetch(:description, ""),
+          'locale' => "en",
+          'details' => {},
+          'routes' => [
+            {
+              'path' => options.fetch(:base_path),
+              'type' => options.fetch(:type),
+            }
+          ],
+          'publishing_app' => options.fetch(:publishing_app),
+          'rendering_app' => options.fetch(:rendering_app),
+          'public_updated_at' => time.now.iso8601,
+          'update_type' => options.fetch(:update_type, "major")
+        }
       end
     end
   end

--- a/test/publishing_api/special_route_publisher_test.rb
+++ b/test/publishing_api/special_route_publisher_test.rb
@@ -44,6 +44,18 @@ describe GdsApi::PublishingApi::SpecialRoutePublisher do
   let(:publisher) { GdsApi::PublishingApi::SpecialRoutePublisher.new }
   let(:endpoint) { Plek.current.find('publishing-api') }
 
+  describe "expected put_content payload" do
+    it "is valid" do
+      validator = GovukContentSchemaTestHelpers::Validator.new(
+        "special_route",
+        "schema",
+        expected_put_content_payload
+      )
+
+      assert validator.valid?, validator.errors.join("\n")
+    end
+  end
+
   describe ".publish" do
     before do
       stub_publishing_api_put_content(special_route[:content_id], {})
@@ -60,7 +72,6 @@ describe GdsApi::PublishingApi::SpecialRoutePublisher do
           "#{endpoint}/v2/content/#{content_id}",
           body: expected_put_content_payload
         )
-        assert_valid_special_route(expected_put_content_payload)
 
         assert_publishing_api_publish(content_id)
       end
@@ -131,15 +142,5 @@ describe GdsApi::PublishingApi::SpecialRoutePublisher do
         end
       end
     end
-  end
-
-  def assert_valid_special_route(payload)
-    validator = GovukContentSchemaTestHelpers::Validator.new(
-      "special_route",
-      "schema",
-      payload
-    )
-
-    assert validator.valid?, validator.errors.join("\n")
   end
 end

--- a/test/publishing_api/special_route_publisher_test.rb
+++ b/test/publishing_api/special_route_publisher_test.rb
@@ -19,6 +19,14 @@ describe GdsApi::PublishingApi::SpecialRoutePublisher do
     }
   }
 
+  let(:special_route_links) {
+    {
+      links: {
+        organisations: ['org-content-id']
+      }
+    }
+  }
+
   let(:expected_put_content_payload) {
     {
       base_path: special_route[:base_path],
@@ -95,15 +103,13 @@ describe GdsApi::PublishingApi::SpecialRoutePublisher do
     end
 
     it "publishes links" do
-      links = {
-        links: {
-          organisations: ['org-content-id']
-        }
-      }
+      publisher.publish(special_route.merge(special_route_links))
 
-      publisher.publish(special_route.merge(links))
-
-      assert_requested(:patch, "#{endpoint}/v2/links/#{content_id}", body: links)
+      assert_requested(
+        :patch,
+        "#{endpoint}/v2/links/#{content_id}",
+        body: special_route_links
+      )
     end
   end
 

--- a/test/publishing_api/special_route_publisher_test.rb
+++ b/test/publishing_api/special_route_publisher_test.rb
@@ -24,7 +24,9 @@ describe GdsApi::PublishingApi::SpecialRoutePublisher do
 
   describe ".publish" do
     before do
-      stub_any_publishing_api_call
+      stub_publishing_api_put_content(special_route[:content_id], {})
+      stub_publishing_api_publish(special_route[:content_id], {})
+      stub_publishing_api_patch_links(special_route[:content_id], {})
     end
 
     it "publishes valid special routes" do

--- a/test/publishing_api/special_route_publisher_test.rb
+++ b/test/publishing_api/special_route_publisher_test.rb
@@ -105,41 +105,41 @@ describe GdsApi::PublishingApi::SpecialRoutePublisher do
 
       assert_requested(:patch, "#{endpoint}/v2/links/#{content_id}", body: links)
     end
+  end
 
-    describe 'Timezone handling' do
-      let(:publishing_api) {
-        stub(:publishing_api, put_content_item: nil)
-      }
-      let(:publisher) {
-        GdsApi::PublishingApi::SpecialRoutePublisher.new(publishing_api: publishing_api)
-      }
+  describe 'Timezone handling' do
+    let(:publishing_api) {
+      stub(:publishing_api, put_content_item: nil)
+    }
+    let(:publisher) {
+      GdsApi::PublishingApi::SpecialRoutePublisher.new(publishing_api: publishing_api)
+    }
 
-      it "is robust to Time.zone returning nil" do
-        Timecop.freeze(Time.now) do
-          Time.stubs(:zone).returns(nil)
-          publishing_api.expects(:put_content).with(
-            anything,
-            has_entries(public_updated_at: Time.now.iso8601)
-          )
-          publishing_api.expects(:publish)
+    it "is robust to Time.zone returning nil" do
+      Timecop.freeze(Time.now) do
+        Time.stubs(:zone).returns(nil)
+        publishing_api.expects(:put_content).with(
+          anything,
+          has_entries(public_updated_at: Time.now.iso8601)
+        )
+        publishing_api.expects(:publish)
 
-          publisher.publish(special_route)
-        end
+        publisher.publish(special_route)
       end
+    end
 
-      it "uses Time.zone if available" do
-        Timecop.freeze(Time.now) do
-          time_in_zone = stub("Time in zone", now: Time.parse("2010-01-01 10:10:10 +04:00"))
-          Time.stubs(:zone).returns(time_in_zone)
+    it "uses Time.zone if available" do
+      Timecop.freeze(Time.now) do
+        time_in_zone = stub("Time in zone", now: Time.parse("2010-01-01 10:10:10 +04:00"))
+        Time.stubs(:zone).returns(time_in_zone)
 
-          publishing_api.expects(:put_content).with(
-            anything,
-            has_entries(public_updated_at: time_in_zone.now.iso8601)
-          )
-          publishing_api.expects(:publish)
+        publishing_api.expects(:put_content).with(
+          anything,
+          has_entries(public_updated_at: time_in_zone.now.iso8601)
+        )
+        publishing_api.expects(:publish)
 
-          publisher.publish(special_route)
-        end
+        publisher.publish(special_route)
       end
     end
   end

--- a/test/publishing_api/special_route_publisher_test.rb
+++ b/test/publishing_api/special_route_publisher_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require "gds_api/publishing_api/special_route_publisher"
 require "govuk-content-schema-test-helpers"
-require File.dirname(__FILE__) + '/../../lib/gds_api/test_helpers/publishing_api_v2'
+require_relative '../../lib/gds_api/test_helpers/publishing_api_v2'
 
 describe GdsApi::PublishingApi::SpecialRoutePublisher do
   include ::GdsApi::TestHelpers::PublishingApiV2

--- a/test/publishing_api/special_route_publisher_test.rb
+++ b/test/publishing_api/special_route_publisher_test.rb
@@ -19,6 +19,28 @@ describe GdsApi::PublishingApi::SpecialRoutePublisher do
     }
   }
 
+  let(:expected_put_content_payload) {
+    {
+      base_path: special_route[:base_path],
+      document_type: "special_route",
+      schema_name: "special_route",
+      title: special_route[:title],
+      description: special_route[:description],
+      routes: [
+        {
+          path: special_route[:base_path],
+          type: special_route[:type],
+        }
+      ],
+      locale: "en",
+      details: {},
+      publishing_app: special_route[:publishing_app],
+      rendering_app: special_route[:rendering_app],
+      public_updated_at: Time.now.iso8601,
+      update_type: "major",
+    }
+  }
+
   let(:publisher) { GdsApi::PublishingApi::SpecialRoutePublisher.new }
   let(:endpoint) { Plek.current.find('publishing-api') }
 
@@ -33,28 +55,13 @@ describe GdsApi::PublishingApi::SpecialRoutePublisher do
       Timecop.freeze(Time.now) do
         publisher.publish(special_route)
 
-        expected_payload = {
-          base_path: special_route[:base_path],
-          document_type: "special_route",
-          schema_name: "special_route",
-          title: special_route[:title],
-          description: special_route[:description],
-          routes: [
-            {
-              path: special_route[:base_path],
-              type: special_route[:type],
-            }
-          ],
-          locale: "en",
-          details: {},
-          publishing_app: special_route[:publishing_app],
-          rendering_app: special_route[:rendering_app],
-          public_updated_at: Time.now.iso8601,
-          update_type: "major",
-        }
+        assert_requested(
+          :put,
+          "#{endpoint}/v2/content/#{content_id}",
+          body: expected_put_content_payload
+        )
+        assert_valid_special_route(expected_put_content_payload)
 
-        assert_requested(:put, "#{endpoint}/v2/content/#{content_id}", body: expected_payload)
-        assert_valid_special_route(expected_payload)
         assert_publishing_api_publish(content_id)
       end
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,7 +13,7 @@ end
 require 'minitest/autorun'
 require 'rack/utils'
 require 'rack/test'
-require 'mocha/mini_test'
+require 'mocha/minitest'
 require 'timecop'
 require 'gds-api-adapters'
 require 'govuk-content-schema-test-helpers'


### PR DESCRIPTION
Previously it would always create a new draft (or update the existing
one), and then publish it.

Now it checks if the content or links have changed, and only performs
the appropriate update actions if this is the case.

This code is often invoked when deploying applications, and most of
the time it runs, it doesn't actually change the content or links in a
meaningful way. However, it does create a new needless edition, and
this does lead to unnecessary Publishing API activity (due to
dependency resolution/link expansion). This is especialy true for the
homepage.


Some of the motivation for this change can be seen here https://github.com/alphagov/govuk-app-deployment/pull/255 as that patch was a easier workaround for this issue in the case of the Frontend app. I'm hoping that if the SpecialRoutePublisher can be made smarter, then we can revert that change, and continue running it on deploy.
