### PR TITLE
Extend Asset Manager stub to cover deletion

### DIFF
--- a/lib/gds_api/test_helpers/asset_manager.rb
+++ b/lib/gds_api/test_helpers/asset_manager.rb
@@ -22,7 +22,7 @@ module GdsApi
           "_response_info" => { "status" => "not found" }
         }
 
-        stub_request(:get, "#{ASSET_MANAGER_ENDPOINT}/assets/#{id}")
+        stub_request(:any, "#{ASSET_MANAGER_ENDPOINT}/assets/#{id}")
           .to_return(body: response.to_json, status: 404)
       end
 

--- a/test/asset_manager_test.rb
+++ b/test/asset_manager_test.rb
@@ -52,6 +52,10 @@ describe GdsApi::AssetManager do
     assert_raises GdsApi::HTTPNotFound do
       api.asset("not-really-here")
     end
+
+    assert_raises GdsApi::HTTPNotFound do
+      api.delete_asset("not-really-here")
+    end
   end
 
   it "raises not found when a Whitehall asset does not exist" do


### PR DESCRIPTION
https://trello.com/c/RF88cDFS/498-error-clicking-various-page-links-on-a-blank-document-form-implicitly-creates-invalid-document-record