### PR TITLE
Fix missing released version pact publish

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,16 +26,20 @@ node {
           passwordVariable: 'PACT_BROKER_PASSWORD'
         ]
       ]) {
-        publishBranchPact(govuk)
+        publishPacts(govuk, env.BRANCH_NAME == 'master')
         runPublishingApiPactTests(govuk)
       }
     }
   )
 }
 
-def publishBranchPact(govuk) {
-  stage("Publish branch pact") {
+def publishPacts(govuk, releasedVersion) {
+  stage("Publish pacts") {
     govuk.runRakeTask("pact:publish:branch")
+
+    if (releasedVersion) {
+      govuk.runRakeTask("pact:publish:released_version")
+    }
   }
 }
 


### PR DESCRIPTION
In [46e4a1][1] this project stopped publishing the released version to
the pact broker, which meant the tests against it were using a version
published 12 January 2018. This restores that publishing process.

[1]: https://github.com/alphagov/gds-api-adapters/commit/46e4a13875605bcb4150f105d18d7a59c8425d1d#diff-58231b16fdee45a03a4ee3cf94a9f2c3