### PR TITLE
Change Plek(rummager) to Plek(search)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Find rummager by using the "search" alias, rather than referring to "rummager" directly
+
 # 57.4.1
 
 * Add reject_content_purpose_supergroup as optional email alert api subscriber list param

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Example usage:
 
 ```ruby
 require 'gds_api/rummager'
-rummager = GdsApi::Rummager.new(Plek.new.find('rummager'))
+rummager = GdsApi::Rummager.new(Plek.new.find('search))
 results = rummager.search(q: "taxes")
 ```
 

--- a/lib/gds_api.rb
+++ b/lib/gds_api.rb
@@ -168,7 +168,7 @@ module GdsApi
   #
   # @return [GdsApi::Rummager]
   def self.rummager(options = {})
-    GdsApi::Rummager.new(Plek.find('rummager'), options)
+    GdsApi::Rummager.new(Plek.find('search'), options)
   end
 
   # Creates a GdsApi::Rummager adapter to access via a search.* hostname

--- a/lib/gds_api/test_helpers/rummager.rb
+++ b/lib/gds_api/test_helpers/rummager.rb
@@ -4,7 +4,7 @@ require 'gds_api/test_helpers/json_client_helper'
 module GdsApi
   module TestHelpers
     module Rummager
-      RUMMAGER_ENDPOINT = Plek.current.find('rummager')
+      RUMMAGER_ENDPOINT = Plek.current.find('search')
 
       def stub_any_rummager_post(index: nil)
         if index


### PR DESCRIPTION
For the migration to search-api we're going to re-target the 'search'
alias to search-api.

---

[Trello card](https://trello.com/c/yrq9hZmU/77-point-the-search-alias-to-search-api-if-rummager-is-disabled)