### PR TITLE
Add page param to worldwide locations

### DIFF
--- a/lib/gds_api/worldwide.rb
+++ b/lib/gds_api/worldwide.rb
@@ -1,8 +1,8 @@
 require_relative 'base'
 
 class GdsApi::Worldwide < GdsApi::Base
-  def world_locations
-    get_list("#{base_url}/world-locations")
+  def world_locations(options = { page: 1 })
+    get_list("#{base_url}/world-locations?page=#{options[:page]}")
   end
 
   def world_location(location_slug)

--- a/test/worldwide_api_test.rb
+++ b/test/worldwide_api_test.rb
@@ -32,7 +32,7 @@ describe GdsApi::Worldwide do
     end
 
     it "should raise error if endpoint 404s" do
-      stub_request(:get, "#{@base_api_url}/api/world-locations").to_return(status: 404)
+      stub_request(:get, "#{@base_api_url}/api/world-locations?page=1").to_return(status: 404)
       assert_raises GdsApi::HTTPNotFound do
         @api.world_locations
       end


### PR DESCRIPTION
The default behaviour is to return just the first page of results. This makes it possible to
get all pages via the same interface.

I didn't add a version bump because this is a backwards-compatible change. Let me know if you think changing the version would be worth doing!

```
# Before, only this works
GdsApi::Worldwide.world_locations

# After, this works
GdsApi::Worldwide.world_locations
GdsApi::Worldwide.world_locations page: 2
```