### PR TITLE
Add `send_unpublish_message` method to email-alert-api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Add support for the `unpublish-messages` endpoint in email-alert-api
+
 # 52.7.0
 
 * Expose the `country_name` parameter as part of the Mapit test helper

--- a/lib/gds_api/email_alert_api.rb
+++ b/lib/gds_api/email_alert_api.rb
@@ -57,6 +57,17 @@ class GdsApi::EmailAlertApi < GdsApi::Base
     post_json("#{endpoint}/notifications", publication, headers)
   end
 
+  # Unpublishing alert
+  #
+  # @param message [Hash] content_id
+  #
+  # Used by email-alert-service to send a message to email-alert-api
+  # when an unpublishing message is put on the Rabbitmq queue by
+  # publishing-api
+  def send_unpublish_message(message)
+    post_json("#{endpoint}/unpublish-messages", message)
+  end
+
   # Get topic matches
   #
   # @param attributes [Hash] tags, links, document_type,

--- a/lib/gds_api/test_helpers/email_alert_api.rb
+++ b/lib/gds_api/test_helpers/email_alert_api.rb
@@ -93,6 +93,11 @@ module GdsApi
           .to_return(status: 422)
       end
 
+      def email_alert_api_accepts_unpublishing_message
+        stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/unpublish-messages")
+          .to_return(status: 202, body: {}.to_json)
+      end
+
       def email_alert_api_accepts_alert
         stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/notifications")
           .to_return(status: 202, body: {}.to_json)

--- a/test/email_alert_api_test.rb
+++ b/test/email_alert_api_test.rb
@@ -48,6 +48,24 @@ describe GdsApi::EmailAlertApi do
     end
   end
 
+  let(:unpublish_message) {
+    {
+      "content_id" => "content-id"
+    }
+  }
+
+  describe "unpublishing messages" do
+    before do
+      email_alert_api_accepts_unpublishing_message
+    end
+
+    it "sends an unpublish message" do
+      assert api_client.send_unpublish_message(unpublish_message)
+
+      assert_requested(:post, "#{base_url}/unpublish-messages", body: unpublish_message.to_json)
+    end
+  end
+
   describe "subscriptions" do
     describe "a subscription exists" do
       before do


### PR DESCRIPTION
When called the method sends a request to the unpublishing-messages
endpoint in the email-alert-api. This endpoint starts the process of
notifying a user that their email subscription is no longer active.