### PR TITLE
Add ability to batch search Rummager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 54.1.0
+
+* Add ability to batch search Rummager
+
 # 54.0.0
 
 * Expect `GdsApi::TestHelpers::Organisations` to be using the public API instead of Whitehall.

--- a/lib/gds_api/rummager.rb
+++ b/lib/gds_api/rummager.rb
@@ -70,6 +70,20 @@ module GdsApi
       get_json(request_url, additional_headers)
     end
 
+    # Perform a batch search.
+    #
+    # @param searches [Array] An array valid search queries. Maximum of 6. See Rummager documentation for options.
+    #
+    # # @see https://github.com/alphagov/rummager/blob/master/doc/search-api.md
+    def batch_search(searches, additional_headers = {})
+      url_friendly_searches = searches.each_with_index.map do |search, index|
+        { index => search }
+      end
+      searches_query = { search: url_friendly_searches }
+      request_url = "#{base_url}/batch_search?.json?search=#{Rack::Utils.build_nested_query(searches_query)}"
+      get_json(request_url, additional_headers)
+    end
+
     # Perform a search, returning the results as an enumerator.
     #
     # The enumerator abstracts away rummager's pagination and fetches new pages when

--- a/test/rummager_test.rb
+++ b/test/rummager_test.rb
@@ -5,6 +5,7 @@ describe GdsApi::Rummager do
   before(:each) do
     stub_request(:get, /example.com\/advanced_search/).to_return(body: "[]")
     stub_request(:get, /example.com\/search/).to_return(body: "[]")
+    stub_request(:get, /example.com\/batch_search/).to_return(body: "[]")
   end
 
   # tests for #advanced_search
@@ -136,6 +137,20 @@ describe GdsApi::Rummager do
     GdsApi::Rummager.new("http://example.com").search({ q: "query" }, "authorization" => "token")
 
     assert_requested :get, /.*/, headers: { "authorization" => "token" }
+  end
+
+  it "#batch_search should issue a single request containing all queries" do
+    GdsApi::Rummager.new("http://example.com").batch_search([{ q: 'self assessment' }, { q: 'tax return' }])
+
+    assert_requested :get, /\[\]\[0\]\[q\]=self assessment/
+    assert_requested :get, /\[\]\[1\]\[q\]=tax return/
+  end
+
+  it "#batch_search should return the search deserialized from json" do
+    batch_search_results = [{ "title" => "document-title" }, { "title" => "document-title-2" }]
+    stub_request(:get, /example.com\/batch_search/).to_return(body: batch_search_results.to_json)
+    results = GdsApi::Rummager.new("http://example.com").batch_search([{ q: 'self assessment' }, { q: 'tax return' }])
+    assert_equal batch_search_results, results.to_hash
   end
 
   # tests for search_enum


### PR DESCRIPTION
This commit enables the new batch search endpoint to be called on Rummager, where each of the individual queries to be batched is encoded in a readable string as part of the query string.

Co-authored-by: Oscar Wyatt <oscar.wyatt@digital.cabinet-office.gov.uk>

Trello: https://trello.com/c/QlPhl3wp/122-add-batchsearch-method-to-gds-api-adaptors