### PR TITLE
Pass bearer token to Support API requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 * Pass `LINK_CHECKER_API_BEARER_TOKEN` in Link Checker API requests if present.
+* Pass `SUPPORT_API_BEARER_TOKEN` in Support API requests if present.
 
 # 56.0.0
 

--- a/lib/gds_api.rb
+++ b/lib/gds_api.rb
@@ -175,9 +175,15 @@ module GdsApi
 
   # Creates a GdsApi::SupportApi adapter
   #
+  # This will set a bearer token if a SUPPORT_API_BEARER_TOKEN environment
+  # variable is set
+  #
   # @return [GdsApi::SupportApi]
   def self.support_api(options = {})
-    GdsApi::SupportApi.new(Plek.find('support-api'), options)
+    GdsApi::SupportApi.new(
+      Plek.find('support-api'),
+      { bearer_token: ENV['SUPPORT_API_BEARER_TOKEN'] }.merge(options),
+    )
   end
 
   # Creates a GdsApi::Worldwide adapter for accessing Whitehall APIs on a


### PR DESCRIPTION
https://trello.com/c/WR2MNxo6/24-add-authentication-to-support-api

Support API now authenticates POST requests so we pass the
SUPPORT_API_BEARER_TOKEN to Support API requests if it's present.