### PR TITLE
Add generate argument to `has_expanded_links` test helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+* Add `generate` argument to `publishing_api_has_expanded_links` which reflects the behaviour of the actual request
+  more closely
+
 # 52.5.1
 
 * Make the subscription response for Email Alert API closer to reality.

--- a/lib/gds_api/test_helpers/publishing_api_v2.rb
+++ b/lib/gds_api/test_helpers/publishing_api_v2.rb
@@ -441,11 +441,16 @@ module GdsApi
       #           ]
       #         }
       #       }
-      def publishing_api_has_expanded_links(links, with_drafts: true)
+      def publishing_api_has_expanded_links(links, with_drafts: true, generate: false)
         links = deep_transform_keys(links, &:to_sym)
-        query = with_drafts ? "" : "?with_drafts=false"
-        url = PUBLISHING_API_V2_ENDPOINT + "/expanded-links/" + links[:content_id] + query
-        stub_request(:get, url).to_return(status: 200, body: links.to_json, headers: {})
+        request_params = {}
+        request_params['with_drafts'] = false if !with_drafts
+        request_params['generate'] = true if generate
+
+        url = PUBLISHING_API_V2_ENDPOINT + "/expanded-links/" + links[:content_id]
+        stub_request(:get, url)
+          .with(query: request_params)
+          .to_return(status: 200, body: links.to_json, headers: {})
       end
 
       # Stub a request to get links for content ids

--- a/test/test_helpers/publishing_api_v2_test.rb
+++ b/test/test_helpers/publishing_api_v2_test.rb
@@ -221,8 +221,8 @@ describe GdsApi::TestHelpers::PublishingApiV2 do
         ]
       }
 
-      publishing_api_has_expanded_links(payload, with_drafts: false)
-      response = publishing_api.get_expanded_links("2e20294a-d694-4083-985e-d8bedefc2354", with_drafts: false)
+      publishing_api_has_expanded_links(payload, with_drafts: false, generate: true)
+      response = publishing_api.get_expanded_links("2e20294a-d694-4083-985e-d8bedefc2354", with_drafts: false, generate: true)
 
       assert_equal({
         "content_id" => "2e20294a-d694-4083-985e-d8bedefc2354",


### PR DESCRIPTION
https://trello.com/c/Ch9ufVJ4/139-bug-when-i-save-a-topic-selection-for-the-first-time-the-topics-dont-appear-on-the-overview-page

Now `publishing_api_has_expanded_links` can be called with `generate` as
an argument. This relates to the changes made in this pr for whitehall:
https://github.com/alphagov/whitehall/pull/4094.

`generate` defaults to `false` and in the real request would generate the
expanded links on the fly instead of getting them from stored data if set
to `true`.