### PR TITLE
Add more Asset Manager test helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Add additional Asset Manager test helper methods
+
 # 57.0.0
 
 * Pass `LINK_CHECKER_API_BEARER_TOKEN` in Link Checker API requests if present.

--- a/lib/gds_api/test_helpers/asset_manager.rb
+++ b/lib/gds_api/test_helpers/asset_manager.rb
@@ -11,6 +11,16 @@ module GdsApi
         stub_request(:any, %r{\A#{ASSET_MANAGER_ENDPOINT}}).to_return(status: 503)
       end
 
+      def asset_manager_updates_any_asset(body = {})
+        stub_request(:put, %r{\A#{ASSET_MANAGER_ENDPOINT}/assets})
+          .to_return(body: body.to_json, status: 200)
+      end
+
+      def asset_manager_deletes_any_asset(body = {})
+        stub_request(:delete, %r{\A#{ASSET_MANAGER_ENDPOINT}/assets})
+          .to_return(body: body.to_json, status: 200)
+      end
+
       def asset_manager_has_an_asset(id, atts)
         response = atts.merge("_response_info" => { "status" => "ok" })
 

--- a/lib/gds_api/test_helpers/asset_manager.rb
+++ b/lib/gds_api/test_helpers/asset_manager.rb
@@ -3,6 +3,14 @@ module GdsApi
     module AssetManager
       ASSET_MANAGER_ENDPOINT = Plek.current.find('asset-manager')
 
+      def stub_any_asset_manager_call
+        stub_request(:any, %r{\A#{ASSET_MANAGER_ENDPOINT}}).to_return(status: 200)
+      end
+
+      def asset_manager_is_down
+        stub_request(:any, %r{\A#{ASSET_MANAGER_ENDPOINT}}).to_return(status: 503)
+      end
+
       def asset_manager_has_an_asset(id, atts)
         response = atts.merge("_response_info" => { "status" => "ok" })
 

--- a/lib/gds_api/test_helpers/asset_manager.rb
+++ b/lib/gds_api/test_helpers/asset_manager.rb
@@ -53,8 +53,31 @@ module GdsApi
           .to_return(body: response.to_json, status: 404)
       end
 
-      def asset_manager_receives_an_asset(response_url)
-        stub_request(:post, "#{ASSET_MANAGER_ENDPOINT}/assets").to_return(body: { file_url: response_url }.to_json, status: 200)
+      # This can take a string of an exact url or a hash of options
+      #
+      # with a string:
+      # `asset_manager_receives_an_asset("https://asset-manager/media/619ce797-b415-42e5-b2b1-2ffa0df52302/file.jpg")`
+      #
+      # with a hash:
+      # `asset_manager_receives_an_asset(id: "20d04259-e3ae-4f71-8157-e6c843096e96", filename: "file.jpg")`
+      # which would return a file url of "https://asset-manager/media/20d04259-e3ae-4f71-8157-e6c843096e96/file.jpg"
+      #
+      # with no argument
+      #
+      # `asset_manager_receives_an_asset`
+      # which would return a file url of "https://asset-manager/media/0053adbf-0737-4923-9d8a-8180f2c723af/0d19136c4a94f07"
+      def asset_manager_receives_an_asset(response_url = {})
+        stub_request(:post, "#{ASSET_MANAGER_ENDPOINT}/assets").to_return do
+          unless response_url.is_a?(String)
+            options = {
+              id: SecureRandom.uuid,
+              filename: SecureRandom.hex(8)
+            }.merge(response_url)
+
+            response_url = "#{ASSET_MANAGER_ENDPOINT}/media/#{options[:id]}/#{options[:filename]}"
+          end
+          { body: { file_url: response_url }.to_json, status: 200 }
+        end
       end
 
       def asset_manager_upload_failure

--- a/test/test_helpers/asset_manager_test.rb
+++ b/test/test_helpers/asset_manager_test.rb
@@ -1,0 +1,59 @@
+require 'test_helper'
+require 'gds_api/asset_manager'
+require 'gds_api/test_helpers/asset_manager'
+
+describe GdsApi::TestHelpers::AssetManager do
+  include GdsApi::TestHelpers::AssetManager
+
+  let(:asset_manager) do
+    GdsApi::AssetManager.new(Plek.current.find("asset-manager"))
+  end
+
+  describe "#asset_manager_receives_an_asset" do
+    describe "when passed a string" do
+      it "returns the string as the file url" do
+        url = "https://assets.example.com/path/to/asset"
+        asset_manager_receives_an_asset(url)
+        response = asset_manager.create_asset({})
+
+        assert_equal url, response["file_url"]
+      end
+    end
+
+    describe "when passed no arguments" do
+      it "returns a random, yet valid asset manager url" do
+        asset_manager_receives_an_asset
+        response = asset_manager.create_asset({})
+
+        url_format = %r{\Ahttp://asset-manager.dev.gov.uk/media/[^/]*/[^/]*\Z}
+        assert_match url_format, response["file_url"]
+      end
+    end
+
+    describe "when passed a hash" do
+      it "can specify the id of an asset" do
+        asset_manager_receives_an_asset(id: "123")
+        response = asset_manager.create_asset({})
+
+        url_format = %r{\Ahttp://asset-manager.dev.gov.uk/media/123/[^/]*\Z}
+        assert_match url_format, response["file_url"]
+      end
+
+      it "can specify the filename of an asset" do
+        asset_manager_receives_an_asset(filename: "file.ext")
+        response = asset_manager.create_asset({})
+
+        url_format = %r{\Ahttp://asset-manager.dev.gov.uk/media/[^/]*/file.ext\Z}
+        assert_match url_format, response["file_url"]
+      end
+
+      it "can specify both filename and id" do
+        asset_manager_receives_an_asset(id: "123", filename: "file.ext")
+        response = asset_manager.create_asset({})
+
+        url_format = %r{\Ahttp://asset-manager.dev.gov.uk/media/123/file.ext\Z}
+        assert_match url_format, response["file_url"]
+      end
+    end
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/5JMGsuBj/687-follow-up-work-from-versioning-review

This moves some Asset Manager test helpers that we mocked out directly in Content Publisher into GDS API Adapters. They provide ability to:

- Stub all Asset Manager calls
- Stub Asset Manager as being down
- Stub a batch of Asset Manager creates
- Stub a batch of Asset Manager updates
- Stub a batch of Asset Manager deletes