### PR TITLE
Auto-correct linting errors

### DIFF
--- a/gds-api-adapters.gemspec
+++ b/gds-api-adapters.gemspec
@@ -1,4 +1,5 @@
 # -*- encoding: utf-8 -*-
+
 lib = File.expand_path('../lib/', __FILE__)
 $:.unshift lib unless $:.include?(lib)
 
@@ -17,13 +18,13 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.3.0'
   s.files        = Dir.glob("lib/**/*") + Dir.glob("test/fixtures/**/*") + %w(README.md Rakefile)
   s.require_path = 'lib'
-  s.add_dependency 'plek', '>= 1.9.0'
-  s.add_dependency 'null_logger'
+  s.add_dependency 'addressable'
   s.add_dependency 'link_header'
   s.add_dependency 'lrucache', '~> 0.1.1'
-  s.add_dependency 'rest-client', '~> 2.0'
+  s.add_dependency 'null_logger'
+  s.add_dependency 'plek', '>= 1.9.0'
   s.add_dependency 'rack-cache'
-  s.add_dependency 'addressable'
+  s.add_dependency 'rest-client', '~> 2.0'
 
   s.add_development_dependency 'govuk-content-schema-test-helpers', '~> 1.6'
   s.add_development_dependency 'govuk-lint', '~> 3.7'

--- a/lib/gds_api/govuk_headers.rb
+++ b/lib/gds_api/govuk_headers.rb
@@ -6,7 +6,7 @@ module GdsApi
       end
 
       def headers
-        header_data.select { |_k, v| !(v.nil? || v.empty?) }
+        header_data.reject { |_k, v| (v.nil? || v.empty?) }
       end
 
       def clear_headers

--- a/lib/gds_api/imminence.rb
+++ b/lib/gds_api/imminence.rb
@@ -2,7 +2,7 @@ require_relative 'base'
 
 class GdsApi::Imminence < GdsApi::Base
   def api_url(type, params)
-    vals = [:limit, :lat, :lng, :postcode].select { |p| params.include? p }
+    vals = %i[limit lat lng postcode].select { |p| params.include? p }
     querystring = URI.encode_www_form vals.map { |p| [p, params[p]] }
     "#{@endpoint}/places/#{type}.json?#{querystring}"
   end

--- a/lib/gds_api/json_client.rb
+++ b/lib/gds_api/json_client.rb
@@ -259,26 +259,21 @@ module GdsApi
       end
 
       return ::RestClient::Request.execute(method_params)
-
     rescue Errno::ECONNREFUSED => e
       logger.error loggable.merge(status: 'refused', error_message: e.message, error_class: e.class.name, end_time: Time.now.to_f).to_json
       raise GdsApi::EndpointNotFound.new("Could not connect to #{url}")
-
     rescue RestClient::Exceptions::Timeout => e
       logger.error loggable.merge(status: 'timeout', error_message: e.message, error_class: e.class.name, end_time: Time.now.to_f).to_json
       raise GdsApi::TimedOutException.new
-
     rescue URI::InvalidURIError => e
       logger.error loggable.merge(status: 'invalid_uri', error_message: e.message, error_class: e.class.name, end_time: Time.now.to_f).to_json
       raise GdsApi::InvalidUrl
-
     rescue RestClient::Exception => e
       # Log the error here, since we have access to loggable, but raise the
       # exception up to the calling method to deal with
       loggable.merge!(status: e.http_code, end_time: Time.now.to_f, body: e.http_body)
       logger.warn loggable.to_json
       raise
-
     rescue Errno::ECONNRESET => e
       logger.error loggable.merge(status: 'connection_reset', error_message: e.message, error_class: e.class.name, end_time: Time.now.to_f).to_json
       raise GdsApi::TimedOutException.new

--- a/lib/gds_api/null_cache.rb
+++ b/lib/gds_api/null_cache.rb
@@ -4,10 +4,8 @@ module GdsApi
       nil
     end
 
-    def []=(k, v)
-    end
+    def []=(k, v); end
 
-    def store(k, v, expiry_time = nil)
-    end
+    def store(k, v, expiry_time = nil); end
   end
 end

--- a/lib/gds_api/publishing_api_v2.rb
+++ b/lib/gds_api/publishing_api_v2.rb
@@ -104,10 +104,7 @@ class GdsApi::PublishingApiV2 < GdsApi::Base
       update_type: update_type
     }
 
-    optional_keys = [
-      :locale,
-      :previous_version,
-    ]
+    optional_keys = %i[locale previous_version]
 
     params = merge_optional_keys(params, options, optional_keys)
 
@@ -174,10 +171,7 @@ class GdsApi::PublishingApiV2 < GdsApi::Base
   #
   # @see https://github.com/alphagov/publishing-api/blob/master/doc/api.md#post-v2contentcontent_iddiscard-draft
   def discard_draft(content_id, options = {})
-    optional_keys = [
-      :locale,
-      :previous_version,
-    ]
+    optional_keys = %i[locale previous_version]
 
     params = merge_optional_keys({}, options, optional_keys)
 
@@ -291,7 +285,7 @@ class GdsApi::PublishingApiV2 < GdsApi::Base
       links: params.fetch(:links)
     }
 
-    payload = merge_optional_keys(payload, params, [:previous_version, :bulk_publishing])
+    payload = merge_optional_keys(payload, params, %i[previous_version bulk_publishing])
 
     patch_json(links_url(content_id), payload)
   end

--- a/lib/gds_api/response.rb
+++ b/lib/gds_api/response.rb
@@ -87,7 +87,7 @@ module GdsApi
       when Hash
         Hash[value.map { |k, v|
           # NOTE: Don't bother transforming if the value is nil
-          if 'web_url' == k && v
+          if k == 'web_url' && v
             # Use relative URLs to route when the web_url value is on the
             # same domain as the site root. Note that we can't just use the
             # `route_to` method, as this would give us technically correct

--- a/lib/gds_api/router.rb
+++ b/lib/gds_api/router.rb
@@ -19,7 +19,7 @@ class GdsApi::Router < GdsApi::Base
 
   def get_route(path, type = nil)
     if type
-      $stderr.puts "DEPRECATION WARNING: passing type to GdsApi::Router#get_route is deprecated and will be removed in a future version. Caller: #{caller[0]}"
+      warn "DEPRECATION WARNING: passing type to GdsApi::Router#get_route is deprecated and will be removed in a future version. Caller: #{caller(1..1)}"
     end
     get_json("#{endpoint}/routes?incoming_path=#{CGI.escape(path)}")
   end

--- a/lib/gds_api/test_helpers/mapit.rb
+++ b/lib/gds_api/test_helpers/mapit.rb
@@ -23,7 +23,7 @@ module GdsApi
           "postcode"  => postcode
         }
 
-        area_response = Hash[areas.map.with_index {|area, i|
+        area_response = Hash[areas.map.with_index { |area, i|
           [i, {
             'codes' => {
               'ons' => area['ons'],

--- a/test/list_response_test.rb
+++ b/test/list_response_test.rb
@@ -32,7 +32,7 @@ describe GdsApi::ListResponse do
       response = GdsApi::ListResponse.new(stub(body: data.to_json), nil)
 
       assert_equal [], response.to_a
-      assert ! response.any?
+      assert response.none?
     end
   end
 

--- a/test/organisations_api_test.rb
+++ b/test/organisations_api_test.rb
@@ -12,7 +12,7 @@ describe GdsApi::Organisations do
 
   describe "fetching list of organisations" do
     it "should get the organisations" do
-      organisation_slugs = %w(ministry-of-fun, tea-agency)
+      organisation_slugs = %w(ministry-of-fun tea-agency)
       organisations_api_has_organisations(organisation_slugs)
 
       response = @api.organisations

--- a/test/publishing_api_test.rb
+++ b/test/publishing_api_test.rb
@@ -132,7 +132,6 @@ describe GdsApi::PublishingApi do
           headers: {
             "Content-Type" => "application/json"
           },
-
         )
         .will_respond_with(
           status: 422,

--- a/test/publishing_api_v2_test.rb
+++ b/test/publishing_api_v2_test.rb
@@ -154,8 +154,7 @@ describe GdsApi::PublishingApiV2 do
             "schema_name" => "manual",
             "locale" => "en",
             "details" => { "body" => [] },
-            "previous_version" => "3"
-          )
+            "previous_version" => "3")
 
           publishing_api
             .given("the content item #{@content_id} is at version 3")
@@ -186,8 +185,7 @@ describe GdsApi::PublishingApiV2 do
             "schema_name" => "manual",
             "locale" => "en",
             "details" => { "body" => [] },
-            "previous_version" => "2"
-          )
+            "previous_version" => "2")
 
           publishing_api
             .given("the content item #{@content_id} is at version 3")
@@ -1123,8 +1121,7 @@ describe GdsApi::PublishingApiV2 do
             links: {
               organisations: ["591436ab-c2ae-416f-a3c5-1901d633fbfb"],
             },
-            previous_version: 3,
-          )
+            previous_version: 3,)
 
           assert_equal 200, response.code
         end
@@ -1171,8 +1168,7 @@ describe GdsApi::PublishingApiV2 do
               links: {
                 organisations: ["591436ab-c2ae-416f-a3c5-1901d633fbfb"],
               },
-              previous_version: 2,
-            )
+              previous_version: 2,)
           end
 
           assert_equal 409, error.code
@@ -1375,7 +1371,7 @@ describe GdsApi::PublishingApiV2 do
 
       response = @api_client.get_content_items(
         document_type: 'topic',
-        fields: [:title, :base_path],
+        fields: %i[title base_path],
       )
 
       assert_equal 200, response.code
@@ -1419,7 +1415,7 @@ describe GdsApi::PublishingApiV2 do
 
       response = @api_client.get_content_items(
         document_type: 'topic',
-        fields: [:content_id, :locale],
+        fields: %i[content_id locale],
       )
 
       assert_equal 200, response.code
@@ -1463,7 +1459,7 @@ describe GdsApi::PublishingApiV2 do
 
       response = @api_client.get_content_items(
         document_type: 'topic',
-        fields: [:content_id, :locale],
+        fields: %i[content_id locale],
         locale: 'fr',
       )
 
@@ -1509,7 +1505,7 @@ describe GdsApi::PublishingApiV2 do
 
       response = @api_client.get_content_items(
         document_type: 'topic',
-        fields: [:content_id, :locale],
+        fields: %i[content_id locale],
         locale: 'all',
       )
 
@@ -1556,7 +1552,7 @@ describe GdsApi::PublishingApiV2 do
 
       response = @api_client.get_content_items(
         document_type: 'topic',
-        fields: [:content_id, :details],
+        fields: %i[content_id details],
       )
 
       assert_equal 200, response.code
@@ -1593,7 +1589,7 @@ describe GdsApi::PublishingApiV2 do
               rel: "self"
             }],
             results: [
-              { content_id:  "aaaaaaaa-aaaa-1aaa-aaaa-aaaaaaaaaaaa" }
+              { content_id: "aaaaaaaa-aaaa-1aaa-aaaa-aaaaaaaaaaaa" }
             ]
           }
         )
@@ -1976,7 +1972,7 @@ describe GdsApi::PublishingApiV2 do
   end
 
   describe "content ID validation" do
-    [:get_content, :get_links, :get_linked_items, :discard_draft].each do |method|
+    %i[get_content get_links get_linked_items discard_draft].each do |method|
       it "happens on #{method}" do
         proc { @api_client.send(method, nil) }.must_raise ArgumentError
       end

--- a/test/test_helpers/publishing_api_v2_test.rb
+++ b/test/test_helpers/publishing_api_v2_test.rb
@@ -159,8 +159,7 @@ describe GdsApi::TestHelpers::PublishingApiV2 do
           "content_id" => "2878337b-bed9-4e7f-85b6-10ed2cbcd504",
           "version" => 3
         },
-        response
-      )
+        response)
     end
   end
 


### PR DESCRIPTION
I'm running into some annoying existing linting errors in https://github.com/alphagov/gds-api-adapters/pull/841. This fixes the correctable errors using `govuk-lint-ruby -a`.