### PR TITLE
Add missing v1-esque stub for when the API is down

### DIFF
--- a/lib/gds_api/test_helpers/publishing_api_v2.rb
+++ b/lib/gds_api/test_helpers/publishing_api_v2.rb
@@ -10,6 +10,7 @@ module GdsApi
       include ContentItemHelpers
 
       PUBLISHING_API_V2_ENDPOINT = Plek.current.find('publishing-api') + '/v2'
+      PUBLISHING_API_ENDPOINT = Plek.current.find('publishing-api')
 
       # Stub a PUT /v2/content/:content_id request with the given content id and request body.
       # if no response_hash is given, a default response as follows is created:
@@ -166,6 +167,7 @@ module GdsApi
       # Stub any version 2 request to the publishing API to return a 503 response
       def publishing_api_isnt_available
         stub_request(:any, /#{PUBLISHING_API_V2_ENDPOINT}\/.*/).to_return(status: 503)
+        stub_request(:any, /#{PUBLISHING_API_ENDPOINT}\/.*/).to_return(status: 503)
       end
 
       # Assert that a draft was saved and published, and links were updated.

--- a/test/test_helpers/publishing_api_v2_test.rb
+++ b/test/test_helpers/publishing_api_v2_test.rb
@@ -324,4 +324,22 @@ describe GdsApi::TestHelpers::PublishingApiV2 do
       )
     end
   end
+
+  describe '#publishing_api_isnt_available' do
+    it "returns a 503 for V2 requests" do
+      publishing_api_isnt_available
+
+      assert_raises GdsApi::BaseError do
+        publishing_api.get_content_items({})
+      end
+    end
+
+    it "returns a 503 for V1 requests" do
+      publishing_api_isnt_available
+
+      assert_raises GdsApi::BaseError do
+        publishing_api.lookup_content_id(base_path: "")
+      end
+    end
+  end
 end


### PR DESCRIPTION
https://trello.com/c/vqd2BLa0/449-we-dont-publish-urls-the-same-as-whitehall-does