### PR TITLE
Prefer stub_ prefix for all adapter test helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 57.1.0
 
+* Change all test helpers to use a stub\_ prefix (old names are now aliases)
 * Add additional Asset Manager test helper methods
 
 # 57.0.0

--- a/lib/gds_api/test_helpers/calendars.rb
+++ b/lib/gds_api/test_helpers/calendars.rb
@@ -3,17 +3,18 @@ module GdsApi
     module Calendars
       CALENDARS_ENDPOINT = Plek.current.find('calendars')
 
-      def calendars_endpoint(in_division: nil)
+
+      def stub_calendars_endpoint(in_division: nil)
         endpoint = "#{CALENDARS_ENDPOINT}/bank-holidays"
         endpoint += "/#{in_division}" unless in_division.nil?
         endpoint + '.json'
       end
 
-      def calendars_has_no_bank_holidays(in_division: nil)
+      def stub_calendars_has_no_bank_holidays(in_division: nil)
         calendars_has_bank_holidays_on([], in_division: in_division)
       end
 
-      def calendars_has_bank_holidays_on(dates, in_division: nil)
+      def stub_calendars_has_bank_holidays_on(dates, in_division: nil)
         events = dates.map.with_index do |date, idx|
           {
             title: "Caturday #{idx}!",
@@ -50,9 +51,15 @@ module GdsApi
           .to_return(body: response.to_json, status: 200)
       end
 
-      def calendars_has_a_bank_holiday_on(date, in_division: nil)
+      def stub_calendars_has_a_bank_holiday_on(date, in_division: nil)
         calendars_has_bank_holidays_on([date], in_division: in_division)
       end
+
+      # Aliases for DEPRECATED methods
+      alias_method :calendars_endpoint, :stub_calendars_endpoint
+      alias_method :calendars_has_no_bank_holidays, :stub_calendars_has_no_bank_holidays
+      alias_method :calendars_has_bank_holidays_on, :stub_calendars_has_bank_holidays_on
+      alias_method :calendars_has_a_bank_holiday_on, :stub_calendars_has_a_bank_holiday_on
     end
   end
 end

--- a/lib/gds_api/test_helpers/content_store.rb
+++ b/lib/gds_api/test_helpers/content_store.rb
@@ -14,15 +14,14 @@ module GdsApi
       #   :private  if true, the Cache-Control header will include the "private" directive. By default it
       #             will include "public"
       #   :draft    will point to the draft content store if set to true
-
-      def content_store_endpoint(draft = false)
+      def stub_content_store_endpoint(draft = false)
         draft ? Plek.current.find('draft-content-store') : Plek.current.find('content-store')
       end
 
-      def content_store_has_item(base_path, body = content_item_for_base_path(base_path), options = {})
+      def stub_content_store_has_item(base_path, body = content_item_for_base_path(base_path), options = {})
         max_age = options.fetch(:max_age, 900)
         visibility = options[:private] ? "private" : "public"
-        url = content_store_endpoint(options[:draft]) + "/content" + base_path
+        url = stub_content_store_endpoint(options[:draft]) + "/content" + base_path
         body = body.to_json unless body.is_a?(String)
 
         stub_request(:get, url).to_return(
@@ -35,11 +34,11 @@ module GdsApi
         )
       end
 
-      def content_store_does_not_have_item(base_path, options = {})
-        url = content_store_endpoint(options[:draft]) + "/content" + base_path
+      def stub_content_store_does_not_have_item(base_path, options = {})
+        url = stub_content_store_endpoint(options[:draft]) + "/content" + base_path
         stub_request(:get, url).to_return(status: 404, headers: {})
 
-        url = content_store_endpoint(options[:draft]) + "/incoming-links" + base_path
+        url = stub_content_store_endpoint(options[:draft]) + "/incoming-links" + base_path
         stub_request(:get, url).to_return(status: 404, headers: {})
       end
 
@@ -54,7 +53,7 @@ module GdsApi
       #
       # @example
       #
-      #   content_store.content_store_has_gone_item('/sample-slug')
+      #   stub_content_store.stub_content_store_has_gone_item('/sample-slug')
       #
       #   # Will return HTTP Status Code 410 and the following response body:
       #   {
@@ -67,8 +66,8 @@ module GdsApi
       #     "withdrawn_notice" => {},
       #     "details" => {}
       #   }
-      def content_store_has_gone_item(base_path, body = gone_content_item_for_base_path(base_path), options = {})
-        url = content_store_endpoint(options[:draft]) + "/content" + base_path
+      def stub_content_store_has_gone_item(base_path, body = gone_content_item_for_base_path(base_path), options = {})
+        url = stub_content_store_endpoint(options[:draft]) + "/content" + base_path
         body = body.to_json unless body.is_a?(String)
 
         stub_request(:get, url).to_return(
@@ -78,20 +77,28 @@ module GdsApi
         )
       end
 
-      def content_store_isnt_available
-        stub_request(:any, /#{content_store_endpoint}\/.*/).to_return(status: 503)
+      def stub_content_store_isnt_available
+        stub_request(:any, /#{stub_content_store_endpoint}\/.*/).to_return(status: 503)
       end
 
       def content_item_for_base_path(base_path)
         super.merge("base_path" => base_path)
       end
 
-      def content_store_has_incoming_links(base_path, links)
-        url = content_store_endpoint + "/incoming-links" + base_path
+      def stub_content_store_has_incoming_links(base_path, links)
+        url = stub_content_store_endpoint + "/incoming-links" + base_path
         body = links.to_json
 
         stub_request(:get, url).to_return(body: body)
       end
+
+      # Aliases for DEPRECATED methods
+      alias_method :content_store_endpoint, :stub_content_store_endpoint
+      alias_method :content_store_has_item, :stub_content_store_has_item
+      alias_method :content_store_does_not_have_item, :stub_content_store_does_not_have_item
+      alias_method :content_store_has_gone_item, :stub_content_store_has_gone_item
+      alias_method :content_store_isnt_available, :stub_content_store_isnt_available
+      alias_method :content_store_has_incoming_links, :stub_content_store_has_incoming_links
     end
   end
 end

--- a/lib/gds_api/test_helpers/email_alert_api.rb
+++ b/lib/gds_api/test_helpers/email_alert_api.rb
@@ -6,7 +6,7 @@ module GdsApi
     module EmailAlertApi
       EMAIL_ALERT_API_ENDPOINT = Plek.find("email-alert-api")
 
-      def email_alert_api_has_updated_subscriber(id, new_address)
+      def stub_email_alert_api_has_updated_subscriber(id, new_address)
         stub_request(:patch, "#{EMAIL_ALERT_API_ENDPOINT}/subscribers/#{id}")
           .to_return(
             status: 200,
@@ -14,12 +14,12 @@ module GdsApi
           )
       end
 
-      def email_alert_api_does_not_have_updated_subscriber(id)
+      def stub_email_alert_api_does_not_have_updated_subscriber(id)
         stub_request(:patch, "#{EMAIL_ALERT_API_ENDPOINT}/subscribers/#{id}")
           .to_return(status: 404)
       end
 
-      def email_alert_api_has_updated_subscription(subscription_id, frequency)
+      def stub_email_alert_api_has_updated_subscription(subscription_id, frequency)
         stub_request(:patch, "#{EMAIL_ALERT_API_ENDPOINT}/subscriptions/#{subscription_id}")
           .to_return(
             status: 200,
@@ -27,12 +27,12 @@ module GdsApi
           )
       end
 
-      def email_alert_api_does_not_have_updated_subscription(subscription_id)
+      def stub_email_alert_api_does_not_have_updated_subscription(subscription_id)
         stub_request(:patch, "#{EMAIL_ALERT_API_ENDPOINT}/subscriptions/#{subscription_id}")
           .to_return(status: 404)
       end
 
-      def email_alert_api_has_subscriber_subscriptions(id, address)
+      def stub_email_alert_api_has_subscriber_subscriptions(id, address)
         stub_request(:get, "#{EMAIL_ALERT_API_ENDPOINT}/subscribers/#{id}/subscriptions")
           .to_return(
             status: 200,
@@ -40,12 +40,12 @@ module GdsApi
           )
       end
 
-      def email_alert_api_does_not_have_subscriber_subscriptions(id)
+      def stub_email_alert_api_does_not_have_subscriber_subscriptions(id)
         stub_request(:get, "#{EMAIL_ALERT_API_ENDPOINT}/subscribers/#{id}/subscriptions")
           .to_return(status: 404)
       end
 
-      def email_alert_api_has_subscription(
+      def stub_email_alert_api_has_subscription(
         id,
         frequency,
         title: "Some title",
@@ -67,7 +67,7 @@ module GdsApi
           )
       end
 
-      def email_alert_api_has_subscriber_list(attributes)
+      def stub_email_alert_api_has_subscriber_list(attributes)
         stub_request(:get, build_subscriber_lists_url(attributes))
           .to_return(
             status: 200,
@@ -75,12 +75,12 @@ module GdsApi
           )
       end
 
-      def email_alert_api_does_not_have_subscriber_list(attributes)
+      def stub_email_alert_api_does_not_have_subscriber_list(attributes)
         stub_request(:get, build_subscriber_lists_url(attributes))
           .to_return(status: 404)
       end
 
-      def email_alert_api_creates_subscriber_list(attributes)
+      def stub_email_alert_api_creates_subscriber_list(attributes)
         stub_request(:post, build_subscriber_lists_url)
           .to_return(
             status: 201,
@@ -88,17 +88,17 @@ module GdsApi
           )
       end
 
-      def email_alert_api_refuses_to_create_subscriber_list
+      def stub_email_alert_api_refuses_to_create_subscriber_list
         stub_request(:post, build_subscriber_lists_url)
           .to_return(status: 422)
       end
 
-      def email_alert_api_accepts_unpublishing_message
+      def stub_email_alert_api_accepts_unpublishing_message
         stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/unpublish-messages")
           .to_return(status: 202, body: {}.to_json)
       end
 
-      def email_alert_api_accepts_alert
+      def stub_email_alert_api_accepts_alert
         stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/notifications")
           .to_return(status: 202, body: {}.to_json)
       end
@@ -118,7 +118,7 @@ module GdsApi
         assert_requested(:post, "#{EMAIL_ALERT_API_ENDPOINT}/notifications", times: 1, &matcher)
       end
 
-      def email_alert_api_has_notifications(notifications, start_at = nil)
+      def stub_email_alert_api_has_notifications(notifications, start_at = nil)
         url = "#{EMAIL_ALERT_API_ENDPOINT}/notifications"
         url += "?start_at=#{start_at}" if start_at
         url_regexp = Regexp.new("^#{Regexp.escape(url)}$")
@@ -130,7 +130,7 @@ module GdsApi
           )
       end
 
-      def email_alert_api_has_notification(notification)
+      def stub_email_alert_api_has_notification(notification)
         url = "#{EMAIL_ALERT_API_ENDPOINT}/notifications/#{notification['web_service_bulletin']['to_param']}"
 
         stub_request(:get, url).to_return(
@@ -139,50 +139,50 @@ module GdsApi
         )
       end
 
-      def email_alert_api_unsubscribes_a_subscription(uuid)
+      def stub_email_alert_api_unsubscribes_a_subscription(uuid)
         stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/unsubscribe/#{uuid}")
           .with(body: "{}")
           .to_return(status: 204)
       end
 
-      def email_alert_api_has_no_subscription_for_uuid(uuid)
+      def stub_email_alert_api_has_no_subscription_for_uuid(uuid)
         stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/unsubscribe/#{uuid}")
           .with(body: "{}")
           .to_return(status: 404)
       end
 
-      def email_alert_api_unsubscribes_a_subscriber(subscriber_id)
+      def stub_email_alert_api_unsubscribes_a_subscriber(subscriber_id)
         stub_request(:delete, "#{EMAIL_ALERT_API_ENDPOINT}/subscribers/#{subscriber_id}")
           .to_return(status: 204)
       end
 
-      def email_alert_api_has_no_subscriber(subscriber_id)
+      def stub_email_alert_api_has_no_subscriber(subscriber_id)
         stub_request(:delete, "#{EMAIL_ALERT_API_ENDPOINT}/subscribers/#{subscriber_id}")
           .to_return(status: 404)
       end
 
-      def email_alert_api_creates_a_subscription(subscribable_id, address, frequency, returned_subscription_id)
+      def stub_email_alert_api_creates_a_subscription(subscribable_id, address, frequency, returned_subscription_id)
         stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscriptions")
           .with(
             body: { subscribable_id: subscribable_id, address: address, frequency: frequency }.to_json
         ).to_return(status: 201, body: { subscription_id: returned_subscription_id }.to_json)
       end
 
-      def email_alert_api_creates_an_existing_subscription(subscribable_id, address, frequency, returned_subscription_id)
+      def stub_email_alert_api_creates_an_existing_subscription(subscribable_id, address, frequency, returned_subscription_id)
         stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscriptions")
           .with(
             body: { subscribable_id: subscribable_id, address: address, frequency: frequency }.to_json
         ).to_return(status: 200, body: { subscription_id: returned_subscription_id }.to_json)
       end
 
-      def email_alert_api_refuses_to_create_subscription(subscribable_id, address, frequency)
+      def stub_email_alert_api_refuses_to_create_subscription(subscribable_id, address, frequency)
         stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscriptions")
           .with(
             body: { subscribable_id: subscribable_id, address: address, frequency: frequency }.to_json
         ).to_return(status: 422)
       end
 
-      def email_alert_api_creates_an_auth_token(subscriber_id, address)
+      def stub_email_alert_api_creates_an_auth_token(subscriber_id, address)
         stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscribers/auth-token")
           .to_return(
             status: 201,
@@ -204,7 +204,7 @@ module GdsApi
         end
       end
 
-      def email_alert_api_has_subscribable(reference:, returned_attributes:)
+      def stub_email_alert_api_has_subscribable(reference:, returned_attributes:)
         stub_request(:get, "#{EMAIL_ALERT_API_ENDPOINT}/subscribables/#{reference}")
           .to_return(
             status: 200,
@@ -214,10 +214,37 @@ module GdsApi
         )
       end
 
-      def email_alert_api_does_not_have_subscribable(reference:)
+      def stub_email_alert_api_does_not_have_subscribable(reference:)
         stub_request(:get, "#{EMAIL_ALERT_API_ENDPOINT}/subscribables/#{reference}")
           .to_return(status: 404)
       end
+
+      # Aliases for DEPRECATED methods
+      alias_method :email_alert_api_has_updated_subscriber, :stub_email_alert_api_has_updated_subscriber
+      alias_method :email_alert_api_does_not_have_updated_subscriber, :stub_email_alert_api_does_not_have_updated_subscriber
+      alias_method :email_alert_api_has_updated_subscription, :stub_email_alert_api_has_updated_subscription
+      alias_method :email_alert_api_does_not_have_updated_subscription, :stub_email_alert_api_does_not_have_updated_subscription
+      alias_method :email_alert_api_has_subscriber_subscriptions, :stub_email_alert_api_has_subscriber_subscriptions
+      alias_method :email_alert_api_does_not_have_subscriber_subscriptions, :stub_email_alert_api_does_not_have_subscriber_subscriptions
+      alias_method :email_alert_api_has_subscription, :stub_email_alert_api_has_subscription
+      alias_method :email_alert_api_has_subscriber_list, :stub_email_alert_api_has_subscriber_list
+      alias_method :email_alert_api_does_not_have_subscriber_list, :stub_email_alert_api_does_not_have_subscriber_list
+      alias_method :email_alert_api_creates_subscriber_list, :stub_email_alert_api_creates_subscriber_list
+      alias_method :email_alert_api_refuses_to_create_subscriber_list, :stub_email_alert_api_refuses_to_create_subscriber_list
+      alias_method :email_alert_api_accepts_unpublishing_message, :stub_email_alert_api_accepts_unpublishing_message
+      alias_method :email_alert_api_accepts_alert, :stub_email_alert_api_accepts_alert
+      alias_method :email_alert_api_has_notifications, :stub_email_alert_api_has_notifications
+      alias_method :email_alert_api_has_notification, :stub_email_alert_api_has_notification
+      alias_method :email_alert_api_unsubscribes_a_subscription, :stub_email_alert_api_unsubscribes_a_subscription
+      alias_method :email_alert_api_has_no_subscription_for_uuid, :stub_email_alert_api_has_no_subscription_for_uuid
+      alias_method :email_alert_api_unsubscribes_a_subscriber, :stub_email_alert_api_unsubscribes_a_subscriber
+      alias_method :email_alert_api_has_no_subscriber, :stub_email_alert_api_has_no_subscriber
+      alias_method :email_alert_api_creates_a_subscription, :stub_email_alert_api_creates_a_subscription
+      alias_method :email_alert_api_creates_an_existing_subscription, :stub_email_alert_api_creates_an_existing_subscription
+      alias_method :email_alert_api_refuses_to_create_subscription, :stub_email_alert_api_refuses_to_create_subscription
+      alias_method :email_alert_api_creates_an_auth_token, :stub_email_alert_api_creates_an_auth_token
+      alias_method :email_alert_api_has_subscribable, :stub_email_alert_api_has_subscribable
+      alias_method :email_alert_api_does_not_have_subscribable, :stub_email_alert_api_does_not_have_subscribable
 
     private
 

--- a/lib/gds_api/test_helpers/imminence.rb
+++ b/lib/gds_api/test_helpers/imminence.rb
@@ -7,12 +7,12 @@ module GdsApi
       # you could redefine/override the constant or stub directly.
       IMMINENCE_API_ENDPOINT = Plek.current.find('imminence')
 
-      def imminence_has_places(latitude, longitude, details)
+      def stub_imminence_has_places(latitude, longitude, details)
         query_hash = { "lat" => latitude, "lng" => longitude, "limit" => "5" }
         stub_imminence_places_request(details['slug'], query_hash, details['details'])
       end
 
-      def imminence_has_areas_for_postcode(postcode, areas)
+      def stub_imminence_has_areas_for_postcode(postcode, areas)
         results = {
           "_response_info" => { "status" => "ok" },
           "total" => areas.size, "startIndex" => 1, "pageSize" => areas.size,
@@ -23,7 +23,7 @@ module GdsApi
           to_return(body: results.to_json)
       end
 
-      def imminence_has_places_for_postcode(places, slug, postcode, limit)
+      def stub_imminence_has_places_for_postcode(places, slug, postcode, limit)
         query_hash = { "postcode" => postcode, "limit" => limit }
         stub_imminence_places_request(slug, query_hash, places)
       end
@@ -33,6 +33,11 @@ module GdsApi
         with(query: query_hash).
         to_return(status: status_code, body: return_data.to_json, headers: {})
       end
+
+      # Aliases for DEPRECATED methods
+      alias_method :imminence_has_places, :stub_imminence_has_places
+      alias_method :imminence_has_areas_for_postcode, :stub_imminence_has_areas_for_postcode
+      alias_method :imminence_has_places_for_postcode, :stub_imminence_has_places_for_postcode
     end
   end
 end

--- a/lib/gds_api/test_helpers/licence_application.rb
+++ b/lib/gds_api/test_helpers/licence_application.rb
@@ -7,7 +7,7 @@ module GdsApi
       # you could redefine/override the constant or stub directly.
       LICENCE_APPLICATION_ENDPOINT = Plek.current.find("licensify")
 
-      def licence_exists(identifier, licence)
+      def stub_licence_exists(identifier, licence)
         licence = licence.to_json unless licence.is_a?(String)
         stub_request(:get, "#{LICENCE_APPLICATION_ENDPOINT}/api/licence/#{identifier}").
           with(headers: GdsApi::JsonClient.default_request_headers).
@@ -15,20 +15,26 @@ module GdsApi
             body: licence)
       end
 
-      def licence_does_not_exist(identifier)
+      def stub_licence_does_not_exist(identifier)
         stub_request(:get, "#{LICENCE_APPLICATION_ENDPOINT}/api/licence/#{identifier}").
           with(headers: GdsApi::JsonClient.default_request_headers).
           to_return(status: 404,
             body: "{\"error\": [\"Unrecognised Licence Id: #{identifier}\"]}")
       end
 
-      def licence_times_out(identifier)
+      def stub_licence_times_out(identifier)
         stub_request(:get, "#{LICENCE_APPLICATION_ENDPOINT}/api/licence/#{identifier}").to_timeout
       end
 
-      def licence_returns_error(identifier)
+      def stub_licence_returns_error(identifier)
         stub_request(:get, "#{LICENCE_APPLICATION_ENDPOINT}/api/licence/#{identifier}").to_return(status: 500)
       end
+
+      # Aliases for DEPRECATED methods
+      alias_method :licence_exists, :stub_licence_exists
+      alias_method :licence_does_not_exist, :stub_licence_does_not_exist
+      alias_method :licence_times_out, :stub_licence_times_out
+      alias_method :licence_returns_error, :stub_licence_returns_error
     end
   end
 end

--- a/lib/gds_api/test_helpers/link_checker_api.rb
+++ b/lib/gds_api/test_helpers/link_checker_api.rb
@@ -5,7 +5,7 @@ module GdsApi
     module LinkCheckerApi
       LINK_CHECKER_API_ENDPOINT = Plek.current.find("link-checker-api")
 
-      def link_checker_api_link_report_hash(uri:, status: :ok, checked: nil, errors: [], warnings: [], problem_summary: nil, suggested_fix: nil)
+      def stub_link_checker_api_link_report_hash(uri:, status: :ok, checked: nil, errors: [], warnings: [], problem_summary: nil, suggested_fix: nil)
         {
           uri: uri,
           status: status,
@@ -17,18 +17,18 @@ module GdsApi
         }
       end
 
-      def link_checker_api_batch_report_hash(id:, status: :completed, links: [], totals: {}, completed_at: nil)
+      def stub_link_checker_api_batch_report_hash(id:, status: :completed, links: [], totals: {}, completed_at: nil)
         {
           id: id,
           status: status,
-          links: links.map { |hash| link_checker_api_link_report_hash(**hash) },
+          links: links.map { |hash| stub_link_checker_api_link_report_hash(**hash) },
           totals: totals,
           completed_at: completed_at || Time.now.iso8601,
         }
       end
 
-      def link_checker_api_check(uri:, status: :ok, checked: nil, errors: [], warnings: [], problem_summary: nil, suggested_fix: nil)
-        body = link_checker_api_link_report_hash(
+      def stub_link_checker_api_check(uri:, status: :ok, checked: nil, errors: [], warnings: [], problem_summary: nil, suggested_fix: nil)
+        body = stub_link_checker_api_link_report_hash(
           uri: uri, status: status, checked: checked, errors: errors, warnings: warnings, problem_summary: problem_summary, suggested_fix: suggested_fix,
         ).to_json
 
@@ -37,8 +37,8 @@ module GdsApi
           .to_return(body: body, status: 200, headers: { "Content-Type" => "application/json" })
       end
 
-      def link_checker_api_get_batch(id:, status: :completed, links: [], totals: {}, completed_at: nil)
-        body = link_checker_api_batch_report_hash(
+      def stub_link_checker_api_get_batch(id:, status: :completed, links: [], totals: {}, completed_at: nil)
+        body = stub_link_checker_api_batch_report_hash(
           id: id, status: status, links: links, totals: totals, completed_at: completed_at
         ).to_json
 
@@ -46,10 +46,10 @@ module GdsApi
           .to_return(body: body, status: 200, headers: { "Content-Type" => "application/json" })
       end
 
-      def link_checker_api_create_batch(uris:, checked_within: nil, webhook_uri: nil, webhook_secret_token: nil, id: 0, status: :in_progress, links: nil, totals: {}, completed_at: nil)
+      def stub_link_checker_api_create_batch(uris:, checked_within: nil, webhook_uri: nil, webhook_secret_token: nil, id: 0, status: :in_progress, links: nil, totals: {}, completed_at: nil)
         links = uris.map { |uri| { uri: uri } } if links.nil?
 
-        response_body = link_checker_api_batch_report_hash(
+        response_body = stub_link_checker_api_batch_report_hash(
           id: id,
           status: status,
           links: links,
@@ -73,7 +73,7 @@ module GdsApi
           )
       end
 
-      def link_checker_api_upsert_resource_monitor(app:, reference:, links:)
+      def stub_link_checker_api_upsert_resource_monitor(app:, reference:, links:)
         response_body = { id: 1 }.to_json
 
         request_body = {
@@ -89,6 +89,14 @@ module GdsApi
             headers: { "Content-Type" => "application/json" }
           )
       end
+
+      # Aliases for DEPRECATED methods
+      alias_method :link_link_checker_api_link_report_hash, :stub_link_checker_api_link_report_hash
+      alias_method :link_link_checker_api_batch_report_hash, :stub_link_checker_api_batch_report_hash
+      alias_method :link_link_checker_api_check, :stub_link_checker_api_check
+      alias_method :link_link_checker_api_get_batch, :stub_link_checker_api_get_batch
+      alias_method :link_link_checker_api_create_batch, :stub_link_checker_api_create_batch
+      alias_method :link_link_checker_api_upsert_resource_monitor, :stub_link_checker_api_upsert_resource_monitor
     end
   end
 end

--- a/lib/gds_api/test_helpers/local_links_manager.rb
+++ b/lib/gds_api/test_helpers/local_links_manager.rb
@@ -5,7 +5,7 @@ module GdsApi
     module LocalLinksManager
       LOCAL_LINKS_MANAGER_ENDPOINT = Plek.current.find('local-links-manager')
 
-      def local_links_manager_has_a_link(authority_slug:, lgsl:, lgil:, url:)
+      def stub_local_links_manager_has_a_link(authority_slug:, lgsl:, lgil:, url:)
         response = {
           "local_authority" => {
             "name" => authority_slug.capitalize,
@@ -25,7 +25,7 @@ module GdsApi
           .to_return(body: response.to_json, status: 200)
       end
 
-      def local_links_manager_has_no_link(authority_slug:, lgsl:, lgil:)
+      def stub_local_links_manager_has_no_link(authority_slug:, lgsl:, lgil:)
         response = {
           "local_authority" => {
             "name" => authority_slug.capitalize,
@@ -40,7 +40,7 @@ module GdsApi
           .to_return(body: response.to_json, status: 200)
       end
 
-      def local_links_manager_has_no_link_and_no_homepage_url(authority_slug:, lgsl:, lgil:)
+      def stub_local_links_manager_has_no_link_and_no_homepage_url(authority_slug:, lgsl:, lgil:)
         response = {
           "local_authority" => {
             "name" => authority_slug.capitalize,
@@ -55,7 +55,7 @@ module GdsApi
           .to_return(body: response.to_json, status: 200)
       end
 
-      def local_links_manager_request_with_missing_parameters(authority_slug, lgsl, lgil)
+      def stub_local_links_manager_request_with_missing_parameters(authority_slug, lgsl, lgil)
         # convert nil to an empty string, otherwise query param is not expressed correctly
         params = {
           authority_slug: authority_slug || "",
@@ -68,7 +68,7 @@ module GdsApi
           .to_return(body: {}.to_json, status: 400)
       end
 
-      def local_links_manager_does_not_have_required_objects(authority_slug, lgsl, lgil)
+      def stub_local_links_manager_does_not_have_required_objects(authority_slug, lgsl, lgil)
         params = { authority_slug: authority_slug, lgsl: lgsl, lgil: lgil }
 
         stub_request(:get, "#{LOCAL_LINKS_MANAGER_ENDPOINT}/api/link")
@@ -76,7 +76,7 @@ module GdsApi
           .to_return(body: {}.to_json, status: 404)
       end
 
-      def local_links_manager_has_a_local_authority(authority_slug)
+      def stub_local_links_manager_has_a_local_authority(authority_slug)
         response = {
           "local_authorities" => [
             {
@@ -92,7 +92,7 @@ module GdsApi
           .to_return(body: response.to_json, status: 200)
       end
 
-      def local_links_manager_has_a_district_and_county_local_authority(district_slug, county_slug)
+      def stub_local_links_manager_has_a_district_and_county_local_authority(district_slug, county_slug)
         response = {
           "local_authorities" => [
             {
@@ -113,19 +113,19 @@ module GdsApi
           .to_return(body: response.to_json, status: 200)
       end
 
-      def local_links_manager_request_without_local_authority_slug
+      def stub_local_links_manager_request_without_local_authority_slug
         stub_request(:get, "#{LOCAL_LINKS_MANAGER_ENDPOINT}/api/local-authority")
         .with(query: { authority_slug: '' })
         .to_return(body: {}.to_json, status: 400)
       end
 
-      def local_links_manager_does_not_have_an_authority(authority_slug)
+      def stub_local_links_manager_does_not_have_an_authority(authority_slug)
         stub_request(:get, "#{LOCAL_LINKS_MANAGER_ENDPOINT}/api/local-authority")
         .with(query: { authority_slug: authority_slug })
         .to_return(body: {}.to_json, status: 404)
       end
 
-      def local_links_manager_has_a_local_authority_without_homepage(authority_slug)
+      def stub_local_links_manager_has_a_local_authority_without_homepage(authority_slug)
         response = {
           "local_authorities" => [
             {
@@ -140,6 +140,18 @@ module GdsApi
           .with(query: { authority_slug: authority_slug })
           .to_return(body: response.to_json, status: 200)
       end
+
+      # Aliases for DEPRECATED methods
+      alias_method :local_links_manager_has_a_link, :stub_local_links_manager_has_a_link
+      alias_method :local_links_manager_has_no_link, :stub_local_links_manager_has_no_link
+      alias_method :local_links_manager_has_no_link_and_no_homepage_url, :stub_local_links_manager_has_no_link_and_no_homepage_url
+      alias_method :local_links_manager_request_with_missing_parameters, :stub_local_links_manager_request_with_missing_parameters
+      alias_method :local_links_manager_does_not_have_required_objects, :stub_local_links_manager_does_not_have_required_objects
+      alias_method :local_links_manager_has_a_local_authority, :stub_local_links_manager_has_a_local_authority
+      alias_method :local_links_manager_has_a_district_and_county_local_authority, :stub_local_links_manager_has_a_district_and_county_local_authority
+      alias_method :local_links_manager_request_without_local_authority_slug, :stub_local_links_manager_request_without_local_authority_slug
+      alias_method :local_links_manager_does_not_have_an_authority, :stub_local_links_manager_does_not_have_an_authority
+      alias_method :local_links_manager_has_a_local_authority_without_homepage, :stub_local_links_manager_has_a_local_authority_without_homepage
     end
   end
 end

--- a/lib/gds_api/test_helpers/mapit.rb
+++ b/lib/gds_api/test_helpers/mapit.rb
@@ -3,7 +3,7 @@ module GdsApi
     module Mapit
       MAPIT_ENDPOINT = Plek.current.find('mapit')
 
-      def mapit_has_a_postcode(postcode, coords)
+      def stub_mapit_has_a_postcode(postcode, coords)
         response = {
           "wgs84_lat" => coords.first,
           "wgs84_lon" => coords.last,
@@ -16,7 +16,7 @@ module GdsApi
           .to_return(body: response.to_json, status: 200)
       end
 
-      def mapit_has_a_postcode_and_areas(postcode, coords, areas)
+      def stub_mapit_has_a_postcode_and_areas(postcode, coords, areas)
         response = {
           "wgs84_lat" => coords.first,
           "wgs84_lon" => coords.last,
@@ -42,35 +42,45 @@ module GdsApi
           .to_return(body: response.to_json, status: 200)
       end
 
-      def mapit_does_not_have_a_postcode(postcode)
+      def stub_mapit_does_not_have_a_postcode(postcode)
         stub_request(:get, "#{MAPIT_ENDPOINT}/postcode/" + postcode.tr(' ', '+') + ".json")
           .to_return(body: { "code" => 404, "error" => "No Postcode matches the given query." }.to_json, status: 404)
       end
 
-      def mapit_does_not_have_a_bad_postcode(postcode)
+      def stub_mapit_does_not_have_a_bad_postcode(postcode)
         stub_request(:get, "#{MAPIT_ENDPOINT}/postcode/" + postcode.tr(' ', '+') + ".json")
           .to_return(body: { "code" => 400, "error" => "Postcode '#{postcode}' is not valid." }.to_json, status: 400)
       end
 
-      def mapit_has_areas(area_type, areas)
+      def stub_mapit_has_areas(area_type, areas)
         stub_request(:get, "#{MAPIT_ENDPOINT}/areas/" + area_type + ".json")
           .to_return(body: areas.to_json, status: 200)
       end
 
-      def mapit_does_not_have_areas(area_type)
+      def stub_mapit_does_not_have_areas(area_type)
         stub_request(:get, "#{MAPIT_ENDPOINT}/areas/" + area_type + ".json")
           .to_return(body: [].to_json, status: 200)
       end
 
-      def mapit_has_area_for_code(code_type, code, area)
+      def stub_mapit_has_area_for_code(code_type, code, area)
         stub_request(:get, "#{MAPIT_ENDPOINT}/code/#{code_type}/#{code}.json")
           .to_return(body: area.to_json, status: 200)
       end
 
-      def mapit_does_not_have_area_for_code(code_type, code)
+      def stub_mapit_does_not_have_area_for_code(code_type, code)
         stub_request(:get, "#{MAPIT_ENDPOINT}/code/#{code_type}/#{code}.json")
         .to_return(body: { "code" => 404, "error" => "No areas were found that matched code #{code_type} = #{code}." }.to_json, status: 404)
       end
+
+      # Aliases for DEPRECATED methods
+      alias_method :mapit_has_a_postcode, :stub_mapit_has_a_postcode
+      alias_method :mapit_has_a_postcode_and_areas, :stub_mapit_has_a_postcode_and_areas
+      alias_method :mapit_does_not_have_a_postcode, :stub_mapit_does_not_have_a_postcode
+      alias_method :mapit_does_not_have_a_bad_postcode, :stub_mapit_does_not_have_a_bad_postcode
+      alias_method :mapit_has_areas, :stub_mapit_has_areas
+      alias_method :mapit_does_not_have_areas, :stub_mapit_does_not_have_areas
+      alias_method :mapit_has_area_for_code, :stub_mapit_has_area_for_code
+      alias_method :mapit_does_not_have_area_for_code, :stub_mapit_does_not_have_area_for_code
     end
   end
 end

--- a/lib/gds_api/test_helpers/organisations.rb
+++ b/lib/gds_api/test_helpers/organisations.rb
@@ -10,7 +10,7 @@ module GdsApi
 
       WEBSITE_ROOT = Plek.new.website_root
 
-      def organisations_api_has_organisations(organisation_slugs)
+      def stub_organisations_api_has_organisations(organisation_slugs)
         bodies = organisation_slugs.map { |slug| organisation_for_slug(slug) }
         organisations_api_has_organisations_with_bodies(bodies)
       end
@@ -20,7 +20,7 @@ module GdsApi
       #
       # This also sets up the individual endpoints for each slug
       # by calling organisations_api_has_organisation below
-      def organisations_api_has_organisations_with_bodies(organisation_bodies)
+      def stub_organisations_api_has_organisations_with_bodies(organisation_bodies)
         # Stub API call to the endpoint for an individual organisation
         organisation_bodies.each do |body|
           slug = body["details"]["slug"]
@@ -65,13 +65,13 @@ module GdsApi
         end
       end
 
-      def organisations_api_has_organisation(organisation_slug, details = nil)
+      def stub_organisations_api_has_organisation(organisation_slug, details = nil)
         details ||= organisation_for_slug(organisation_slug)
         stub_request(:get, "#{WEBSITE_ROOT}/api/organisations/#{organisation_slug}").
           to_return(status: 200, body: details.to_json)
       end
 
-      def organisations_api_does_not_have_organisation(organisation_slug)
+      def stub_organisations_api_does_not_have_organisation(organisation_slug)
         stub_request(:get, "#{WEBSITE_ROOT}/api/organisations/#{organisation_slug}").to_return(status: 404)
       end
 
@@ -114,6 +114,12 @@ module GdsApi
           ],
         }
       end
+
+      # Aliases for DEPRECATED methods
+      alias_method :organisations_api_has_organisations, :stub_organisations_api_has_organisations
+      alias_method :organisations_api_has_organisations_with_bodies, :stub_organisations_api_has_organisations_with_bodies
+      alias_method :organisations_api_has_organisation, :stub_organisations_api_has_organisation
+      alias_method :organisations_api_does_not_have_organisation, :stub_organisations_api_does_not_have_organisation
     end
   end
 end

--- a/lib/gds_api/test_helpers/publishing_api.rb
+++ b/lib/gds_api/test_helpers/publishing_api.rb
@@ -59,7 +59,7 @@ module GdsApi
         end
       end
 
-      def publishing_api_isnt_available
+      def stub_publishing_api_isnt_available
         stub_request(:any, /#{PUBLISHING_API_ENDPOINT}\/.*/).to_return(status: 503)
       end
 
@@ -71,7 +71,7 @@ module GdsApi
         }
       end
 
-      def publishing_api_has_path_reservation_for(path, publishing_app)
+      def stub_publishing_api_has_path_reservation_for(path, publishing_app)
         data = publishing_api_path_data_for(path, "publishing_app" => publishing_app)
         error_data = data.merge("errors" => { "path" => ["is already reserved by the #{publishing_app} application"] })
 
@@ -86,13 +86,18 @@ module GdsApi
                     body: data.to_json)
       end
 
-      def publishing_api_returns_path_reservation_validation_error_for(path, error_details = nil)
+      def stub_publishing_api_returns_path_reservation_validation_error_for(path, error_details = nil)
         error_details ||= { "base" => ["computer says no"] }
         error_data = publishing_api_path_data_for(path).merge("errors" => error_details)
 
         stub_request(:put, "#{PUBLISHING_API_ENDPOINT}/paths#{path}").
           to_return(status: 422, body: error_data.to_json, headers: { content_type: "application/json" })
       end
+
+      # Aliases for DEPRECATED methods
+      alias_method :publishing_api_isnt_available, :stub_publishing_api_isnt_available
+      alias_method :publishing_api_has_path_reservation_for, :stub_publishing_api_has_path_reservation_for
+      alias_method :publishing_api_returns_path_reservation_validation_error_for, :stub_publishing_api_returns_path_reservation_validation_error_for
 
     private
 

--- a/lib/gds_api/test_helpers/publishing_api_v2.rb
+++ b/lib/gds_api/test_helpers/publishing_api_v2.rb
@@ -165,7 +165,7 @@ module GdsApi
       end
 
       # Stub any version 2 request to the publishing API to return a 503 response
-      def publishing_api_isnt_available
+      def stub_publishing_api_isnt_available
         stub_request(:any, /#{PUBLISHING_API_V2_ENDPOINT}\/.*/).to_return(status: 503)
         stub_request(:any, /#{PUBLISHING_API_ENDPOINT}\/.*/).to_return(status: 503)
       end
@@ -280,7 +280,7 @@ module GdsApi
       #
       # @example
       #
-      #   publishing_api_has_content(
+      #   stub_publishing_api_has_content(
       #     vehicle_recalls_and_faults,   # this is a variable containing an array of content items
       #     document_type: described_class.publishing_api_document_type,   #example of a document_type: "vehicle_recalls_and_faults_alert"
       #     fields: fields,   #example: let(:fields) { %i[base_path content_id public_updated_at title publication_state] }
@@ -289,7 +289,7 @@ module GdsApi
       #   )
       # @param items [Array]
       # @param params [Hash]
-      def publishing_api_has_content(items, params = {})
+      def stub_publishing_api_has_content(items, params = {})
         url = PUBLISHING_API_V2_ENDPOINT + "/content"
 
         if params.respond_to? :fetch
@@ -324,7 +324,7 @@ module GdsApi
 
       # This method has been refactored into publishing_api_has_content (above)
       # publishing_api_has_content allows for flexible passing in of arguments, please use instead
-      def publishing_api_has_fields_for_document(document_type, items, fields)
+      def stub_publishing_api_has_fields_for_document(document_type, items, fields)
         body = Array(items).map { |item|
           deep_stringify_keys(item).slice(*fields)
         }
@@ -341,7 +341,7 @@ module GdsApi
       # Stub GET /v2/linkables to return a set of content items with a specific document type
       #
       # @param linkables [Array]
-      def publishing_api_has_linkables(linkables, document_type:)
+      def stub_publishing_api_has_linkables(linkables, document_type:)
         url = PUBLISHING_API_V2_ENDPOINT + "/linkables?document_type=#{document_type}"
         stub_request(:get, url).to_return(status: 200, body: linkables.to_json, headers: {})
       end
@@ -349,7 +349,7 @@ module GdsApi
       # Stub GET /v2/content/:content_id to return a specific content item hash
       #
       # @param item [Hash]
-      def publishing_api_has_item(item, params = {})
+      def stub_publishing_api_has_item(item, params = {})
         item = deep_transform_keys(item, &:to_sym)
         url = PUBLISHING_API_V2_ENDPOINT + "/content/" + item[:content_id]
         stub_request(:get, url)
@@ -360,7 +360,7 @@ module GdsApi
       # Stub GET /v2/content/:content_id to progress through a series of responses.
       #
       # @param items [Array]
-      def publishing_api_has_item_in_sequence(content_id, items)
+      def stub_publishing_api_has_item_in_sequence(content_id, items)
         items = items.each { |item| deep_transform_keys(item, &:to_sym) }
         url = PUBLISHING_API_V2_ENDPOINT + "/content/" + content_id
         calls = -1
@@ -376,7 +376,7 @@ module GdsApi
       # Stub GET /v2/content/:content_id to return a 404 response
       #
       # @param content_id [UUID]
-      def publishing_api_does_not_have_item(content_id)
+      def stub_publishing_api_does_not_have_item(content_id)
         url = PUBLISHING_API_V2_ENDPOINT + "/content/" + content_id
         stub_request(:get, url).to_return(status: 404, body: resource_not_found(content_id, "content item").to_json, headers: {})
       end
@@ -387,7 +387,7 @@ module GdsApi
       #
       # @example
       #
-      #  publishing_api_has_links(
+      #  stub_publishing_api_has_links(
       #    {
       #      "content_id" => "64aadc14-9bca-40d9-abb6-4f21f9792a05",
       #      "links" => {
@@ -411,7 +411,7 @@ module GdsApi
       #        },
       #        "version" => 6
       #      }
-      def publishing_api_has_links(links)
+      def stub_publishing_api_has_links(links)
         links = deep_transform_keys(links, &:to_sym)
         url = PUBLISHING_API_V2_ENDPOINT + "/links/" + links[:content_id]
         stub_request(:get, url).to_return(status: 200, body: links.to_json, headers: {})
@@ -422,7 +422,7 @@ module GdsApi
       # @param [Hash] links the structure of the links hash
       #
       # @example
-      #   publishing_api_has_expanded_links(
+      #   stub_publishing_api_has_expanded_links(
       #     {
       #       "content_id" => "64aadc14-9bca-40d9-abb4-4f21f9792a05",
       #       "expanded_links" => {
@@ -471,7 +471,7 @@ module GdsApi
       #           ]
       #         }
       #       }
-      def publishing_api_has_expanded_links(links, with_drafts: true, generate: false)
+      def stub_publishing_api_has_expanded_links(links, with_drafts: true, generate: false)
         links = deep_transform_keys(links, &:to_sym)
         request_params = {}
         request_params['with_drafts'] = false if !with_drafts
@@ -488,7 +488,7 @@ module GdsApi
       # @param [Hash] links the links for each content id
       #
       # @example
-      #   publishing_api_has_links_for_content_ids(
+      #   stub_publishing_api_has_links_for_content_ids(
       #     { "2878337b-bed9-4e7f-85b6-10ed2cbcd504" => {
       #         "links" => { "taxons" => ["eb6965c7-3056-45d0-ae50-2f0a5e2e0854"] }
       #       },
@@ -507,7 +507,7 @@ module GdsApi
       #           ]
       #         }
       #       }
-      def publishing_api_has_links_for_content_ids(links)
+      def stub_publishing_api_has_links_for_content_ids(links)
         url = PUBLISHING_API_V2_ENDPOINT + "/links/by-content-id"
         stub_request(:post, url).with(body: { content_ids: links.keys }).to_return(status: 200, body: links.to_json, headers: {})
       end
@@ -515,7 +515,7 @@ module GdsApi
       # Stub GET /v2/links/:content_id to return a 404 response
       #
       # @param content_id [UUID]
-      def publishing_api_does_not_have_links(content_id)
+      def stub_publishing_api_does_not_have_links(content_id)
         url = PUBLISHING_API_V2_ENDPOINT + "/links/" + content_id
         stub_request(:get, url).to_return(status: 404, body: resource_not_found(content_id, "link set").to_json, headers: {})
       end
@@ -526,12 +526,12 @@ module GdsApi
       #
       # @example
       #
-      #   publishing_api_has_lookups({
+      #   stub_publishing_api_has_lookups({
       #     "/foo" => "51ac4247-fd92-470a-a207-6b852a97f2db",
       #     "/bar" => "261bd281-f16c-48d5-82d2-9544019ad9ca"
       #   })
       #
-      def publishing_api_has_lookups(lookup_hash)
+      def stub_publishing_api_has_lookups(lookup_hash)
         url = Plek.current.find('publishing-api') + '/lookup-by-base-path'
         stub_request(:post, url).to_return(body: lookup_hash.to_json)
       end
@@ -544,7 +544,7 @@ module GdsApi
       #
       # @example
       #
-      #   publishing_api_has_linked_items(
+      #   stub_publishing_api_has_linked_items(
       #     [ item_1, item_2 ],
       #     {
       #       content_id: "51ac4247-fd92-470a-a207-6b852a97f2db",
@@ -553,7 +553,7 @@ module GdsApi
       #     }
       #   )
       #
-      def publishing_api_has_linked_items(items, params = {})
+      def stub_publishing_api_has_linked_items(items, params = {})
         content_id = params.fetch(:content_id)
         link_type = params.fetch(:link_type)
         fields = params.fetch(:fields, %w(base_path content_id document_type title))
@@ -577,14 +577,14 @@ module GdsApi
       #
       # @example
       #
-      #   publishing_api_get_editions(
+      #   stub_publishing_api_get_editions(
       #     vehicle_recalls_and_faults,   # this is a variable containing an array of editions
       #     fields: fields,   #example: let(:fields) { %i[base_path content_id public_updated_at title publication_state] }
       #     per_page: 50
       #   )
       # @param items [Array]
       # @param params [Hash]
-      def publishing_api_get_editions(editions, params = {})
+      def stub_publishing_api_get_editions(editions, params = {})
         url = PUBLISHING_API_V2_ENDPOINT + "/editions"
 
         results = editions.map do |edition|
@@ -606,6 +606,22 @@ module GdsApi
           .with(query: params)
           .to_return(status: 200, body: body.to_json, headers: {})
       end
+
+      # Aliases for DEPRECATED methods
+      alias_method :publishing_api_isnt_available, :stub_publishing_api_isnt_available
+      alias_method :pubishing_api_has_content, :stub_publishing_api_has_content
+      alias_method :pubishing_api_has_fields_for_document, :stub_publishing_api_has_fields_for_document
+      alias_method :pubishing_api_has_linkables, :stub_publishing_api_has_linkables
+      alias_method :pubishing_api_has_item, :stub_publishing_api_has_item
+      alias_method :pubishing_api_has_item_in_sequence, :stub_publishing_api_has_item_in_sequence
+      alias_method :pubishing_api_does_not_have_item, :stub_publishing_api_does_not_have_item
+      alias_method :pubishing_api_has_links, :stub_publishing_api_has_links
+      alias_method :pubishing_api_has_expanded_links, :stub_publishing_api_has_expanded_links
+      alias_method :pubishing_api_has_links_for_content_ids, :stub_publishing_api_has_links_for_content_ids
+      alias_method :pubishing_api_does_not_have_links, :stub_publishing_api_does_not_have_links
+      alias_method :pubishing_api_has_lookups, :stub_publishing_api_has_lookups
+      alias_method :pubishing_api_has_linked_items, :stub_publishing_api_has_linked_items
+      alias_method :pubishing_api_get_editions, :stub_publishing_api_get_editions
 
     private
 

--- a/lib/gds_api/test_helpers/rummager.rb
+++ b/lib/gds_api/test_helpers/rummager.rb
@@ -83,27 +83,27 @@ module GdsApi
         )
       end
 
-      def rummager_has_services_and_info_data_for_organisation
+      def stub_rummager_has_services_and_info_data_for_organisation
         stub_request_for(search_results_found)
         run_example_query
       end
 
-      def rummager_has_no_services_and_info_data_for_organisation
+      def stub_rummager_has_no_services_and_info_data_for_organisation
         stub_request_for(no_search_results_found)
         run_example_query
       end
 
-      def rummager_has_specialist_sector_organisations(_sub_sector)
+      def stub_rummager_has_specialist_sector_organisations(_sub_sector)
         stub_request_for(sub_sector_organisations_results)
         run_example_query
       end
 
-      def rummager_has_no_policies_for_any_type
+      def stub_rummager_has_no_policies_for_any_type
         stub_request(:get, %r{/search.json})
           .to_return(body: no_search_results_found)
       end
 
-      def rummager_has_policies_for_every_type(options = {})
+      def stub_rummager_has_policies_for_every_type(options = {})
         if options[:count]
           stub_request(:get, %r{/search.json.*count=#{options[:count]}.*})
             .to_return(body: first_n_results(new_policies_results, n: options[:count]))
@@ -112,6 +112,13 @@ module GdsApi
             .to_return(body: new_policies_results)
         end
       end
+
+      # Aliases for DEPRECATED methods
+      alias_method :rummager_has_services_and_info_data_for_organisation, :stub_rummager_has_services_and_info_data_for_organisation
+      alias_method :rummager_has_no_services_and_info_data_for_organisation, :stub_rummager_has_no_services_and_info_data_for_organisation
+      alias_method :rummager_has_specialist_sector_organisations, :stub_rummager_has_specialist_sector_organisations
+      alias_method :rummager_has_no_policies_for_any_type, :stub_rummager_has_no_policies_for_any_type
+      alias_method :rummager_has_policies_for_every_type, :stub_rummager_has_policies_for_every_type
 
     private
 

--- a/lib/gds_api/test_helpers/support.rb
+++ b/lib/gds_api/test_helpers/support.rb
@@ -15,9 +15,12 @@ module GdsApi
         post_stub.to_return(status: 201)
       end
 
-      def support_isnt_available
+      def stub_support_isnt_available
         stub_request(:post, /#{SUPPORT_ENDPOINT}\/.*/).to_return(status: 503)
       end
+
+      # Aliases for DEPRECATED methods
+      alias_method :support_isnt_available, :stub_support_isnt_available
     end
   end
 end

--- a/lib/gds_api/test_helpers/support_api.rb
+++ b/lib/gds_api/test_helpers/support_api.rb
@@ -68,7 +68,7 @@ module GdsApi
         post_stub.to_return(status: 200, body: response_body.to_json)
       end
 
-      def support_api_isnt_available
+      def stub_support_api_isnt_available
         stub_request(:post, /#{SUPPORT_API_ENDPOINT}\/.*/).to_return(status: 503)
       end
 
@@ -147,6 +147,9 @@ module GdsApi
       def stub_any_support_api_call
         stub_request(:any, %r{\A#{SUPPORT_API_ENDPOINT}})
       end
+
+      # Aliases for DEPRECATED methods
+      alias_method :support_api_isnt_available, :stub_support_api_isnt_available
     end
   end
 end

--- a/lib/gds_api/test_helpers/worldwide.rb
+++ b/lib/gds_api/test_helpers/worldwide.rb
@@ -12,9 +12,9 @@ module GdsApi
       # The stubs are setup to paginate in chunks of 20
       #
       # This also sets up the individual endpoints for each slug
-      # by calling worldwide_api_has_location below
-      def worldwide_api_has_locations(location_slugs)
-        location_slugs.each { |s| worldwide_api_has_location(s) }
+      # by calling stub_worldwide_api_has_location below
+      def stub_worldwide_api_has_locations(location_slugs)
+        location_slugs.each { |s| stub_worldwide_api_has_location(s) }
         pages = []
         location_slugs.each_slice(20) do |slugs|
           pages << slugs.map { |s| world_location_details_for_slug(s) }
@@ -48,8 +48,8 @@ module GdsApi
         end
       end
 
-      def worldwide_api_has_selection_of_locations
-        worldwide_api_has_locations %w(
+      def stub_worldwide_api_has_selection_of_locations
+        stub_worldwide_api_has_locations %w(
           afghanistan angola australia bahamas belarus brazil brunei cambodia chad
           croatia denmark eritrea france ghana iceland japan laos luxembourg malta
           micronesia mozambique nicaragua panama portugal sao-tome-and-principe singapore
@@ -59,24 +59,24 @@ module GdsApi
         )
       end
 
-      def worldwide_api_has_location(location_slug, details = nil)
+      def stub_worldwide_api_has_location(location_slug, details = nil)
         details ||= world_location_for_slug(location_slug)
         stub_request(:get, "#{WORLDWIDE_API_ENDPOINT}/api/world-locations/#{location_slug}").
           to_return(status: 200, body: details.to_json)
       end
 
-      def worldwide_api_does_not_have_location(location_slug)
+      def stub_worldwide_api_does_not_have_location(location_slug)
         stub_request(:get, "#{WORLDWIDE_API_ENDPOINT}/api/world-locations/#{location_slug}").to_return(status: 404)
       end
 
-      def worldwide_api_has_organisations_for_location(location_slug, json_or_hash)
+      def stub_worldwide_api_has_organisations_for_location(location_slug, json_or_hash)
         json = json_or_hash.is_a?(Hash) ? json_or_hash.to_json : json_or_hash
         url = "#{WORLDWIDE_API_ENDPOINT}/api/world-locations/#{location_slug}/organisations"
         stub_request(:get, url).
           to_return(status: 200, body: json, headers: { "Link" => "<#{url}; rel\"self\"" })
       end
 
-      def worldwide_api_has_no_organisations_for_location(location_slug)
+      def stub_worldwide_api_has_no_organisations_for_location(location_slug)
         details = { "results" => [], "total" => 0, "_response_info" => { "status" => "ok" } }
         url = "#{WORLDWIDE_API_ENDPOINT}/api/world-locations/#{location_slug}/organisations"
         stub_request(:get, url).
@@ -108,6 +108,14 @@ module GdsApi
           },
         }
       end
+
+      # Aliases for DEPRECATED methods
+      alias_method :worldwide_api_has_locations, :stub_worldwide_api_has_locations
+      alias_method :worldwide_api_has_selection_of_locations, :stub_worldwide_api_has_selection_of_locations
+      alias_method :worldwide_api_has_location, :stub_worldwide_api_has_location
+      alias_method :worldwide_api_has_does_not_have_location, :stub_worldwide_api_does_not_have_location
+      alias_method :worldwide_api_has_organisations_for_location, :stub_worldwide_api_has_organisations_for_location
+      alias_method :worldwide_api_has_no_organisations_for_location, :stub_worldwide_api_has_no_organisations_for_location
     end
   end
 end

--- a/test/calendars_test.rb
+++ b/test/calendars_test.rb
@@ -47,7 +47,7 @@ describe GdsApi::Calendars do
     end
 
     it "fetches the bank holidays requested for all divisions" do
-      calendars_has_a_bank_holiday_on(Date.parse('2012-12-12'))
+      stub_calendars_has_a_bank_holiday_on(Date.parse('2012-12-12'))
       holidays = @api.bank_holidays
 
       assert_equal "2012-12-12", holidays['england-and-wales']['events'][0]['date']
@@ -56,7 +56,7 @@ describe GdsApi::Calendars do
     end
 
     it "fetches the bank holidays requested for just one divisions" do
-      calendars_has_a_bank_holiday_on(Date.parse('2012-12-12'), in_division: 'scotland')
+      stub_calendars_has_a_bank_holiday_on(Date.parse('2012-12-12'), in_division: 'scotland')
       holidays = @api.bank_holidays(:scotland)
 
       assert_equal "2012-12-12", holidays['events'][0]['date']

--- a/test/content_store_test.rb
+++ b/test/content_store_test.rb
@@ -13,7 +13,7 @@ describe GdsApi::ContentStore do
   describe "#content_item" do
     it "returns the item" do
       base_path = "/test-from-content-store"
-      content_store_has_item(base_path)
+      stub_content_store_has_item(base_path)
 
       response = @api.content_item(base_path)
 
@@ -21,7 +21,7 @@ describe GdsApi::ContentStore do
     end
 
     it "raises if the item doesn't exist" do
-      content_store_does_not_have_item("/non-existent")
+      stub_content_store_does_not_have_item("/non-existent")
 
       assert_raises(GdsApi::HTTPNotFound) do
         @api.content_item("/non-existent")
@@ -29,7 +29,7 @@ describe GdsApi::ContentStore do
     end
 
     it "raises if the item doesn't exist" do
-      content_store_does_not_have_item("/non-existent")
+      stub_content_store_does_not_have_item("/non-existent")
 
       assert_raises GdsApi::HTTPNotFound do
         @api.content_item("/non-existent")
@@ -37,7 +37,7 @@ describe GdsApi::ContentStore do
     end
 
     it "raises if the item is gone" do
-      content_store_has_gone_item("/it-is-gone")
+      stub_content_store_has_gone_item("/it-is-gone")
 
       assert_raises(GdsApi::HTTPGone) do
         @api.content_item("/it-is-gone")
@@ -45,7 +45,7 @@ describe GdsApi::ContentStore do
     end
 
     it "raises if the item is gone" do
-      content_store_has_gone_item("/it-is-gone")
+      stub_content_store_has_gone_item("/it-is-gone")
 
       assert_raises GdsApi::HTTPGone do
         @api.content_item("/it-is-gone")

--- a/test/email_alert_api_test.rb
+++ b/test/email_alert_api_test.rb
@@ -26,7 +26,7 @@ describe GdsApi::EmailAlertApi do
     }
 
     before do
-      email_alert_api_accepts_alert
+      stub_email_alert_api_accepts_alert
     end
 
     it "posts a new alert" do
@@ -56,7 +56,7 @@ describe GdsApi::EmailAlertApi do
 
   describe "unpublishing messages" do
     before do
-      email_alert_api_accepts_unpublishing_message
+      stub_email_alert_api_accepts_unpublishing_message
     end
 
     it "sends an unpublish message" do
@@ -69,7 +69,7 @@ describe GdsApi::EmailAlertApi do
   describe "subscriptions" do
     describe "a subscription exists" do
       before do
-        email_alert_api_has_subscription(1, "weekly")
+        stub_email_alert_api_has_subscription(1, "weekly")
       end
 
       it "returns the subscription attributes" do
@@ -95,11 +95,11 @@ describe GdsApi::EmailAlertApi do
 
       describe "a subscriber list with that tag set does not yet exist" do
         before do
-          email_alert_api_does_not_have_subscriber_list(
+          stub_email_alert_api_does_not_have_subscriber_list(
             "tags" => tags,
           )
 
-          email_alert_api_creates_subscriber_list(
+          stub_email_alert_api_creates_subscriber_list(
             "title" => title,
             "tags" => tags,
             "subscription_url" => expected_subscription_url,
@@ -125,7 +125,7 @@ describe GdsApi::EmailAlertApi do
 
       describe "a subscriber list with that tag set does already exist" do
         before do
-          email_alert_api_has_subscriber_list(
+          stub_email_alert_api_has_subscriber_list(
             "title" => "Some Title",
             "tags" => tags,
             "subscription_url" => expected_subscription_url,
@@ -154,7 +154,7 @@ describe GdsApi::EmailAlertApi do
         }
 
         before do
-          email_alert_api_has_subscriber_list(
+          stub_email_alert_api_has_subscriber_list(
             "title" => "Some Title",
             "tags" => tags,
             "document_type" => "travel_advice",
@@ -185,7 +185,7 @@ describe GdsApi::EmailAlertApi do
         }
 
         before do
-          email_alert_api_has_subscriber_list(
+          stub_email_alert_api_has_subscriber_list(
             "title" => "Some Title",
             "tags" => tags,
             "email_document_supertype" => "publications",
@@ -220,7 +220,7 @@ describe GdsApi::EmailAlertApi do
         }
 
         before do
-          email_alert_api_has_subscriber_list(
+          stub_email_alert_api_has_subscriber_list(
             "title" => "Some Title",
             "tags" => tags,
             "gov_delivery_id" => "TOPIC-A",
@@ -256,7 +256,7 @@ describe GdsApi::EmailAlertApi do
         }
 
         before do
-          email_alert_api_has_subscriber_list(
+          stub_email_alert_api_has_subscriber_list(
             "title" => "Some Title",
             "tags" => tags,
             "links" => links,
@@ -277,7 +277,7 @@ describe GdsApi::EmailAlertApi do
     describe "with an existing subscription" do
       it "returns a 204" do
         uuid = SecureRandom.uuid
-        email_alert_api_unsubscribes_a_subscription(uuid)
+        stub_email_alert_api_unsubscribes_a_subscription(uuid)
         api_response = api_client.unsubscribe(uuid)
 
         assert_equal(
@@ -290,7 +290,7 @@ describe GdsApi::EmailAlertApi do
     describe "without an existing subscription" do
       it "returns a 404" do
         uuid = SecureRandom.uuid
-        email_alert_api_has_no_subscription_for_uuid(uuid)
+        stub_email_alert_api_has_no_subscription_for_uuid(uuid)
 
         assert_raises GdsApi::HTTPNotFound do
           api_client.unsubscribe(uuid)
@@ -303,7 +303,7 @@ describe GdsApi::EmailAlertApi do
     describe "with an existing subscriber" do
       it "returns a 204" do
         subscriber_id = SecureRandom.random_number(10)
-        email_alert_api_unsubscribes_a_subscriber(subscriber_id)
+        stub_email_alert_api_unsubscribes_a_subscriber(subscriber_id)
         api_response = api_client.unsubscribe_subscriber(subscriber_id)
 
         assert_equal(
@@ -316,7 +316,7 @@ describe GdsApi::EmailAlertApi do
     describe "without an existing subscriber" do
       it "returns a 404" do
         subscriber_id = SecureRandom.random_number(10)
-        email_alert_api_has_no_subscriber(subscriber_id)
+        stub_email_alert_api_has_no_subscriber(subscriber_id)
 
         assert_raises GdsApi::HTTPNotFound do
           api_client.unsubscribe_subscriber(subscriber_id)
@@ -333,7 +333,7 @@ describe GdsApi::EmailAlertApi do
         created_subscription_id = 1
         frequency = "daily"
 
-        email_alert_api_creates_a_subscription(
+        stub_email_alert_api_creates_a_subscription(
           subscribable_id,
           address,
           frequency,
@@ -352,7 +352,7 @@ describe GdsApi::EmailAlertApi do
         created_subscription_id = 1
         frequency = "immediately"
 
-        email_alert_api_creates_a_subscription(
+        stub_email_alert_api_creates_a_subscription(
           subscribable_id,
           address,
           frequency,
@@ -372,7 +372,7 @@ describe GdsApi::EmailAlertApi do
       existing_subscription_id = 1
       frequency = "immediately"
 
-      email_alert_api_creates_an_existing_subscription(
+      stub_email_alert_api_creates_an_existing_subscription(
         subscribable_id,
         address,
         frequency,
@@ -386,7 +386,7 @@ describe GdsApi::EmailAlertApi do
 
   describe "subscribing with an invalid address" do
     it "raises an unprocessable entity error" do
-      email_alert_api_refuses_to_create_subscription(123, "invalid", "weekly")
+      stub_email_alert_api_refuses_to_create_subscription(123, "invalid", "weekly")
 
       assert_raises GdsApi::HTTPUnprocessableEntity do
         api_client.subscribe(subscribable_id: 123, address: "invalid", frequency: "weekly")
@@ -396,7 +396,7 @@ describe GdsApi::EmailAlertApi do
 
   describe "get_subscribable when one exists" do
     it "returns it" do
-      email_alert_api_has_subscribable(
+      stub_email_alert_api_has_subscribable(
         reference: "test123",
         returned_attributes: {
           id: 1,
@@ -412,7 +412,7 @@ describe GdsApi::EmailAlertApi do
 
   describe "get_subscribable when one doesn't exist" do
     it "returns 404" do
-      email_alert_api_does_not_have_subscribable(reference: "test123")
+      stub_email_alert_api_does_not_have_subscribable(reference: "test123")
 
       assert_raises GdsApi::HTTPNotFound do
         api_client.get_subscribable(reference: "test123")
@@ -422,7 +422,7 @@ describe GdsApi::EmailAlertApi do
 
   describe "change_subscriber when a subscriber exists" do
     it "changes the subscriber's address" do
-      email_alert_api_has_updated_subscriber(1, "test2@example.com")
+      stub_email_alert_api_has_updated_subscriber(1, "test2@example.com")
       api_response = api_client.change_subscriber(
         id: 1,
         new_address: "test2@example.com"
@@ -435,7 +435,7 @@ describe GdsApi::EmailAlertApi do
 
   describe "change_subscriber when a subscriber doesn't exist" do
     it "returns 404" do
-      email_alert_api_does_not_have_updated_subscriber(1)
+      stub_email_alert_api_does_not_have_updated_subscriber(1)
 
       assert_raises GdsApi::HTTPNotFound do
         api_client.change_subscriber(
@@ -448,7 +448,7 @@ describe GdsApi::EmailAlertApi do
 
   describe "change_subscription when a subscription exists" do
     it "changes the subscription's frequency" do
-      email_alert_api_has_updated_subscription(
+      stub_email_alert_api_has_updated_subscription(
         "8ed841d1-3d20-4633-aaf4-df41deaaf51c",
         "weekly"
       )
@@ -464,7 +464,7 @@ describe GdsApi::EmailAlertApi do
 
   describe "change_subscription when a subscription doesn't exist" do
     it "returns 404" do
-      email_alert_api_does_not_have_updated_subscription("8ed841d1-3d20-4633-aaf4-df41deaaf51c")
+      stub_email_alert_api_does_not_have_updated_subscription("8ed841d1-3d20-4633-aaf4-df41deaaf51c")
 
       assert_raises GdsApi::HTTPNotFound do
         api_client.change_subscription(
@@ -477,7 +477,7 @@ describe GdsApi::EmailAlertApi do
 
   describe "get_subscriptions when a subscriber exists" do
     it "returns it" do
-      email_alert_api_has_subscriber_subscriptions(1, "test@example.com")
+      stub_email_alert_api_has_subscriber_subscriptions(1, "test@example.com")
       api_response = api_client.get_subscriptions(id: 1)
       assert_equal(200, api_response.code)
       parsed_body = api_response.to_h
@@ -487,7 +487,7 @@ describe GdsApi::EmailAlertApi do
 
   describe "get_subscriptions when a subscriber doesn't exist" do
     it "returns 404" do
-      email_alert_api_does_not_have_subscriber_subscriptions(1)
+      stub_email_alert_api_does_not_have_subscriber_subscriptions(1)
 
       assert_raises GdsApi::HTTPNotFound do
         api_client.get_subscriptions(id: 1)
@@ -497,7 +497,7 @@ describe GdsApi::EmailAlertApi do
 
   describe "create an auth token" do
     it "returns 201" do
-      email_alert_api_creates_an_auth_token(1, "test@example.com")
+      stub_email_alert_api_creates_an_auth_token(1, "test@example.com")
       api_response = api_client.create_auth_token(address: 1, destination: "/test")
       assert_equal(201, api_response.code)
     end

--- a/test/link_checker_api_test.rb
+++ b/test/link_checker_api_test.rb
@@ -12,7 +12,7 @@ describe GdsApi::LinkCheckerApi do
 
   describe "#check" do
     it "returns a useful response" do
-      link_checker_api_check(uri: "http://example.com", status: :broken)
+      stub_link_checker_api_check(uri: "http://example.com", status: :broken)
 
       link_report = @api.check("http://example.com")
 
@@ -22,7 +22,7 @@ describe GdsApi::LinkCheckerApi do
 
   describe "#create_batch" do
     it "returns a useful response" do
-      link_checker_api_create_batch(uris: ["http://example.com"])
+      stub_link_checker_api_create_batch(uris: ["http://example.com"])
 
       batch_report = @api.create_batch(["http://example.com"])
 
@@ -33,7 +33,7 @@ describe GdsApi::LinkCheckerApi do
 
   describe "#get_batch" do
     it "returns a useful response" do
-      link_checker_api_get_batch(id: 10, links: [{ uri: "http://example.com" }])
+      stub_link_checker_api_get_batch(id: 10, links: [{ uri: "http://example.com" }])
 
       batch_report = @api.get_batch(10)
 
@@ -44,7 +44,7 @@ describe GdsApi::LinkCheckerApi do
 
   describe "#upsert_resource_monitor" do
     it "returns a useful response" do
-      link_checker_api_upsert_resource_monitor(
+      stub_link_checker_api_upsert_resource_monitor(
         reference: "Test:10",
         app: "testing",
         links: ["http://example.com"]

--- a/test/local_links_manager_api_test.rb
+++ b/test/local_links_manager_api_test.rb
@@ -13,7 +13,7 @@ describe GdsApi::LocalLinksManager do
   describe "#link" do
     describe "when making a request" do
       it "returns the local authority and local interaction details if link present" do
-        local_links_manager_has_a_link(
+        stub_local_links_manager_has_a_link(
           authority_slug: "blackburn",
           lgsl: 2,
           lgil: 4,
@@ -39,7 +39,7 @@ describe GdsApi::LocalLinksManager do
       end
 
       it "returns the local authority details only if no link present" do
-        local_links_manager_has_no_link(
+        stub_local_links_manager_has_no_link(
           authority_slug: "blackburn",
           lgsl: 2,
           lgil: 4,
@@ -59,7 +59,7 @@ describe GdsApi::LocalLinksManager do
       end
 
       it 'returns the local authority without a homepage url if no homepage link present' do
-        local_links_manager_has_no_link_and_no_homepage_url(
+        stub_local_links_manager_has_no_link_and_no_homepage_url(
           authority_slug: "blackburn",
           lgsl: 2,
           lgil: 4,
@@ -81,7 +81,7 @@ describe GdsApi::LocalLinksManager do
 
     describe "when making request with missing required parameters" do
       it "raises HTTPClientError when authority_slug is missing" do
-        local_links_manager_request_with_missing_parameters(nil, 2, 8)
+        stub_local_links_manager_request_with_missing_parameters(nil, 2, 8)
 
         assert_raises GdsApi::HTTPClientError do
           @api.local_link(nil, 2, 8)
@@ -89,7 +89,7 @@ describe GdsApi::LocalLinksManager do
       end
 
       it "raises HTTPClientError when LGSL is missing" do
-        local_links_manager_request_with_missing_parameters('blackburn', nil, 8)
+        stub_local_links_manager_request_with_missing_parameters('blackburn', nil, 8)
 
         assert_raises GdsApi::HTTPClientError do
           @api.local_link('blackburn', nil, 8)
@@ -97,7 +97,7 @@ describe GdsApi::LocalLinksManager do
       end
 
       it "raises HTTPClientError when LGIL is missing" do
-        local_links_manager_request_with_missing_parameters('blackburn', 2, nil)
+        stub_local_links_manager_request_with_missing_parameters('blackburn', 2, nil)
 
         assert_raises GdsApi::HTTPClientError do
           @api.local_link('blackburn', 2, nil)
@@ -107,7 +107,7 @@ describe GdsApi::LocalLinksManager do
 
     describe "when making request with invalid required parameters" do
       it "raises when authority_slug is invalid" do
-        local_links_manager_does_not_have_required_objects("hogwarts", 2, 8)
+        stub_local_links_manager_does_not_have_required_objects("hogwarts", 2, 8)
 
         assert_raises(GdsApi::HTTPNotFound) do
           @api.local_link("hogwarts", 2, 8)
@@ -115,7 +115,7 @@ describe GdsApi::LocalLinksManager do
       end
 
       it "raises when LGSL is invalid" do
-        local_links_manager_does_not_have_required_objects("blackburn", 999, 8)
+        stub_local_links_manager_does_not_have_required_objects("blackburn", 999, 8)
 
         assert_raises(GdsApi::HTTPNotFound) do
           @api.local_link("blackburn", 999, 8)
@@ -123,7 +123,7 @@ describe GdsApi::LocalLinksManager do
       end
 
       it "raises when the LGSL and LGIL combination is invalid" do
-        local_links_manager_does_not_have_required_objects("blackburn", 2, 9)
+        stub_local_links_manager_does_not_have_required_objects("blackburn", 2, 9)
 
         assert_raises(GdsApi::HTTPNotFound) do
           @api.local_link("blackburn", 2, 9)
@@ -135,7 +135,7 @@ describe GdsApi::LocalLinksManager do
   describe '#local_authority' do
     describe 'when making a request for a local authority with a parent' do
       it 'should return the local authority and its parent' do
-        local_links_manager_has_a_district_and_county_local_authority('blackburn', 'rochester')
+        stub_local_links_manager_has_a_district_and_county_local_authority('blackburn', 'rochester')
 
         expected_response = {
           "local_authorities" => [
@@ -159,7 +159,7 @@ describe GdsApi::LocalLinksManager do
 
     describe 'when making a request for a local authority without a parent' do
       it 'should return the local authority' do
-        local_links_manager_has_a_local_authority('blackburn')
+        stub_local_links_manager_has_a_local_authority('blackburn')
 
         expected_response = {
           "local_authorities" => [
@@ -178,7 +178,7 @@ describe GdsApi::LocalLinksManager do
 
     describe 'when making a request without the required parameters' do
       it "raises HTTPClientError when authority_slug is missing" do
-        local_links_manager_request_without_local_authority_slug
+        stub_local_links_manager_request_without_local_authority_slug
 
         assert_raises GdsApi::HTTPClientError do
           @api.local_authority(nil)
@@ -188,7 +188,7 @@ describe GdsApi::LocalLinksManager do
 
     describe 'when making a request with invalid required parameters' do
       it "raises when authority_slug is invalid" do
-        local_links_manager_does_not_have_an_authority("hogwarts")
+        stub_local_links_manager_does_not_have_an_authority("hogwarts")
 
         assert_raises(GdsApi::HTTPNotFound) { @api.local_authority("hogwarts") }
       end

--- a/test/mapit_test.rb
+++ b/test/mapit_test.rb
@@ -12,7 +12,7 @@ describe GdsApi::Mapit do
 
   describe "postcodes" do
     it "should return the coordinates" do
-      mapit_has_a_postcode("SW1A 1AA", [51.5010096, -0.1415870])
+      stub_mapit_has_a_postcode("SW1A 1AA", [51.5010096, -0.1415870])
 
       response = @api.location_for_postcode("SW1A 1AA")
       assert_equal 51.5010096, response.lat
@@ -20,14 +20,14 @@ describe GdsApi::Mapit do
     end
 
     it "should return the postcode" do
-      mapit_has_a_postcode("SW1A 1AA", [51.5010096, -0.1415870])
+      stub_mapit_has_a_postcode("SW1A 1AA", [51.5010096, -0.1415870])
 
       response = @api.location_for_postcode("SW1A 1AA")
       assert_equal "SW1A 1AA", response.postcode
     end
 
     it "should return areas" do
-      mapit_has_a_postcode_and_areas("SW1A 1AA", [51.5010096, -0.1415870], [
+      stub_mapit_has_a_postcode_and_areas("SW1A 1AA", [51.5010096, -0.1415870], [
         { 'name' => 'Lancashire County Council', 'type' => 'CTY', 'ons' => '30', 'gss' => 'E10000017' },
         { 'name' => 'South Ribble Borough Council', 'type' => 'DIS', 'ons' => '30UN', 'gss' => 'E07000126' }
       ])
@@ -46,7 +46,7 @@ describe GdsApi::Mapit do
     end
 
     it "should raise if a postcode doesn't exist" do
-      mapit_does_not_have_a_postcode("SW1A 1AA")
+      stub_mapit_does_not_have_a_postcode("SW1A 1AA")
 
       assert_raises(GdsApi::HTTPNotFound) do
         @api.location_for_postcode("SW1A 1AA")
@@ -54,7 +54,7 @@ describe GdsApi::Mapit do
     end
 
     it "should return 400 for an invalid postcode" do
-      mapit_does_not_have_a_bad_postcode("B4DP05TC0D3")
+      stub_mapit_does_not_have_a_bad_postcode("B4DP05TC0D3")
 
       assert_raises GdsApi::HTTPClientError do
         @api.location_for_postcode("B4DP05TC0D3")
@@ -64,10 +64,10 @@ describe GdsApi::Mapit do
 
   describe "areas_for_type" do
     before do
-      mapit_has_areas('EUR', "123" => { "name" => "Eastern", "id" => "123", "country_name" => "England" },
+      stub_mapit_has_areas('EUR', "123" => { "name" => "Eastern", "id" => "123", "country_name" => "England" },
        "234" => { "name" => "North West", "id" => "234", "country_name" => "England" },
        "345" => { "name" => "Scotland", "id" => "345", "country_name" => "Scotland" })
-      mapit_does_not_have_areas('FOO')
+      stub_mapit_does_not_have_areas('FOO')
     end
     it "should return areas of a type" do
       areas = @api.areas_for_type('EUR').to_hash
@@ -98,8 +98,8 @@ describe GdsApi::Mapit do
         },
         type: "DIS"
       }
-      mapit_has_area_for_code('ons', '30UN', south_ribble_area)
-      mapit_does_not_have_area_for_code('govuk_slug', 'neverland')
+      stub_mapit_has_area_for_code('ons', '30UN', south_ribble_area)
+      stub_mapit_does_not_have_area_for_code('govuk_slug', 'neverland')
     end
 
     it "should return area for a code type" do

--- a/test/organisations_api_test.rb
+++ b/test/organisations_api_test.rb
@@ -13,7 +13,7 @@ describe GdsApi::Organisations do
   describe "fetching list of organisations" do
     it "should get the organisations" do
       organisation_slugs = %w(ministry-of-fun tea-agency)
-      organisations_api_has_organisations(organisation_slugs)
+      stub_organisations_api_has_organisations(organisation_slugs)
 
       response = @api.organisations
       assert_equal organisation_slugs, response.map { |r| r['details']['slug'] }
@@ -22,7 +22,7 @@ describe GdsApi::Organisations do
 
     it "should handle the pagination" do
       organisation_slugs = (1..50).map { |n| "organisation-#{n}" }
-      organisations_api_has_organisations(organisation_slugs)
+      stub_organisations_api_has_organisations(organisation_slugs)
 
       response = @api.organisations
       assert_equal(
@@ -41,14 +41,14 @@ describe GdsApi::Organisations do
 
   describe "fetching an organisation" do
     it "should return the details" do
-      organisations_api_has_organisation('ministry-of-fun')
+      stub_organisations_api_has_organisation('ministry-of-fun')
 
       response = @api.organisation('ministry-of-fun')
       assert_equal 'Ministry Of Fun', response['title']
     end
 
     it "should raise for a non-existent organisation" do
-      organisations_api_does_not_have_organisation('non-existent')
+      stub_organisations_api_does_not_have_organisation('non-existent')
 
       assert_raises(GdsApi::HTTPNotFound) do
         @api.organisation('non-existent')

--- a/test/rummager_helpers_test.rb
+++ b/test/rummager_helpers_test.rb
@@ -6,13 +6,13 @@ class RummagerHelpersTest < Minitest::Test
   include GdsApi::TestHelpers::Rummager
 
   def test_services_and_info_data_returns_an_adequate_response_object
-    response = rummager_has_services_and_info_data_for_organisation
+    response = stub_rummager_has_services_and_info_data_for_organisation
 
     assert_instance_of GdsApi::Response, response
   end
 
   def test_no_services_and_info_data_found_for_organisation
-    response = rummager_has_no_services_and_info_data_for_organisation
+    response = stub_rummager_has_no_services_and_info_data_for_organisation
 
     assert_instance_of GdsApi::Response, response
     assert_equal 0, response['facets']['specialist_sectors']['total_options']

--- a/test/support_api_test.rb
+++ b/test/support_api_test.rb
@@ -53,7 +53,7 @@ describe GdsApi::SupportApi do
   end
 
   it "throws an exception when the support app isn't available" do
-    support_api_isnt_available
+    stub_support_api_isnt_available
 
     assert_raises(GdsApi::HTTPServerError) { @api.create_service_feedback({}) }
   end

--- a/test/support_test.rb
+++ b/test/support_test.rb
@@ -23,7 +23,7 @@ describe GdsApi::Support do
   end
 
   it "throws an exception when the support app isn't available while creating FOI requests" do
-    support_isnt_available
+    stub_support_isnt_available
 
     assert_raises(GdsApi::HTTPServerError) { @api.create_foi_request({}) }
   end
@@ -41,7 +41,7 @@ describe GdsApi::Support do
   end
 
   it "throws an exception when the support app isn't available while creating named contacts" do
-    support_isnt_available
+    stub_support_isnt_available
 
     assert_raises(GdsApi::HTTPServerError) { @api.create_named_contact({}) }
   end

--- a/test/test_helpers/publishing_api_v2_test.rb
+++ b/test/test_helpers/publishing_api_v2_test.rb
@@ -12,7 +12,7 @@ describe GdsApi::TestHelpers::PublishingApiV2 do
         { 'content_id' => 'id-1', 'title' => 'title 1', 'link_type' => 'taxons' },
         { 'content_id' => 'id-2', 'title' => 'title 2', 'link_type' => 'taxons' },
       ]
-      publishing_api_has_linked_items(
+      stub_publishing_api_has_linked_items(
         links,
         content_id: 'content-id',
         link_type: 'taxons',
@@ -43,7 +43,7 @@ describe GdsApi::TestHelpers::PublishingApiV2 do
                 }
               }
 
-      publishing_api_has_links_for_content_ids(links)
+      stub_publishing_api_has_links_for_content_ids(links)
 
       assert_equal publishing_api.get_links_for_content_ids(links.keys), links
     end
@@ -53,7 +53,7 @@ describe GdsApi::TestHelpers::PublishingApiV2 do
     it "stubs the lookup for content items" do
       lookup_hash = { "/foo" => "2878337b-bed9-4e7f-85b6-10ed2cbcd504" }
 
-      publishing_api_has_lookups(lookup_hash)
+      stub_publishing_api_has_lookups(lookup_hash)
 
       assert_equal publishing_api.lookup_content_ids(base_paths: ["/foo"]), lookup_hash
       assert_equal publishing_api.lookup_content_id(base_path: "/foo"), "2878337b-bed9-4e7f-85b6-10ed2cbcd504"
@@ -62,7 +62,7 @@ describe GdsApi::TestHelpers::PublishingApiV2 do
 
   describe "#publishing_api_has_content" do
     it "stubs the call to get content items" do
-      publishing_api_has_content([{ "content_id" => "2878337b-bed9-4e7f-85b6-10ed2cbcd504" }])
+      stub_publishing_api_has_content([{ "content_id" => "2878337b-bed9-4e7f-85b6-10ed2cbcd504" }])
 
       response = publishing_api.get_content_items({})['results']
 
@@ -70,7 +70,7 @@ describe GdsApi::TestHelpers::PublishingApiV2 do
     end
 
     it 'allows params' do
-      publishing_api_has_content(
+      stub_publishing_api_has_content(
         [{
           "content_id" => "2878337b-bed9-4e7f-85b6-10ed2cbcd504"
         }],
@@ -94,7 +94,7 @@ describe GdsApi::TestHelpers::PublishingApiV2 do
       content_id_2 = "2878337b-bed9-4e7f-85b6-10ed2cbcd505"
       content_id_3 = "2878337b-bed9-4e7f-85b6-10ed2cbcd506"
 
-      publishing_api_has_content(
+      stub_publishing_api_has_content(
         [
           { "content_id" => content_id_1 },
           { "content_id" => content_id_2 },
@@ -120,7 +120,7 @@ describe GdsApi::TestHelpers::PublishingApiV2 do
       content_id_1 = "2878337b-bed9-4e7f-85b6-10ed2cbcd504"
       content_id_2 = "2878337b-bed9-4e7f-85b6-10ed2cbcd505"
 
-      publishing_api_has_content(
+      stub_publishing_api_has_content(
         [
           { "content_id" => content_id_1 },
           { "content_id" => content_id_2 },
@@ -138,14 +138,14 @@ describe GdsApi::TestHelpers::PublishingApiV2 do
 
   describe "#publishing_api_has_item" do
     it "stubs the call to get content items" do
-      publishing_api_has_item("content_id" => "2878337b-bed9-4e7f-85b6-10ed2cbcd504")
+      stub_publishing_api_has_item("content_id" => "2878337b-bed9-4e7f-85b6-10ed2cbcd504")
       response = publishing_api.get_content("2878337b-bed9-4e7f-85b6-10ed2cbcd504").parsed_content
 
       assert_equal({ "content_id" => "2878337b-bed9-4e7f-85b6-10ed2cbcd504" }, response)
     end
 
     it 'allows params' do
-      publishing_api_has_item(
+      stub_publishing_api_has_item(
         "content_id" => "2878337b-bed9-4e7f-85b6-10ed2cbcd504",
         "version" => 3,
       )
@@ -174,7 +174,7 @@ describe GdsApi::TestHelpers::PublishingApiV2 do
         ]
       }
 
-      publishing_api_has_expanded_links(payload)
+      stub_publishing_api_has_expanded_links(payload)
       response = publishing_api.get_expanded_links("2e20294a-d694-4083-985e-d8bedefc2354")
 
       assert_equal({
@@ -197,7 +197,7 @@ describe GdsApi::TestHelpers::PublishingApiV2 do
         ]
       }
 
-      publishing_api_has_expanded_links(payload)
+      stub_publishing_api_has_expanded_links(payload)
       response = publishing_api.get_expanded_links("2e20294a-d694-4083-985e-d8bedefc2354")
 
       assert_equal({
@@ -220,7 +220,7 @@ describe GdsApi::TestHelpers::PublishingApiV2 do
         ]
       }
 
-      publishing_api_has_expanded_links(payload, with_drafts: false, generate: true)
+      stub_publishing_api_has_expanded_links(payload, with_drafts: false, generate: true)
       response = publishing_api.get_expanded_links("2e20294a-d694-4083-985e-d8bedefc2354", with_drafts: false, generate: true)
 
       assert_equal({
@@ -311,7 +311,7 @@ describe GdsApi::TestHelpers::PublishingApiV2 do
         { "content_id" => "id-2", "title" => "title 2" },
       ]
 
-      publishing_api_get_editions(
+      stub_publishing_api_get_editions(
         editions,
         fields: ["title"]
       )
@@ -327,7 +327,7 @@ describe GdsApi::TestHelpers::PublishingApiV2 do
 
   describe '#publishing_api_isnt_available' do
     it "returns a 503 for V2 requests" do
-      publishing_api_isnt_available
+      stub_publishing_api_isnt_available
 
       assert_raises GdsApi::BaseError do
         publishing_api.get_content_items({})
@@ -335,7 +335,7 @@ describe GdsApi::TestHelpers::PublishingApiV2 do
     end
 
     it "returns a 503 for V1 requests" do
-      publishing_api_isnt_available
+      stub_publishing_api_isnt_available
 
       assert_raises GdsApi::BaseError do
         publishing_api.lookup_content_id(base_path: "")

--- a/test/worldwide_api_test.rb
+++ b/test/worldwide_api_test.rb
@@ -13,7 +13,7 @@ describe GdsApi::Worldwide do
   describe "fetching list of world locations" do
     it "should get the world locations" do
       country_slugs = %w(the-shire rivendel rohan lorien gondor arnor mordor)
-      worldwide_api_has_locations(country_slugs)
+      stub_worldwide_api_has_locations(country_slugs)
 
       response = @api.world_locations
       assert_equal country_slugs, response.map { |r| r['details']['slug'] }
@@ -22,7 +22,7 @@ describe GdsApi::Worldwide do
 
     it "should handle the pagination" do
       country_slugs = (1..50).map { |n| "country-#{n}" }
-      worldwide_api_has_locations(country_slugs)
+      stub_worldwide_api_has_locations(country_slugs)
 
       response = @api.world_locations
       assert_equal(
@@ -41,14 +41,14 @@ describe GdsApi::Worldwide do
 
   describe "fetching a world location" do
     it "should return the details" do
-      worldwide_api_has_location('rohan')
+      stub_worldwide_api_has_location('rohan')
 
       response = @api.world_location('rohan')
       assert_equal 'Rohan', response['title']
     end
 
     it "raises for a non-existent location" do
-      worldwide_api_does_not_have_location('non-existent')
+      stub_worldwide_api_does_not_have_location('non-existent')
 
       assert_raises(GdsApi::HTTPNotFound) do
         @api.world_location('non-existent')
@@ -59,7 +59,7 @@ describe GdsApi::Worldwide do
   describe "fetching organisations for a location" do
     it "should return the organisation details" do
       details = JSON.parse(load_fixture_file("world_organisations_australia.json").read)
-      worldwide_api_has_organisations_for_location('australia', details)
+      stub_worldwide_api_has_organisations_for_location('australia', details)
 
       response = @api.organisations_for_world_location('australia')
       assert response.is_a?(GdsApi::ListResponse)


### PR DESCRIPTION
Using some of these helpers currently leads to amusing tests e.g.

   # current way
   ... some test setup ...
   email_alert_api_unsubscribes_a_subscriber
   ... some more test ...

   # proposed way
   ... some test setup ...
   stub_email_alert_api_unsubscribes_a_subscriber
   ... some more test ...

Without some kind of prefix, the behaviour of these methods is a bit
ambiguous, especially where they suggest some rather scary autonomous
action, like Email Alert API randomly deleting a subscriber by itself.

This deprecates the existing API adapter test helpers and favours a new
stub_ prefix, similar to the WebMock and PublishingApi test helpers.