### PR TITLE
Add reject_content_purpose_supergroup attribute to email alert api subscriber lookup

### DIFF
--- a/lib/gds_api/email_alert_api.rb
+++ b/lib/gds_api/email_alert_api.rb
@@ -26,6 +26,7 @@ class GdsApi::EmailAlertApi < GdsApi::Base
     government_document_supertype = attributes["government_document_supertype"]
     gov_delivery_id = attributes["gov_delivery_id"]
     content_purpose_supergroup = attributes["content_purpose_supergroup"]
+    reject_content_purpose_supergroup = attributes["reject_content_purpose_supergroup"]
 
     if tags && links
       message = "please provide either tags or links (or neither), but not both"
@@ -40,6 +41,7 @@ class GdsApi::EmailAlertApi < GdsApi::Base
     params[:government_document_supertype] = government_document_supertype if government_document_supertype
     params[:gov_delivery_id] = gov_delivery_id if gov_delivery_id
     params[:content_purpose_supergroup] = content_purpose_supergroup if content_purpose_supergroup
+    params[:reject_content_purpose_supergroup] = reject_content_purpose_supergroup if reject_content_purpose_supergroup
 
     query_string = nested_query_string(params)
     get_json("#{endpoint}/subscriber-lists?" + query_string)

--- a/lib/gds_api/test_helpers/email_alert_api.rb
+++ b/lib/gds_api/test_helpers/email_alert_api.rb
@@ -328,6 +328,8 @@ module GdsApi
           email_document_supertype = attributes["email_document_supertype"]
           government_document_supertype = attributes["government_document_supertype"]
           gov_delivery_id = attributes["gov_delivery_id"]
+          content_purpose_supergroup = attributes["content_purpose_supergroup"]
+          reject_content_purpose_supergroup = attributes["reject_content_purpose_supergroup"]
 
           params = {}
           params[:tags] = tags if tags
@@ -336,6 +338,8 @@ module GdsApi
           params[:email_document_supertype] = email_document_supertype if email_document_supertype
           params[:government_document_supertype] = government_document_supertype if government_document_supertype
           params[:gov_delivery_id] = gov_delivery_id if gov_delivery_id
+          params[:content_purpose_supergroup] = content_purpose_supergroup if content_purpose_supergroup
+          params[:reject_content_purpose_supergroup] = reject_content_purpose_supergroup if reject_content_purpose_supergroup
 
           query = Rack::Utils.build_nested_query(params)
         end


### PR DESCRIPTION
https://trello.com/c/ylw7DDQa/329-enable-email-alert-api-to-reject-a-content-purpose-supergroup

Blocked by https://github.com/alphagov/email-alert-api/pull/784
Blocks https://github.com/alphagov/rummager/pull/1422