### PR TITLE
Release 53.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unrelease
+# 53.0.0
 
 * Remove support for caching responses.
 

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '52.8.0'.freeze
+  VERSION = '53.0.0'.freeze
 end


### PR DESCRIPTION
This removes support for caching responses so I figured it should be a major version bump, although not technically a breaking change since all our apps have caching disabled at the moment.

[Trello Card](https://trello.com/c/0HSDBjNk/398-remove-gds-api-adapters-cache)