### PR TITLE
Make business finder feedback more generic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
+# 57.3.1
+
+* Rename `create_business_finder_feedback` to `create_content_improvement_feedback`
+
 # 57.3.0
 
 * Add Router API stubs for getting routes.
 
 # 57.2.4
 
-* Add `content_purpose_supergroup` as optional parameter to `find_subscriber_list` in `GdsApi::EmailAlertApi` 
+* Add `content_purpose_supergroup` as optional parameter to `find_subscriber_list` in `GdsApi::EmailAlertApi`
 * Add automatic bearer tokens for `GdsApi.router` and `GdsApi.content_store`.
 
 # 57.2.3

--- a/lib/gds_api/support_api.rb
+++ b/lib/gds_api/support_api.rb
@@ -47,8 +47,8 @@ class GdsApi::SupportApi < GdsApi::Base
     get_json("#{endpoint}/anonymous-feedback/problem-reports/#{date_string}/totals")
   end
 
-  def create_business_finder_feedback(params)
-    post_json("#{endpoint}/anonymous-feedback/business-finder", params)
+  def create_content_improvement_feedback(params)
+    post_json("#{endpoint}/anonymous-feedback/content_improvement", params)
   end
 
   def anonymous_feedback(options = {})

--- a/lib/gds_api/test_helpers/support_api.rb
+++ b/lib/gds_api/test_helpers/support_api.rb
@@ -48,8 +48,8 @@ module GdsApi
         post_stub.to_return(status: 201)
       end
 
-      def stub_support_api_create_business_finder_feedback(params)
-        post_stub = stub_http_request(:post, "#{SUPPORT_API_ENDPOINT}/anonymous-feedback/business-finder")
+      def stub_support_api_create_content_improvement_feedback(params)
+        post_stub = stub_http_request(:post, "#{SUPPORT_API_ENDPOINT}/anonymous-feedback/content_improvement")
         post_stub.with(body: params)
         post_stub.to_return(status: 201)
       end

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '57.3.0'.freeze
+  VERSION = '57.3.1'.freeze
 end

--- a/test/support_api_test.rb
+++ b/test/support_api_test.rb
@@ -42,9 +42,9 @@ describe GdsApi::SupportApi do
 
   it 'can submit anonymous-contact/business-finder' do
     request_details = { description: 'something is missing' }
-    stub_post = stub_support_api_create_business_finder_feedback(request_details)
+    stub_post = stub_support_api_create_content_improvement_feedback(request_details)
 
-    @api.create_business_finder_feedback(request_details)
+    @api.create_content_improvement_feedback(request_details)
 
     assert_requested(stub_post)
   end


### PR DESCRIPTION
Follows on from https://github.com/alphagov/gds-api-adapters/pull/894. We want to make it more generic so it can be used elsewhere on other pages in the future.