### PR TITLE
Avoid using 'Link' header to unroll API pagination

### DIFF
--- a/lib/gds_api/test_helpers/worldwide.rb
+++ b/lib/gds_api/test_helpers/worldwide.rb
@@ -21,6 +21,8 @@ module GdsApi
         end
 
         pages.each_with_index do |page, i|
+          links = { self: "#{WORLDWIDE_API_ENDPOINT}/api/world-locations?page=#{i + 1}" }
+
           page_details = plural_response_base.merge("results" => page,
             "total" => location_slugs.size,
             "pages" => pages.size,
@@ -28,22 +30,22 @@ module GdsApi
             "page_size" => 20,
             "start_index" => i * 20 + 1)
 
-          links = { self: "#{WORLDWIDE_API_ENDPOINT}/api/world-locations?page=#{i + 1}" }
-          links[:next] = "#{WORLDWIDE_API_ENDPOINT}/api/world-locations?page=#{i + 2}" if pages[i + 1]
-          links[:previous] = "#{WORLDWIDE_API_ENDPOINT}/api/world-locations?page=#{i}" unless i == 0
-          page_details["_response_info"]["links"] = []
-          link_headers = []
-          links.each do |rel, href|
-            page_details["_response_info"]["links"] << { "rel" => rel, "href" => href }
-            link_headers << "<#{href}>; rel=\"#{rel}\""
+          if pages[i + 1]
+            page_details["next_page_url"] = "#{WORLDWIDE_API_ENDPOINT}/api/world-locations?page=#{i + 2}"
+            links[:next] = page_details["next_page_url"]
           end
 
-          stub_request(:get, links[:self]).
-            to_return(status: 200, body: page_details.to_json, headers: { "Link" => link_headers.join(", ") })
-          if i == 0
-            # First page exists at URL with and without page param
-            stub_request(:get, links[:self].sub(/\?page=1/, '')).
-              to_return(status: 200, body: page_details.to_json, headers: { "Link" => link_headers.join(", ") })
+          unless i.zero?
+            page_details["previous_page_url"] = "#{WORLDWIDE_API_ENDPOINT}/api/world-locations?page=#{i}"
+            links[:previous] = page_details["previous_page_url"]
+          end
+
+          if i.zero?
+            stub_request(:get, links[:self].sub(/\?page=1/, ''))
+              .to_return(status: 200, body: page_details.to_json)
+          else
+            stub_request(:get, links[:self])
+              .to_return(status: 200, body: page_details.to_json)
           end
         end
       end

--- a/test/list_response_test.rb
+++ b/test/list_response_test.rb
@@ -41,7 +41,10 @@ describe GdsApi::ListResponse do
       page_1 = {
         "results" => %w(foo1 bar1),
         "total" => 6,
-        "current_page" => 1, "pages" => 3, "page_size" => 2,
+        "current_page" => 1,
+        "pages" => 3,
+        "page_size" => 2,
+        "next_page_url" => "http://www.example.com/2",
         "_response_info" => {
           "status" => "ok",
           "links" => [
@@ -53,7 +56,11 @@ describe GdsApi::ListResponse do
       page_2 = {
         "results" => %w(foo2 bar2),
         "total" => 6,
-        "current_page" => 2, "pages" => 3, "page_size" => 2,
+        "current_page" => 2,
+        "pages" => 3,
+        "page_size" => 2,
+        "next_page_url" => "http://www.example.com/3",
+        "previous_page_url" => "http://www.example.com/1",
         "_response_info" => {
           "status" => "ok",
           "links" => [
@@ -66,7 +73,10 @@ describe GdsApi::ListResponse do
       page_3 = {
         "results" => %w(foo3 bar3),
         "total" => 6,
-        "current_page" => 3, "pages" => 3, "page_size" => 2,
+        "current_page" => 3,
+        "pages" => 3,
+        "page_size" => 2,
+        "previous_page_url" => "http://www.example.com/2",
         "_response_info" => {
           "status" => "ok",
           "links" => [
@@ -77,24 +87,15 @@ describe GdsApi::ListResponse do
       }
       @p1_response = stub(
         body: page_1.to_json,
-        status: 200,
-        headers: {
-          link: '<http://www.example.com/1>; rel="self", <http://www.example.com/2>; rel="next"'
-        }
+        status: 200
       )
       @p2_response = stub(
         body: page_2.to_json,
-        status: 200,
-        headers: {
-          link: '<http://www.example.com/2>; rel="self", <http://www.example.com/3>; rel="next", <http://www.example.com/1>; rel="previous"'
-        }
+        status: 200
       )
       @p3_response = stub(
         body: page_3.to_json,
-        status: 200,
-        headers: {
-          link: '<http://www.example.com/3>; rel="self", <http://www.example.com/1>; rel="previous"'
-        }
+        status: 200
       )
 
       @client = stub


### PR DESCRIPTION
The 'Link' header originally exposed by Whitehall is no longer reliable (we 
think this is due to a Fastly issue). Currently this header is used
to compact a set of paginated API responses into a single array result,
using the "next" and "previous" links contained within the header.

Pagination is an issue for the /organisations and /world-locations APIs,
both of which also have pagination fields in the body, as well as in the
special 'Link' header. Using the 'next_page_url' and 'previous_page_url'
fields to control the compaction process fixes the 'Link' header bug.

In trying to make this change, the API helpers for organisations and world
locations needed updating to include the additional fields. In order to
make this change easier, I've refactored the code by combining similar
inline conditionals into discrete blocks of code. The 'Link' header is
no longer in the stub response, to reflect that it's not reliable.