### PR TITLE
Allow get_linked_items include_withdrawn

### DIFF
--- a/lib/gds_api/publishing_api_v2.rb
+++ b/lib/gds_api/publishing_api_v2.rb
@@ -358,7 +358,7 @@ class GdsApi::PublishingApiV2 < GdsApi::Base
   #
   # @see https://github.com/alphagov/publishing-api/blob/master/doc/api.md#get-v2linkedcontent_id
   def get_linked_items(content_id, params = {})
-    query = query_string(params)
+    query = query_string(convert_include_withdrawn(params))
     validate_content_id(content_id)
     get_json("#{endpoint}/v2/linked/#{content_id}#{query}")
   end
@@ -428,6 +428,12 @@ private
     validate_content_id(content_id)
     query = query_string(params)
     "#{endpoint}/v2/content/#{content_id}#{query}"
+  end
+
+  def convert_include_withdrawn(params)
+    new_params = params.reject { |k, _| k == :include_withdrawn }
+    return new_params.merge(debug: 'include_withdrawn') if params[:include_withdrawn]
+    new_params
   end
 
   def links_url(content_id)

--- a/lib/gds_api/test_helpers/publishing_api_v2.rb
+++ b/lib/gds_api/test_helpers/publishing_api_v2.rb
@@ -503,6 +503,8 @@ module GdsApi
 
       #
       # Stub calls to the get linked items endpoint
+      # Including include_withdrawn: true in the params
+      # adds 'debug' => 'include_withdrawn' to the request
       #
       # @param items [Array] The linked items we wish to return
       # @param params [Hash] A hash of parameters
@@ -525,13 +527,10 @@ module GdsApi
 
         url = Plek.current.find('publishing-api') + "/v2/linked/#{content_id}"
 
-        request_parmeters = {
-          "fields" => fields,
-          "link_type" => link_type,
-        }
+        request_parameters = build_request_parameters(fields, link_type, params[:include_withdrawn])
 
         stub_request(:get, url)
-          .with(query: request_parmeters)
+          .with(query: request_parameters)
           .and_return(
             body: items.to_json,
             status: 200
@@ -573,6 +572,16 @@ module GdsApi
       end
 
     private
+
+      def build_request_parameters(fields, link_type, include_withdrawn)
+        request_parameters = {
+          "fields" => fields,
+          "link_type" => link_type,
+        }
+
+        return request_parameters.merge('debug' => 'include_withdrawn') if include_withdrawn
+        request_parameters
+      end
 
       def stub_publishing_api_put(*args)
         stub_publishing_api_postlike_call(:put, *args)

--- a/test/test_helpers/publishing_api_v2_test.rb
+++ b/test/test_helpers/publishing_api_v2_test.rb
@@ -30,18 +30,44 @@ describe GdsApi::TestHelpers::PublishingApiV2 do
         links
       )
     end
+
+    it "stubs the get linked items api call with 'debug' => 'include_withdrawn'" do
+      links = [
+        { 'content_id' => 'id-1', 'title' => 'title 1', 'link_type' => 'taxons' },
+        { 'content_id' => 'id-2', 'title' => 'title 2', 'link_type' => 'taxons' },
+      ]
+      publishing_api_has_linked_items(
+        links,
+        content_id: 'content-id',
+        link_type: 'taxons',
+        fields: [:title],
+        include_withdrawn: true
+      )
+
+      api_response = publishing_api.get_linked_items(
+        'content-id',
+        link_type: 'taxons',
+        fields: [:title],
+        include_withdrawn: true
+      )
+
+      assert_equal(
+        api_response.to_hash,
+        links
+      )
+    end
   end
 
   describe "#publish_api_has_links_for_content_ids" do
     it "stubs the call to get links for content ids" do
       links = {
-                "2878337b-bed9-4e7f-85b6-10ed2cbcd504" => {
-                  "links" => { "taxons" => ["eb6965c7-3056-45d0-ae50-2f0a5e2e0854"] }
-                },
-                "eec13cea-219d-4896-9c97-60114da23559" => {
-                  "links" => {}
-                }
-              }
+        "2878337b-bed9-4e7f-85b6-10ed2cbcd504" => {
+          "links" => { "taxons" => ["eb6965c7-3056-45d0-ae50-2f0a5e2e0854"] }
+        },
+        "eec13cea-219d-4896-9c97-60114da23559" => {
+          "links" => {}
+        }
+      }
 
       publishing_api_has_links_for_content_ids(links)
 
@@ -100,8 +126,8 @@ describe GdsApi::TestHelpers::PublishingApiV2 do
           { "content_id" => content_id_2 },
           { "content_id" => content_id_3 },
         ],
-                  page: 1,
-          per_page: 2
+        page: 1,
+        per_page: 2
       )
 
       response = publishing_api.get_content_items(page: 1, per_page: 2)
@@ -125,8 +151,8 @@ describe GdsApi::TestHelpers::PublishingApiV2 do
           { "content_id" => content_id_1 },
           { "content_id" => content_id_2 },
         ],
-                  page: 10,
-          per_page: 2
+        page: 10,
+        per_page: 2
       )
 
       response = publishing_api.get_content_items(page: 10, per_page: 2)
@@ -156,9 +182,9 @@ describe GdsApi::TestHelpers::PublishingApiV2 do
       ).parsed_content
 
       assert_equal({
-          "content_id" => "2878337b-bed9-4e7f-85b6-10ed2cbcd504",
-          "version" => 3
-        },
+        "content_id" => "2878337b-bed9-4e7f-85b6-10ed2cbcd504",
+        "version" => 3
+      },
         response
       )
     end


### PR DESCRIPTION
Including including_withdrawn: true will call publishing API
with 'debug' => 'include_withdrawn'

We need to stub this call in content-taggger but the param is ignored when stubbing the call.