### PR TITLE
Add endpoint for feedback from Eu exit bus. finder

### DIFF
--- a/lib/gds_api/support_api.rb
+++ b/lib/gds_api/support_api.rb
@@ -47,6 +47,10 @@ class GdsApi::SupportApi < GdsApi::Base
     get_json("#{endpoint}/anonymous-feedback/problem-reports/#{date_string}/totals")
   end
 
+  def create_business_finder_feedback(params)
+    post_json("#{endpoint}/anonymous-feedback/business-finder", params)
+  end
+
   def anonymous_feedback(options = {})
     uri = "#{endpoint}/anonymous-feedback" + query_string(options)
     get_json(uri)

--- a/lib/gds_api/test_helpers/support_api.rb
+++ b/lib/gds_api/test_helpers/support_api.rb
@@ -48,6 +48,12 @@ module GdsApi
         post_stub.to_return(status: 201)
       end
 
+      def stub_support_api_create_business_finder_feedback(params)
+        post_stub = stub_http_request(:post, "#{SUPPORT_API_ENDPOINT}/anonymous-feedback/business-finder")
+        post_stub.with(body: params)
+        post_stub.to_return(status: 201)
+      end
+
       def stub_support_api_problem_report_daily_totals_for(date, expected_results = nil)
         date_string = date.strftime("%Y-%m-%d")
         get_stub = stub_http_request(:get, "#{SUPPORT_API_ENDPOINT}/anonymous-feedback/problem-reports/#{date_string}/totals")

--- a/test/support_api_test.rb
+++ b/test/support_api_test.rb
@@ -40,6 +40,15 @@ describe GdsApi::SupportApi do
     assert_requested(stub_post)
   end
 
+  it 'can submit anonymous-contact/business-finder' do
+    request_details = { description: 'something is missing' }
+    stub_post = stub_support_api_create_business_finder_feedback(request_details)
+
+    @api.create_business_finder_feedback(request_details)
+
+    assert_requested(stub_post)
+  end
+
   it "fetches problem report daily totals" do
     response_body = { "data" => ["results"] }
     request_date = Date.new(2014, 7, 12)


### PR DESCRIPTION
We want to collect feedback on what's missing from
the EU exit business finder.

The commit adds support for posting this feedback to the support-api.

Trello: https://trello.com/c/a9WXTd6f/64-build-a-feedback-component-to-sit-below-business-finder-results