### PR TITLE
Extend default Content Store timeout for migration

### DIFF
--- a/lib/gds_api/content_store.rb
+++ b/lib/gds_api/content_store.rb
@@ -4,10 +4,17 @@ require_relative 'base'
 require_relative 'exceptions'
 
 class GdsApi::ContentStore < GdsApi::Base
+  EXTENDED_TIMEOUT_FOR_AWS = 8
+
   class ItemNotFound < GdsApi::HTTPNotFound
     def self.build_from(http_error)
       new(http_error.code, http_error.message, http_error.error_details)
     end
+  end
+
+  def initialize(endpoint_url, options = {})
+    options[:timeout] ||= EXTENDED_TIMEOUT_FOR_AWS
+    super(endpoint_url, options)
   end
 
   def content_item(base_path)


### PR DESCRIPTION
https://trello.com/c/WIcZf3ZQ/393-investigate-high-smart-answers-5xx-rate

Following the migration of the Content Store to AWS, we are now seeing
increased response times from apps still hosted in Carrenza. This
increases the default time for Content Store during the migration, so
that our apps can cope with the longer response times.