### PR TITLE
Disable diff based Ruby linting in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,6 +9,7 @@ node {
   govuk.setEnvar("PACT_BROKER_BASE_URL", "https://pact-broker.cloudapps.digital")
 
   govuk.buildProject(
+    rubyListDiff: false,
     extraParameters: [
       stringParam(
         name: 'PUBLISHING_API_BRANCH',


### PR DESCRIPTION
This ensures that all the code is checked, avoiding any errors being
missed.