### PR TITLE
Change GdsApi.organisations to use the public endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 * Ensure new Publishing API patch_links stub is symbol/string-agnostic
+* Change GdsApi.organisations adapter to use the public organisations API
 
 # 54.1.1
 

--- a/lib/gds_api.rb
+++ b/lib/gds_api.rb
@@ -110,7 +110,7 @@ module GdsApi
   #
   # @return [GdsApi::Organisations]
   def self.organisations(options = {})
-    GdsApi::Organisations.new(Plek.find('whitehall-admin'), options)
+    GdsApi::Organisations.new(Plek.new.website_root, options)
   end
 
   # Creates a GdsApi::PublishingApi adapter


### PR DESCRIPTION
The test helpers in the GDS API Adapters where changed in [1], but I
think it makes sense to change this as well for the same reasoning,
that depending on the public organisations API is more flexible than
Whitehall.

1: bd9d95911b5c389c691c14174a7d12d0b85fd8ee