### PR TITLE
Prefer stub_ prefix for Asset Manager test helpers

### DIFF
--- a/lib/gds_api/test_helpers/asset_manager.rb
+++ b/lib/gds_api/test_helpers/asset_manager.rb
@@ -7,35 +7,35 @@ module GdsApi
         stub_request(:any, %r{\A#{ASSET_MANAGER_ENDPOINT}}).to_return(status: 200)
       end
 
-      def asset_manager_is_down
+      def stub_asset_manager_is_down
         stub_request(:any, %r{\A#{ASSET_MANAGER_ENDPOINT}}).to_return(status: 503)
       end
 
-      def asset_manager_updates_any_asset(body = {})
+      def stub_asset_manager_updates_any_asset(body = {})
         stub_request(:put, %r{\A#{ASSET_MANAGER_ENDPOINT}/assets})
           .to_return(body: body.to_json, status: 200)
       end
 
-      def asset_manager_deletes_any_asset(body = {})
+      def stub_asset_manager_deletes_any_asset(body = {})
         stub_request(:delete, %r{\A#{ASSET_MANAGER_ENDPOINT}/assets})
           .to_return(body: body.to_json, status: 200)
       end
 
-      def asset_manager_has_an_asset(id, atts)
+      def stub_asset_manager_has_an_asset(id, atts)
         response = atts.merge("_response_info" => { "status" => "ok" })
 
         stub_request(:get, "#{ASSET_MANAGER_ENDPOINT}/assets/#{id}")
           .to_return(body: response.to_json, status: 200)
       end
 
-      def asset_manager_has_a_whitehall_asset(legacy_url_path, atts)
+      def stub_asset_manager_has_a_whitehall_asset(legacy_url_path, atts)
         response = atts.merge("_response_info" => { "status" => "ok" })
 
         stub_request(:get, "#{ASSET_MANAGER_ENDPOINT}/whitehall_assets/#{legacy_url_path}")
           .to_return(body: response.to_json, status: 200)
       end
 
-      def asset_manager_does_not_have_an_asset(id)
+      def stub_asset_manager_does_not_have_an_asset(id)
         response = {
           "_response_info" => { "status" => "not found" }
         }
@@ -44,7 +44,7 @@ module GdsApi
           .to_return(body: response.to_json, status: 404)
       end
 
-      def asset_manager_does_not_have_a_whitehall_asset(legacy_url_path)
+      def stub_asset_manager_does_not_have_a_whitehall_asset(legacy_url_path)
         response = {
           "_response_info" => { "status" => "not found" }
         }
@@ -56,17 +56,17 @@ module GdsApi
       # This can take a string of an exact url or a hash of options
       #
       # with a string:
-      # `asset_manager_receives_an_asset("https://asset-manager/media/619ce797-b415-42e5-b2b1-2ffa0df52302/file.jpg")`
+      # `stub_asset_manager_receives_an_asset("https://asset-manager/media/619ce797-b415-42e5-b2b1-2ffa0df52302/file.jpg")`
       #
       # with a hash:
-      # `asset_manager_receives_an_asset(id: "20d04259-e3ae-4f71-8157-e6c843096e96", filename: "file.jpg")`
+      # `stub_asset_manager_receives_an_asset(id: "20d04259-e3ae-4f71-8157-e6c843096e96", filename: "file.jpg")`
       # which would return a file url of "https://asset-manager/media/20d04259-e3ae-4f71-8157-e6c843096e96/file.jpg"
       #
       # with no argument
       #
-      # `asset_manager_receives_an_asset`
+      # `stub_asset_manager_receives_an_asset`
       # which would return a file url of "https://asset-manager/media/0053adbf-0737-4923-9d8a-8180f2c723af/0d19136c4a94f07"
-      def asset_manager_receives_an_asset(response_url = {})
+      def stub_asset_manager_receives_an_asset(response_url = {})
         stub_request(:post, "#{ASSET_MANAGER_ENDPOINT}/assets").to_return do
           unless response_url.is_a?(String)
             options = {
@@ -80,27 +80,41 @@ module GdsApi
         end
       end
 
-      def asset_manager_upload_failure
+      def stub_asset_manager_upload_failure
         stub_request(:post, "#{ASSET_MANAGER_ENDPOINT}/assets").to_return(status: 500)
       end
 
-      def asset_manager_update_asset(asset_id, body = {})
+      def stub_asset_manager_update_asset(asset_id, body = {})
         stub_request(:put, "#{ASSET_MANAGER_ENDPOINT}/assets/#{asset_id}")
           .to_return(body: body.to_json, status: 200)
       end
 
-      def asset_manager_update_failure(asset_id)
+      def stub_asset_manager_update_asset_failure(asset_id)
         stub_request(:put, "#{ASSET_MANAGER_ENDPOINT}/assets/#{asset_id}").to_return(status: 500)
       end
 
-      def asset_manager_delete_asset(asset_id, body = {})
+      def stub_asset_manager_delete_asset(asset_id, body = {})
         stub_request(:delete, "#{ASSET_MANAGER_ENDPOINT}/assets/#{asset_id}")
           .to_return(body: body.to_json, status: 200)
       end
 
-      def asset_manager_delete_asset_failure(asset_id)
+      def stub_asset_manager_delete_asset_failure(asset_id)
         stub_request(:delete, "#{ASSET_MANAGER_ENDPOINT}/assets/#{asset_id}").to_return(status: 500)
       end
+
+      # Aliases for DEPRECATED methods
+      alias_method :asset_manager_is_down, :stub_asset_manager_is_down
+      alias_method :asset_manager_updates_any_asset, :stub_asset_manager_updates_any_asset
+      alias_method :asset_manager_deletes_any_asset, :stub_asset_manager_deletes_any_asset
+      alias_method :asset_manager_has_an_asset, :stub_asset_manager_has_an_asset
+      alias_method :asset_manager_has_a_whitehall_asset, :stub_asset_manager_has_a_whitehall_asset
+      alias_method :asset_manager_does_not_have_an_asset, :stub_asset_manager_does_not_have_an_asset
+      alias_method :asset_manager_does_not_have_a_whitehall_asset, :stub_asset_manager_does_not_have_a_whitehall_asset
+      alias_method :asset_manager_receives_an_asset, :stub_asset_manager_receives_an_asset
+      alias_method :asset_manager_update_asset, :stub_asset_manager_update_asset
+      alias_method :asset_manager_update_failure, :stub_asset_manager_update_asset_failure
+      alias_method :asset_manager_delete_asset, :stub_asset_manager_delete_asset
+      alias_method :asset_manager_delete_failure, :stub_asset_manager_delete_asset_failure
     end
   end
 end

--- a/test/asset_manager_test.rb
+++ b/test/asset_manager_test.rb
@@ -14,7 +14,7 @@ describe GdsApi::AssetManager do
   let(:asset_url) { [base_api_url, "assets", asset_id].join("/") }
   let(:asset_id) { "new-asset-id" }
 
-  let(:asset_manager_response) {
+  let(:stub_asset_manager_response) {
     {
       asset: {
         id: asset_url,
@@ -26,7 +26,7 @@ describe GdsApi::AssetManager do
     req = stub_request(:post, "#{base_api_url}/assets").
       with { |request|
         request.body =~ %r{Content\-Disposition: form\-data; name="asset\[file\]"; filename="hello\.txt"\r\nContent\-Type: text/plain}
-      }.to_return(body: JSON.dump(asset_manager_response), status: 201)
+      }.to_return(body: JSON.dump(stub_asset_manager_response), status: 201)
 
     response = api.create_asset(file: file_fixture)
 
@@ -38,7 +38,7 @@ describe GdsApi::AssetManager do
     req = stub_request(:post, "#{base_api_url}/whitehall_assets").
       with { |request|
         request.body =~ %r{Content\-Disposition: form\-data; name="asset\[file\]"; filename="hello\.txt"\r\nContent\-Type: text/plain}
-      }.to_return(body: JSON.dump(asset_manager_response), status: 201)
+      }.to_return(body: JSON.dump(stub_asset_manager_response), status: 201)
 
     response = api.create_whitehall_asset(file: file_fixture, legacy_url_path: '/government/uploads/path/to/hello.txt')
 
@@ -47,7 +47,7 @@ describe GdsApi::AssetManager do
   end
 
   it "returns not found when an asset does not exist" do
-    asset_manager_does_not_have_an_asset("not-really-here")
+    stub_asset_manager_does_not_have_an_asset("not-really-here")
 
     assert_raises GdsApi::HTTPNotFound do
       api.asset("not-really-here")
@@ -59,7 +59,7 @@ describe GdsApi::AssetManager do
   end
 
   it "raises not found when a Whitehall asset does not exist" do
-    asset_manager_does_not_have_a_whitehall_asset("/path/to/non-existent-asset.png")
+    stub_asset_manager_does_not_have_a_whitehall_asset("/path/to/non-existent-asset.png")
 
     assert_raises GdsApi::HTTPNotFound do
       api.whitehall_asset("/path/to/non-existent-asset.png")
@@ -68,7 +68,7 @@ describe GdsApi::AssetManager do
 
   describe "an asset exists" do
     before do
-      asset_manager_has_an_asset(
+      stub_asset_manager_has_an_asset(
         asset_id,
         "name" => "photo.jpg",
         "content_type" => "image/jpeg",
@@ -80,7 +80,7 @@ describe GdsApi::AssetManager do
 
     it "updates an asset with a file" do
       req = stub_request(:put, "#{base_api_url}/assets/test-id").
-        to_return(body: JSON.dump(asset_manager_response), status: 200)
+        to_return(body: JSON.dump(stub_asset_manager_response), status: 200)
 
       response = api.update_asset(asset_id, file: file_fixture)
 
@@ -99,7 +99,7 @@ describe GdsApi::AssetManager do
 
   describe "a Whitehall asset exists" do
     before do
-      asset_manager_has_a_whitehall_asset(
+      stub_asset_manager_has_a_whitehall_asset(
         "/government/uploads/photo.jpg",
         "id" => "asset-id"
       )
@@ -114,7 +114,7 @@ describe GdsApi::AssetManager do
 
   describe "a Whitehall asset with a legacy_url_path containing non-ascii characters exists" do
     before do
-      asset_manager_has_a_whitehall_asset(
+      stub_asset_manager_has_a_whitehall_asset(
         "/government/uploads/phot%C3%B8.jpg",
         "id" => "asset-id"
       )
@@ -129,7 +129,7 @@ describe GdsApi::AssetManager do
 
   it "deletes an asset for the given id" do
     req = stub_request(:delete, "#{base_api_url}/assets/#{asset_id}").
-      to_return(body: JSON.dump(asset_manager_response), status: 200)
+      to_return(body: JSON.dump(stub_asset_manager_response), status: 200)
 
     response = api.delete_asset(asset_id)
 
@@ -139,7 +139,7 @@ describe GdsApi::AssetManager do
 
   it "restores an asset for the given id" do
     req = stub_request(:post, "#{base_api_url}/assets/#{asset_id}/restore").
-      to_return(body: JSON.dump(asset_manager_response), status: 200)
+      to_return(body: JSON.dump(stub_asset_manager_response), status: 200)
 
     response = api.restore_asset(asset_id)
 

--- a/test/test_helpers/asset_manager_test.rb
+++ b/test/test_helpers/asset_manager_test.rb
@@ -5,16 +5,16 @@ require 'gds_api/test_helpers/asset_manager'
 describe GdsApi::TestHelpers::AssetManager do
   include GdsApi::TestHelpers::AssetManager
 
-  let(:asset_manager) do
+  let(:stub_asset_manager) do
     GdsApi::AssetManager.new(Plek.current.find("asset-manager"))
   end
 
-  describe "#asset_manager_receives_an_asset" do
+  describe "#stub_asset_manager_receives_an_asset" do
     describe "when passed a string" do
       it "returns the string as the file url" do
         url = "https://assets.example.com/path/to/asset"
-        asset_manager_receives_an_asset(url)
-        response = asset_manager.create_asset({})
+        stub_asset_manager_receives_an_asset(url)
+        response = stub_asset_manager.create_asset({})
 
         assert_equal url, response["file_url"]
       end
@@ -22,8 +22,8 @@ describe GdsApi::TestHelpers::AssetManager do
 
     describe "when passed no arguments" do
       it "returns a random, yet valid asset manager url" do
-        asset_manager_receives_an_asset
-        response = asset_manager.create_asset({})
+        stub_asset_manager_receives_an_asset
+        response = stub_asset_manager.create_asset({})
 
         url_format = %r{\Ahttp://asset-manager.dev.gov.uk/media/[^/]*/[^/]*\Z}
         assert_match url_format, response["file_url"]
@@ -32,24 +32,24 @@ describe GdsApi::TestHelpers::AssetManager do
 
     describe "when passed a hash" do
       it "can specify the id of an asset" do
-        asset_manager_receives_an_asset(id: "123")
-        response = asset_manager.create_asset({})
+        stub_asset_manager_receives_an_asset(id: "123")
+        response = stub_asset_manager.create_asset({})
 
         url_format = %r{\Ahttp://asset-manager.dev.gov.uk/media/123/[^/]*\Z}
         assert_match url_format, response["file_url"]
       end
 
       it "can specify the filename of an asset" do
-        asset_manager_receives_an_asset(filename: "file.ext")
-        response = asset_manager.create_asset({})
+        stub_asset_manager_receives_an_asset(filename: "file.ext")
+        response = stub_asset_manager.create_asset({})
 
         url_format = %r{\Ahttp://asset-manager.dev.gov.uk/media/[^/]*/file.ext\Z}
         assert_match url_format, response["file_url"]
       end
 
       it "can specify both filename and id" do
-        asset_manager_receives_an_asset(id: "123", filename: "file.ext")
-        response = asset_manager.create_asset({})
+        stub_asset_manager_receives_an_asset(id: "123", filename: "file.ext")
+        response = stub_asset_manager.create_asset({})
 
         url_format = %r{\Ahttp://asset-manager.dev.gov.uk/media/123/file.ext\Z}
         assert_match url_format, response["file_url"]


### PR DESCRIPTION
https://trello.com/c/5JMGsuBj/581-follow-up-work-from-versioning-review

Using some of these helpers currently leads to amusing tests e.g.

   # current way
   ... some test setup ...
   asset_manager_deletes_any_asset
   ... some more test ...

   # proposed way
   ... some test setup ...
   stub_asset_manager_deletes_any_asset
   ... some more test ...

Without some kind of prefix, the behaviour of these methods is a bit
ambiguous, especially where they suggest some rather scary autonomous
action, like Asset Manager randomly deleting assets it's not keen on!

This deprecates the existing Asset Manager helpers and favours a new
stub_ prefix, similar to the WebMock and PublishingApi test helpers.