### PR TITLE
Fix Rummager batch_search.json URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 * Ensure new Publishing API patch_links stub is symbol/string-agnostic
 * Change GdsApi.organisations adapter to use the public organisations API
+* Fix the URL for Rummager batch queries.
 
 # 54.1.3
 

--- a/lib/gds_api/rummager.rb
+++ b/lib/gds_api/rummager.rb
@@ -80,7 +80,7 @@ module GdsApi
         { index => search }
       end
       searches_query = { search: url_friendly_searches }
-      request_url = "#{base_url}/batch_search?.json?search=#{Rack::Utils.build_nested_query(searches_query)}"
+      request_url = "#{base_url}/batch_search.json?#{Rack::Utils.build_nested_query(searches_query)}"
       get_json(request_url, additional_headers)
     end
 

--- a/test/rummager_test.rb
+++ b/test/rummager_test.rb
@@ -142,13 +142,14 @@ describe GdsApi::Rummager do
   it "#batch_search should issue a single request containing all queries" do
     GdsApi::Rummager.new("http://example.com").batch_search([{ q: 'self assessment' }, { q: 'tax return' }])
 
-    assert_requested :get, /\[\]\[0\]\[q\]=self assessment/
-    assert_requested :get, /\[\]\[1\]\[q\]=tax return/
+    assert_requested :get, /search\[\]\[0\]\[q\]=self assessment/
+    assert_requested :get, /search\[\]\[1\]\[q\]=tax return/
   end
 
   it "#batch_search should return the search deserialized from json" do
     batch_search_results = [{ "title" => "document-title" }, { "title" => "document-title-2" }]
-    stub_request(:get, /example.com\/batch_search/).to_return(body: batch_search_results.to_json)
+    stub_request(:get, "http://example.com/batch_search.json?search[][0][q]=self+assessment&search[][1][q]=tax+return")
+      .to_return(body: batch_search_results.to_json)
     results = GdsApi::Rummager.new("http://example.com").batch_search([{ q: 'self assessment' }, { q: 'tax return' }])
     assert_equal batch_search_results, results.to_hash
   end


### PR DESCRIPTION
Currently it passes all the searches in a top level `search` parameter which is not what Rummager expects.

Also fix some tests to check that the correct URL is being requested.

This is based on the example URL given in https://github.com/alphagov/rummager/pull/1299.

[Trello Card](https://trello.com/c/HoWR8kQM/150-or-between-and-in-facets-in-the-finder)