### PR TITLE
Automatically pass bearer tokens to Content Store and Router API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Add automatic bearer tokens for `GdsApi.router` and `GdsApi.content_store`.
+
 # 57.2.3
 
 * Add `create_business_finder_feedback` to `GdsApi::SupportApi`

--- a/lib/gds_api.rb
+++ b/lib/gds_api.rb
@@ -42,9 +42,15 @@ module GdsApi
 
   # Creates a GdsApi::ContentStore adapter
   #
+  # This will set a bearer token if a CONTENT_STORE_BEARER_TOKEN environment
+  # variable is set
+  #
   # @return [GdsApi::ContentStore]
   def self.content_store(options = {})
-    GdsApi::ContentStore.new(Plek.find('content-store'), options)
+    GdsApi::ContentStore.new(
+      Plek.find('content-store'),
+      { bearer_token: ENV['CONTENT_STORE_BEARER_TOKEN'] }.merge(options),
+    )
   end
 
   # Creates a GdsApi::EmailAlertApi adapter
@@ -146,6 +152,9 @@ module GdsApi
   end
 
   # Creates a GdsApi::Router adapter for communicating with Router API
+  #
+  # This will set a bearer token if a ROUTER_API_BEARER_TOKEN environment
+  # variable is set
   #
   # @return [GdsApi::Router]
   def self.router(options = {})

--- a/lib/gds_api.rb
+++ b/lib/gds_api.rb
@@ -149,7 +149,10 @@ module GdsApi
   #
   # @return [GdsApi::Router]
   def self.router(options = {})
-    GdsApi::Router.new(Plek.find('router-api'), options)
+    GdsApi::Router.new(
+      Plek.find('router-api'),
+      { bearer_token: ENV['ROUTER_API_BEARER_TOKEN'] }.merge(options),
+    )
   end
 
   # Creates a GdsApi::Rummager adapter to access via a rummager.* hostname


### PR DESCRIPTION
This is just for convenience so clients can just use `GdsApi.content_store` and `GdsApi.router` directly.

[Trello Card](https://trello.com/c/dskGorBB/737-rake-task-to-check-where-content-has-ended-up)