### PR TITLE
Permit content_purpose_supergroup as attribute for find_subscriber_list

### DIFF
--- a/lib/gds_api/email_alert_api.rb
+++ b/lib/gds_api/email_alert_api.rb
@@ -25,6 +25,7 @@ class GdsApi::EmailAlertApi < GdsApi::Base
     email_document_supertype = attributes["email_document_supertype"]
     government_document_supertype = attributes["government_document_supertype"]
     gov_delivery_id = attributes["gov_delivery_id"]
+    content_purpose_supergroup = attributes["content_purpose_supergroup"]
 
     if tags && links
       message = "please provide either tags or links (or neither), but not both"
@@ -38,6 +39,7 @@ class GdsApi::EmailAlertApi < GdsApi::Base
     params[:email_document_supertype] = email_document_supertype if email_document_supertype
     params[:government_document_supertype] = government_document_supertype if government_document_supertype
     params[:gov_delivery_id] = gov_delivery_id if gov_delivery_id
+    params[:content_purpose_supergroup] = content_purpose_supergroup if content_purpose_supergroup
 
     query_string = nested_query_string(params)
     get_json("#{endpoint}/subscriber-lists?" + query_string)


### PR DESCRIPTION
https://trello.com/c/TnK2c8fF/169-add-the-ability-to-sign-up-for-emails-on-the-news-and-communications-finder

Relates to https://github.com/alphagov/email-alert-api/pull/776
Should be merged before https://github.com/alphagov/finder-frontend/pull/810
