### PR TITLE
Remove reject_content_purpose_supergroup as optional email alert api subscriber list param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Remove reject_content_purpose_supergroup as optional email alert api subscriber list param
+
 # 57.4.2
 
 * Find rummager by using the "search" alias, rather than referring to "rummager" directly

--- a/lib/gds_api/email_alert_api.rb
+++ b/lib/gds_api/email_alert_api.rb
@@ -26,7 +26,6 @@ class GdsApi::EmailAlertApi < GdsApi::Base
     government_document_supertype = attributes["government_document_supertype"]
     gov_delivery_id = attributes["gov_delivery_id"]
     content_purpose_supergroup = attributes["content_purpose_supergroup"]
-    reject_content_purpose_supergroup = attributes["reject_content_purpose_supergroup"]
 
     if tags && links
       message = "please provide either tags or links (or neither), but not both"
@@ -41,7 +40,6 @@ class GdsApi::EmailAlertApi < GdsApi::Base
     params[:government_document_supertype] = government_document_supertype if government_document_supertype
     params[:gov_delivery_id] = gov_delivery_id if gov_delivery_id
     params[:content_purpose_supergroup] = content_purpose_supergroup if content_purpose_supergroup
-    params[:reject_content_purpose_supergroup] = reject_content_purpose_supergroup if reject_content_purpose_supergroup
 
     query_string = nested_query_string(params)
     get_json("#{endpoint}/subscriber-lists?" + query_string)

--- a/lib/gds_api/test_helpers/email_alert_api.rb
+++ b/lib/gds_api/test_helpers/email_alert_api.rb
@@ -329,7 +329,6 @@ module GdsApi
           government_document_supertype = attributes["government_document_supertype"]
           gov_delivery_id = attributes["gov_delivery_id"]
           content_purpose_supergroup = attributes["content_purpose_supergroup"]
-          reject_content_purpose_supergroup = attributes["reject_content_purpose_supergroup"]
 
           params = {}
           params[:tags] = tags if tags
@@ -339,7 +338,6 @@ module GdsApi
           params[:government_document_supertype] = government_document_supertype if government_document_supertype
           params[:gov_delivery_id] = gov_delivery_id if gov_delivery_id
           params[:content_purpose_supergroup] = content_purpose_supergroup if content_purpose_supergroup
-          params[:reject_content_purpose_supergroup] = reject_content_purpose_supergroup if reject_content_purpose_supergroup
 
           query = Rack::Utils.build_nested_query(params)
         end


### PR DESCRIPTION
This relates to https://github.com/alphagov/email-alert-api/pull/809
https://trello.com/c/45eoS6mj/491-remove-rejectcontentpurposesupergroup-functionality-from-email-alert-api-m-%F0%9F%98%AD