### PR TITLE
Add Router API stubs for getting routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Add Router API stubs for getting routes.
+
 # 57.2.4
 
 * Add `content_purpose_supergroup` as optional parameter to `find_subscriber_list` in `GdsApi::EmailAlertApi` 

--- a/gds-api-adapters.gemspec
+++ b/gds-api-adapters.gemspec
@@ -25,9 +25,11 @@ Gem::Specification.new do |s|
   s.add_dependency 'rack-cache'
   s.add_dependency 'rest-client', '~> 2.0'
 
+  s.add_development_dependency 'climate_control', '~> 0.2'
   s.add_development_dependency 'govuk-content-schema-test-helpers', '~> 1.6'
   s.add_development_dependency 'govuk-lint', '~> 3.7'
   s.add_development_dependency 'minitest', '~> 5.11'
+  s.add_development_dependency 'minitest-around', '~> 0.5'
   s.add_development_dependency 'mocha', '~> 1.3'
   s.add_development_dependency 'pact', '~> 1.20'
   s.add_development_dependency 'pact-consumer-minitest', '~> 1.0'

--- a/lib/gds_api/test_helpers/router.rb
+++ b/lib/gds_api/test_helpers/router.rb
@@ -5,6 +5,30 @@ module GdsApi
     module Router
       ROUTER_API_ENDPOINT = Plek.current.find('router-api')
 
+      def stub_router_has_route(path, route, bearer_token = ENV['ROUTER_API_BEARER_TOKEN'])
+        stub_get_route(path, bearer_token).to_return(
+          status: 200,
+          body: route.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+      end
+
+      def stub_router_doesnt_have_route(path, bearer_token = ENV['ROUTER_API_BEARER_TOKEN'])
+        stub_get_route(path, bearer_token).to_return(status: 404)
+      end
+
+      def stub_router_has_backend_route(path, backend_id:, route_type: "exact", disabled: false)
+        stub_router_has_route(path, handler: "backend", backend_id: backend_id, disabled: disabled, route_type: route_type)
+      end
+
+      def stub_router_has_redirect_route(path, redirect_to:, redirect_type: "permanent", route_type: "exact", disabled: false)
+        stub_router_has_route(path, handler: "redirect", redirect_to: redirect_to, redirect_type: redirect_type, disabled: disabled, route_type: route_type)
+      end
+
+      def stub_router_has_gone_route(path, route_type: "exact", disabled: false)
+        stub_router_has_route(path, handler: "gone", route_type: route_type, disabled: disabled)
+      end
+
       def stub_all_router_registration
         stub_request(:put, %r{\A#{ROUTER_API_ENDPOINT}/backends/[a-z0-9-]+\z})
         stub_request(:put, "#{ROUTER_API_ENDPOINT}/routes")
@@ -63,6 +87,14 @@ module GdsApi
       end
 
     private
+
+      def stub_get_route(path, bearer_token)
+        stub_http_request(:get, "#{ROUTER_API_ENDPOINT}/routes")
+          .with(
+            query: { "incoming_path" => path },
+            headers: { "Authorization" => "Bearer #{bearer_token}" },
+          )
+      end
 
       def stub_route_put(route)
         stub_http_request(:put, "#{ROUTER_API_ENDPOINT}/routes")

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,12 +11,14 @@ SimpleCov.start do
 end
 
 require 'minitest/autorun'
+require 'minitest/around'
 require 'rack/utils'
 require 'rack/test'
 require 'mocha/mini_test'
 require 'timecop'
 require 'gds-api-adapters'
 require 'govuk-content-schema-test-helpers'
+require 'climate_control'
 
 class Minitest::Test
   def teardown


### PR DESCRIPTION
This allows clients to write tests stubbing the response from Router API easily.

[Trello Card](https://trello.com/c/dskGorBB/737-rake-task-to-check-where-content-has-ended-up)