### PR TITLE
Expose the country_name through the API

### DIFF
--- a/lib/gds_api/test_helpers/mapit.rb
+++ b/lib/gds_api/test_helpers/mapit.rb
@@ -31,7 +31,8 @@ module GdsApi
               'govuk_slug' => area['govuk_slug']
             },
             'name' => area['name'],
-            'type' => area['type']
+            'type' => area['type'],
+            'country_name' => area['country_name']
           }]
         }]
 


### PR DESCRIPTION
This is required so the tests in `frontend` can determine the country based on a postcode that is looked up in MapIt.