### PR TITLE
Rename subscribable to subscriber list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+* Rename references of subscribable to subscriber_list in Email Alert API. Note
+  this is a breaking change for users of the Email Alert API adapters, clients
+  will need to also update any references to subscribable.
+
 # 57.5.0
 
 * Support new unreserve_path endpoint for Publishing API (v1) adapter

--- a/lib/gds_api/email_alert_api.rb
+++ b/lib/gds_api/email_alert_api.rb
@@ -126,8 +126,8 @@ class GdsApi::EmailAlertApi < GdsApi::Base
   #  government_document_supertype
   #  subscriber_count
   # }
-  def get_subscriber_list(reference:)
-    get_json("#{endpoint}/subscriber-lists/#{reference}")
+  def get_subscriber_list(slug:)
+    get_json("#{endpoint}/subscriber-lists/#{slug}")
   end
 
   # Get a Subscription

--- a/lib/gds_api/email_alert_api.rb
+++ b/lib/gds_api/email_alert_api.rb
@@ -102,18 +102,18 @@ class GdsApi::EmailAlertApi < GdsApi::Base
   # Subscribe
   #
   # @return [Hash] subscription_id
-  def subscribe(subscribable_id:, address:, frequency: "immediately")
+  def subscribe(subscriber_list_id:, address:, frequency: "immediately")
     post_json(
       "#{endpoint}/subscriptions",
-      subscribable_id: subscribable_id,
+      subscriber_list_id: subscriber_list_id,
       address: address,
       frequency: frequency,
     )
   end
 
-  # Get a Subscribable
+  # Get a Subscriber List
   #
-  # @return [Hash] subscribable: {
+  # @return [Hash] subscriber_list: {
   #  id
   #  title
   #  gov_delivery_id
@@ -126,8 +126,8 @@ class GdsApi::EmailAlertApi < GdsApi::Base
   #  government_document_supertype
   #  subscriber_count
   # }
-  def get_subscribable(reference:)
-    get_json("#{endpoint}/subscribables/#{reference}")
+  def get_subscriber_list(reference:)
+    get_json("#{endpoint}/subscriber-lists/#{reference}")
   end
 
   # Get a Subscription

--- a/lib/gds_api/test_helpers/email_alert_api.rb
+++ b/lib/gds_api/test_helpers/email_alert_api.rb
@@ -204,8 +204,8 @@ module GdsApi
         end
       end
 
-      def stub_email_alert_api_has_subscriber_list_by_slug(reference:, returned_attributes:)
-        stub_request(:get, "#{EMAIL_ALERT_API_ENDPOINT}/subscriber-lists/#{reference}")
+      def stub_email_alert_api_has_subscriber_list_by_slug(slug:, returned_attributes:)
+        stub_request(:get, "#{EMAIL_ALERT_API_ENDPOINT}/subscriber-lists/#{slug}")
           .to_return(
             status: 200,
             body: {
@@ -214,8 +214,8 @@ module GdsApi
         )
       end
 
-      def stub_email_alert_api_does_not_have_subscriber_list_by_slug(reference:)
-        stub_request(:get, "#{EMAIL_ALERT_API_ENDPOINT}/subscriber-lists/#{reference}")
+      def stub_email_alert_api_does_not_have_subscriber_list_by_slug(slug:)
+        stub_request(:get, "#{EMAIL_ALERT_API_ENDPOINT}/subscriber-lists/#{slug}")
           .to_return(status: 404)
       end
 

--- a/lib/gds_api/test_helpers/email_alert_api.rb
+++ b/lib/gds_api/test_helpers/email_alert_api.rb
@@ -161,24 +161,24 @@ module GdsApi
           .to_return(status: 404)
       end
 
-      def stub_email_alert_api_creates_a_subscription(subscribable_id, address, frequency, returned_subscription_id)
+      def stub_email_alert_api_creates_a_subscription(subscriber_list_id, address, frequency, returned_subscription_id)
         stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscriptions")
           .with(
-            body: { subscribable_id: subscribable_id, address: address, frequency: frequency }.to_json
+            body: { subscriber_list_id: subscriber_list_id, address: address, frequency: frequency }.to_json
         ).to_return(status: 201, body: { subscription_id: returned_subscription_id }.to_json)
       end
 
-      def stub_email_alert_api_creates_an_existing_subscription(subscribable_id, address, frequency, returned_subscription_id)
+      def stub_email_alert_api_creates_an_existing_subscription(subscriber_list_id, address, frequency, returned_subscription_id)
         stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscriptions")
           .with(
-            body: { subscribable_id: subscribable_id, address: address, frequency: frequency }.to_json
+            body: { subscriber_list_id: subscriber_list_id, address: address, frequency: frequency }.to_json
         ).to_return(status: 200, body: { subscription_id: returned_subscription_id }.to_json)
       end
 
-      def stub_email_alert_api_refuses_to_create_subscription(subscribable_id, address, frequency)
+      def stub_email_alert_api_refuses_to_create_subscription(subscriber_list_id, address, frequency)
         stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscriptions")
           .with(
-            body: { subscribable_id: subscribable_id, address: address, frequency: frequency }.to_json
+            body: { subscriber_list_id: subscriber_list_id, address: address, frequency: frequency }.to_json
         ).to_return(status: 422)
       end
 
@@ -194,28 +194,28 @@ module GdsApi
         assert_requested(:post, "#{EMAIL_ALERT_API_ENDPOINT}/unsubscribe/#{uuid}", times: 1)
       end
 
-      def assert_subscribed(subscribable_id, address, frequency = "immediately")
+      def assert_subscribed(subscriber_list_id, address, frequency = "immediately")
         assert_requested(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscriptions") do |req|
           JSON.parse(req.body).symbolize_keys == {
-            subscribable_id: subscribable_id,
+            subscriber_list_id: subscriber_list_id,
             address: address,
             frequency: frequency
           }
         end
       end
 
-      def stub_email_alert_api_has_subscribable(reference:, returned_attributes:)
-        stub_request(:get, "#{EMAIL_ALERT_API_ENDPOINT}/subscribables/#{reference}")
+      def stub_email_alert_api_has_subscriber_list_by_slug(reference:, returned_attributes:)
+        stub_request(:get, "#{EMAIL_ALERT_API_ENDPOINT}/subscriber-lists/#{reference}")
           .to_return(
             status: 200,
             body: {
-              subscribable: returned_attributes
+              subscriber_list: returned_attributes
             }.to_json
         )
       end
 
-      def stub_email_alert_api_does_not_have_subscribable(reference:)
-        stub_request(:get, "#{EMAIL_ALERT_API_ENDPOINT}/subscribables/#{reference}")
+      def stub_email_alert_api_does_not_have_subscriber_list_by_slug(reference:)
+        stub_request(:get, "#{EMAIL_ALERT_API_ENDPOINT}/subscriber-lists/#{reference}")
           .to_return(status: 404)
       end
 
@@ -243,8 +243,8 @@ module GdsApi
       alias_method :email_alert_api_creates_an_existing_subscription, :stub_email_alert_api_creates_an_existing_subscription
       alias_method :email_alert_api_refuses_to_create_subscription, :stub_email_alert_api_refuses_to_create_subscription
       alias_method :email_alert_api_creates_an_auth_token, :stub_email_alert_api_creates_an_auth_token
-      alias_method :email_alert_api_has_subscribable, :stub_email_alert_api_has_subscribable
-      alias_method :email_alert_api_does_not_have_subscribable, :stub_email_alert_api_does_not_have_subscribable
+      alias_method :email_alert_api_has_subscriber_list_by_slug, :stub_email_alert_api_has_subscriber_list_by_slug
+      alias_method :email_alert_api_does_not_have_subscriber_list_by_slug, :stub_email_alert_api_does_not_have_subscriber_list_by_slug
 
     private
 

--- a/test/email_alert_api_test.rb
+++ b/test/email_alert_api_test.rb
@@ -328,18 +328,18 @@ describe GdsApi::EmailAlertApi do
   describe "subscribing and a subscription is created" do
     describe "with a frequency specified" do
       it "returns a 201 and the subscription id" do
-        subscribable_id = 5
+        subscriber_list_id = 5
         address = "test@test.com"
         created_subscription_id = 1
         frequency = "daily"
 
         stub_email_alert_api_creates_a_subscription(
-          subscribable_id,
+          subscriber_list_id,
           address,
           frequency,
           created_subscription_id
         )
-        api_response = api_client.subscribe(subscribable_id: subscribable_id, address: address, frequency: frequency)
+        api_response = api_client.subscribe(subscriber_list_id: subscriber_list_id, address: address, frequency: frequency)
         assert_equal(201, api_response.code)
         assert_equal({ "subscription_id" => 1 }, api_response.to_h)
       end
@@ -347,18 +347,18 @@ describe GdsApi::EmailAlertApi do
 
     describe "without a frequency specified" do
       it "returns a 201 and the subscription id" do
-        subscribable_id = 6
+        subscriber_list_id = 6
         address = "test@test.com"
         created_subscription_id = 1
         frequency = "immediately"
 
         stub_email_alert_api_creates_a_subscription(
-          subscribable_id,
+          subscriber_list_id,
           address,
           frequency,
           created_subscription_id
         )
-        api_response = api_client.subscribe(subscribable_id: subscribable_id, address: address)
+        api_response = api_client.subscribe(subscriber_list_id: subscriber_list_id, address: address)
         assert_equal(201, api_response.code)
         assert_equal({ "subscription_id" => 1 }, api_response.to_h)
       end
@@ -367,18 +367,18 @@ describe GdsApi::EmailAlertApi do
 
   describe "subscribing and a subscription already exists" do
     it "returns a 200 and the subscription id" do
-      subscribable_id = 5
+      subscriber_list_id = 5
       address = "test@test.com"
       existing_subscription_id = 1
       frequency = "immediately"
 
       stub_email_alert_api_creates_an_existing_subscription(
-        subscribable_id,
+        subscriber_list_id,
         address,
         frequency,
         existing_subscription_id
       )
-      api_response = api_client.subscribe(subscribable_id: subscribable_id, address: address, frequency: frequency)
+      api_response = api_client.subscribe(subscriber_list_id: subscriber_list_id, address: address, frequency: frequency)
       assert_equal(200, api_response.code)
       assert_equal({ "subscription_id" => 1 }, api_response.to_h)
     end
@@ -389,33 +389,33 @@ describe GdsApi::EmailAlertApi do
       stub_email_alert_api_refuses_to_create_subscription(123, "invalid", "weekly")
 
       assert_raises GdsApi::HTTPUnprocessableEntity do
-        api_client.subscribe(subscribable_id: 123, address: "invalid", frequency: "weekly")
+        api_client.subscribe(subscriber_list_id: 123, address: "invalid", frequency: "weekly")
       end
     end
   end
 
-  describe "get_subscribable when one exists" do
+  describe "get_subscriber_list when one exists" do
     it "returns it" do
-      stub_email_alert_api_has_subscribable(
+      stub_email_alert_api_has_subscriber_list_by_slug(
         reference: "test123",
         returned_attributes: {
           id: 1,
           gov_delivery_id: "test123",
         }
       )
-      api_response = api_client.get_subscribable(reference: "test123")
+      api_response = api_client.get_subscriber_list(reference: "test123")
       assert_equal(200, api_response.code)
       parsed_body = api_response.to_h
-      assert_equal(1, parsed_body["subscribable"]["id"])
+      assert_equal(1, parsed_body["subscriber_list"]["id"])
     end
   end
 
-  describe "get_subscribable when one doesn't exist" do
+  describe "get_subscriber_list when one doesn't exist" do
     it "returns 404" do
-      stub_email_alert_api_does_not_have_subscribable(reference: "test123")
+      stub_email_alert_api_does_not_have_subscriber_list_by_slug(reference: "test123")
 
       assert_raises GdsApi::HTTPNotFound do
-        api_client.get_subscribable(reference: "test123")
+        api_client.get_subscriber_list(reference: "test123")
       end
     end
   end

--- a/test/email_alert_api_test.rb
+++ b/test/email_alert_api_test.rb
@@ -397,13 +397,13 @@ describe GdsApi::EmailAlertApi do
   describe "get_subscriber_list when one exists" do
     it "returns it" do
       stub_email_alert_api_has_subscriber_list_by_slug(
-        reference: "test123",
+        slug: "test123",
         returned_attributes: {
           id: 1,
           gov_delivery_id: "test123",
         }
       )
-      api_response = api_client.get_subscriber_list(reference: "test123")
+      api_response = api_client.get_subscriber_list(slug: "test123")
       assert_equal(200, api_response.code)
       parsed_body = api_response.to_h
       assert_equal(1, parsed_body["subscriber_list"]["id"])
@@ -412,10 +412,10 @@ describe GdsApi::EmailAlertApi do
 
   describe "get_subscriber_list when one doesn't exist" do
     it "returns 404" do
-      stub_email_alert_api_does_not_have_subscriber_list_by_slug(reference: "test123")
+      stub_email_alert_api_does_not_have_subscriber_list_by_slug(slug: "test123")
 
       assert_raises GdsApi::HTTPNotFound do
-        api_client.get_subscriber_list(reference: "test123")
+        api_client.get_subscriber_list(slug: "test123")
       end
     end
   end


### PR DESCRIPTION
At one point we were planning to rename all instances of subscriber lists with subscribables however these never happened and it's confusing to have the same thing named differently. Instead we've decided to stick with subscriber list.

This is a breaking change for users of the Email Alert API adapters, clients would be expected to update the code. However, Email Alert API itself will still accept the old style arguments.

Depends on https://github.com/alphagov/email-alert-api/pull/800.

[Trello Card](https://trello.com/c/5qd2mgF0/76-subscriberlist-and-subscribable-are-used-for-the-same-thing-in-email-alert-api)