### PR TITLE
Change how the default logger is assigned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Change how the default logger is assigned.
+
 # 55.0.0
 
 * Ensure new Publishing API patch_links stub is symbol/string-agnostic

--- a/lib/gds_api/base.rb
+++ b/lib/gds_api/base.rb
@@ -42,7 +42,7 @@ class GdsApi::Base
   def initialize(endpoint_url, options = {})
     options[:endpoint_url] = endpoint_url
     raise InvalidAPIURL unless endpoint_url =~ URI::RFC3986_Parser::RFC3986_URI
-    base_options = { logger: self.class.logger }
+    base_options = { logger: GdsApi::Base.logger }
     default_options = base_options.merge(GdsApi::Base.default_options || {})
     @options = default_options.merge(options)
     self.endpoint = options[:endpoint_url]


### PR DESCRIPTION
Previously, using `self.class.logger` meant that changes to
`GdsApi::Base.logger` wouldn't always apply to new clients.

I'm not to sure why, as Ruby is hard, but I am sure that this
behaviour is confusing. I also think it's unnecessary, as subclasses
can override the logger by passing it in as an option.

So, change this to use `GdsApi::Base.logger`, like how the
`default_options` works.