### PR TITLE
Bump gem version to 57.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 57.2.3
+
+* Add `create_business_finder_feedback` to `GdsApi::SupportApi`
+* Add `stub_support_api_create_business_finder_feedback` to `GdsApi::TestHelpers::SupportApi`
+
 # 57.2.2
 
 * Fix more deprecated helpers (Asset Manager and Link Checker API)

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '57.2.2'.freeze
+  VERSION = '57.2.3'.freeze
 end


### PR DESCRIPTION
Bump the gem version to get the changes in [Add endpoint for feedback from Eu exit bus. finder](https://github.com/alphagov/gds-api-adapters/pull/894)