### PR TITLE
Fix 57.2 again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+* Fix stub_asset_manager_receives_an_asset not returning unique filenames each call
+* Rename stub_asset_manager_is_down to stub_asset_manager_isnt_available
+
 # 57.2.1
 
 * Fix broken test helper for Publishing API

--- a/lib/gds_api/test_helpers/asset_manager.rb
+++ b/lib/gds_api/test_helpers/asset_manager.rb
@@ -7,7 +7,7 @@ module GdsApi
         stub_request(:any, %r{\A#{ASSET_MANAGER_ENDPOINT}}).to_return(status: 200)
       end
 
-      def stub_asset_manager_is_down
+      def stub_asset_manager_isnt_available
         stub_request(:any, %r{\A#{ASSET_MANAGER_ENDPOINT}}).to_return(status: 503)
       end
 
@@ -105,7 +105,6 @@ module GdsApi
       end
 
       # Aliases for DEPRECATED methods
-      alias_method :asset_manager_is_down, :stub_asset_manager_is_down
       alias_method :asset_manager_updates_any_asset, :stub_asset_manager_updates_any_asset
       alias_method :asset_manager_deletes_any_asset, :stub_asset_manager_deletes_any_asset
       alias_method :asset_manager_has_an_asset, :stub_asset_manager_has_an_asset

--- a/lib/gds_api/test_helpers/asset_manager.rb
+++ b/lib/gds_api/test_helpers/asset_manager.rb
@@ -68,15 +68,17 @@ module GdsApi
       # which would return a file url of "https://asset-manager/media/0053adbf-0737-4923-9d8a-8180f2c723af/0d19136c4a94f07"
       def stub_asset_manager_receives_an_asset(response_url = {})
         stub_request(:post, "#{ASSET_MANAGER_ENDPOINT}/assets").to_return do
-          unless response_url.is_a?(String)
+          if response_url.is_a?(String)
+            file_url = response_url
+          else
             options = {
               id: SecureRandom.uuid,
               filename: SecureRandom.hex(8)
             }.merge(response_url)
 
-            response_url = "#{ASSET_MANAGER_ENDPOINT}/media/#{options[:id]}/#{options[:filename]}"
+            file_url = "#{ASSET_MANAGER_ENDPOINT}/media/#{options[:id]}/#{options[:filename]}"
           end
-          { body: { file_url: response_url }.to_json, status: 200 }
+          { body: { file_url: file_url }.to_json, status: 200 }
         end
       end
 

--- a/test/test_helpers/asset_manager_test.rb
+++ b/test/test_helpers/asset_manager_test.rb
@@ -28,6 +28,14 @@ describe GdsApi::TestHelpers::AssetManager do
         url_format = %r{\Ahttp://asset-manager.dev.gov.uk/media/[^/]*/[^/]*\Z}
         assert_match url_format, response["file_url"]
       end
+
+      it "returns a different URL each call" do
+        stub_asset_manager_receives_an_asset
+        response1 = stub_asset_manager.create_asset({})
+        response2 = stub_asset_manager.create_asset({})
+
+        refute_match response1["file_url"], response2["file_url"]
+      end
     end
 
     describe "when passed a hash" do


### PR DESCRIPTION
Oh dear! I managed to make a couple of mistakes in my changes that went into https://github.com/alphagov/gds-api-adapters/pull/883

This corrects a couple of things.

- stub_asset_manager_receives_an_asset doesn't create unique filenames each call as was intended
- rename stub_asset_manager_is_down to stub_asset_manager_isnt_available for consistency

The last change is officially a breaking change, but since it's only just been introduced it seems reasonable to fix it in a bug fix.