### PR TITLE
Bump gem version to 57.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 57.2.4
+
+* Add `content_purpose_supergroup` as optional parameter to `find_subscriber_list` in `GdsApi::EmailAlertApi` 
+
 # 57.2.3
 
 * Add `create_business_finder_feedback` to `GdsApi::SupportApi`

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '57.2.3'.freeze
+  VERSION = '57.2.4'.freeze
 end


### PR DESCRIPTION
Bump the gem version to get the changes in [Permit content_purpose_supergroup as attribute for find_subscriber_list](https://github.com/alphagov/gds-api-adapters/pull/893).