### PR TITLE
Add republish method for publishing api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Add GdsApi::PublishingApiV2#republish endpoint to `publishing_api`
+
 # 57.3.1
 
 * Rename `create_business_finder_feedback` to `create_content_improvement_feedback`

--- a/lib/gds_api/publishing_api_v2.rb
+++ b/lib/gds_api/publishing_api_v2.rb
@@ -106,6 +106,24 @@ class GdsApi::PublishingApiV2 < GdsApi::Base
     post_json(publish_url(content_id), params)
   end
 
+  # Republish a content item
+  #
+  # The publishing-api will "republish" a live edition. This can be used to remove an unpublishing or to
+  # re-send a published edition downstream
+  #
+  # @param content_id [UUID]
+  # @param options [Hash]
+  # @option options [String] locale The language, defaults to 'en' in publishing-api.
+  #
+  # @see ...
+  def republish(content_id, options = {})
+    optional_keys = %i[locale previous_version]
+
+    params = merge_optional_keys({}, options, optional_keys)
+
+    post_json(republish_url(content_id), params)
+  end
+
   # Import content into the publishing API
   #
   # The publishing-api will delete any content which has the content
@@ -445,6 +463,11 @@ private
   def publish_url(content_id)
     validate_content_id(content_id)
     "#{endpoint}/v2/content/#{content_id}/publish"
+  end
+
+  def republish_url(content_id)
+    validate_content_id(content_id)
+    "#{endpoint}/v2/content/#{content_id}/republish"
   end
 
   def unpublish_url(content_id)

--- a/lib/gds_api/test_helpers/publishing_api_v2.rb
+++ b/lib/gds_api/test_helpers/publishing_api_v2.rb
@@ -84,6 +84,21 @@ module GdsApi
         stub_request(:post, url).with(body: body).to_return(response)
       end
 
+      # Stub a POST /v2/content/:content_id/republish request
+      #
+      # @param content_id [UUID]
+      # @param body  [String]
+      # @param response_hash [Hash]
+      def stub_publishing_api_republish(content_id, body = {}, response_hash = {})
+        url = PUBLISHING_API_V2_ENDPOINT + "/content/#{content_id}/republish"
+        response = {
+          status: 200,
+          body: '{}',
+          headers: { "Content-Type" => "application/json; charset=utf-8" }
+        }.merge(response_hash)
+        stub_request(:post, url).with(body: body).to_return(response)
+      end
+
       # Stub a POST /v2/content/:content_id/unpublish request
       #
       # @param content_id [UUID]
@@ -141,6 +156,11 @@ module GdsApi
       # Stub any POST /v2/content/*/publish request
       def stub_any_publishing_api_publish
         stub_request(:post, %r{\A#{PUBLISHING_API_V2_ENDPOINT}/content/.*/publish})
+      end
+
+      # Stub any POST /v2/content/*/publish request
+      def stub_any_publishing_api_republish
+        stub_request(:post, %r{\A#{PUBLISHING_API_V2_ENDPOINT}/content/.*/republish})
       end
 
       # Stub any POST /v2/content/*/unpublish request


### PR DESCRIPTION
This change adds the ability to use the republish enpointi in the
publishing api which is being introduced in the pr below. Calling this
method will send a request to pub api to republish a live document,
remove a withdrawal or send the published items data downstream.

Related to this pr: https://github.com/alphagov/publishing-api/pull/1439
Trello: https://trello.com/c/yhcKNEWr/587-allow-users-undo-withdraw