### PR TITLE
Make the new patch_conflict stub agnostic to keys

### DIFF
--- a/lib/gds_api/test_helpers/publishing_api_v2.rb
+++ b/lib/gds_api/test_helpers/publishing_api_v2.rb
@@ -40,7 +40,7 @@ module GdsApi
       #     "links" => {
       #       "taxons" => %w(level_one_topic level_two_topic),
       #     },
-      #     "previous_version" => "3",
+      #     "previous_version" => 3,
       #   )
       #
       # @param content_id [UUID]
@@ -57,13 +57,14 @@ module GdsApi
       #     "links" => {
       #       "taxons" => %w(level_one_topic level_two_topic),
       #     },
-      #     "previous_version" => "3",
+      #     "previous_version" => 3,
       #   )
       #
       # @param content_id [UUID]
       # @param body  [String]
       def stub_publishing_api_patch_links_conflict(content_id, body)
-        override_response_hash = { status: 409, body: version_conflict(body[:previous_version]) }
+        previous_version = JSON.parse(body.to_json)["previous_version"]
+        override_response_hash = { status: 409, body: version_conflict(previous_version) }
         stub_publishing_api_patch(content_id, body, '/links', override_response_hash)
       end
 


### PR DESCRIPTION
https://trello.com/c/82J6eESL/356-allow-the-user-to-modify-the-topics-for-a-document

Previously the stub assumed the body keys were symbols, but we seem to
have a convention for allowing symbols or strings as keys. Also, the
previous_version should be specified as an integer in the examples.