### PR TITLE
Add active_subscriptions_count to email-alert-api test helper

### DIFF
--- a/lib/gds_api/test_helpers/email_alert_api.rb
+++ b/lib/gds_api/test_helpers/email_alert_api.rb
@@ -279,6 +279,7 @@ module GdsApi
           "subscriber_list" => {
             "id" => "447135c3-07d6-4c3a-8a3b-efa49ef70e52",
             "title" => "Some title",
+            "active_subscriptions_count" => 42,
           }.merge(attributes)
         }
       end

--- a/test/email_alert_api_test.rb
+++ b/test/email_alert_api_test.rb
@@ -97,6 +97,11 @@ describe GdsApi::EmailAlertApi do
             expected_subscription_url,
             subscriber_list_attrs.fetch("subscription_url"),
           )
+
+          assert_equal(
+            42,
+            subscriber_list_attrs.fetch("active_subscriptions_count"),
+          )
         end
       end
 


### PR DESCRIPTION
Related to https://github.com/alphagov/email-alert-api/pull/604

---

[Trello card](https://trello.com/c/3fxFsB93/201-add-subscriber-list-count-stats-to-taxons-in-content-tagger)