### PR TITLE
Add pub api unreserve path

### DIFF
--- a/lib/gds_api/base.rb
+++ b/lib/gds_api/base.rb
@@ -23,7 +23,6 @@ class GdsApi::Base
                           :put_json,
                           :patch_json,
                           :delete_json,
-                          :delete_json_with_params!,
                           :get_raw, :get_raw!,
                           :put_multipart,
                           :post_multipart

--- a/lib/gds_api/json_client.rb
+++ b/lib/gds_api/json_client.rb
@@ -64,8 +64,8 @@ module GdsApi
       do_json_request(:patch, url, params, additional_headers)
     end
 
-    def delete_json(url, additional_headers = {})
-      do_json_request(:delete, url, nil, additional_headers)
+    def delete_json(url, params = {}, additional_headers = {})
+      do_json_request(:delete, url, params, additional_headers)
     end
 
     def delete_json_with_params!(url, params, additional_headers = {})

--- a/lib/gds_api/json_client.rb
+++ b/lib/gds_api/json_client.rb
@@ -68,18 +68,6 @@ module GdsApi
       do_json_request(:delete, url, params, additional_headers)
     end
 
-    def delete_json_with_params!(url, params, additional_headers = {})
-      warn <<-doc
-        DEPRECATION NOTICE: Delete requests should not include parameters.
-
-        Do not use this method as the ability to do this will be removed.
-
-        Called from: #{caller[2]}
-      doc
-
-      do_json_request(:delete, url, params, additional_headers)
-    end
-
     def post_multipart(url, params)
       r = do_raw_request(:post, url, params.merge(multipart: true))
       Response.new(r)

--- a/lib/gds_api/publishing_api.rb
+++ b/lib/gds_api/publishing_api.rb
@@ -12,7 +12,16 @@ class GdsApi::PublishingApi < GdsApi::Base
     e
   end
 
+  def unreserve_path(base_path, publishing_app)
+    payload = { publishing_app: publishing_app }
+    delete_json(unreserve_url(base_path), payload)
+  end
+
 private
+
+  def unreserve_url(base_path)
+    "#{endpoint}/paths#{base_path}"
+  end
 
   def intent_url(base_path)
     "#{endpoint}/publish-intent#{base_path}"

--- a/lib/gds_api/rummager.rb
+++ b/lib/gds_api/rummager.rb
@@ -19,6 +19,7 @@ module GdsApi
       def delete_document(type, id)
         delete_json(
           "#{documents_url}/#{id}",
+          nil,
           _type: type,
         )
       end

--- a/lib/gds_api/test_helpers/publishing_api.rb
+++ b/lib/gds_api/test_helpers/publishing_api.rb
@@ -11,15 +11,15 @@ module GdsApi
 
       PUBLISHING_API_ENDPOINT = Plek.current.find('publishing-api')
 
-      def stub_publishing_api_unreserve_path(base_path, publishing_app)
+      def stub_publishing_api_unreserve_path(base_path, publishing_app = /.*/)
         stub_publishing_api_unreserve_path_with_code(base_path, publishing_app, 200)
       end
 
-      def stub_publishing_api_unreserve_path_not_found(base_path, publishing_app)
+      def stub_publishing_api_unreserve_path_not_found(base_path, publishing_app = /.*/)
         stub_publishing_api_unreserve_path_with_code(base_path, publishing_app, 404)
       end
 
-      def stub_publishing_api_unreserve_path_invalid(base_path, publishing_app)
+      def stub_publishing_api_unreserve_path_invalid(base_path, publishing_app = /.*/)
         stub_publishing_api_unreserve_path_with_code(base_path, publishing_app, 422)
       end
 

--- a/lib/gds_api/test_helpers/publishing_api.rb
+++ b/lib/gds_api/test_helpers/publishing_api.rb
@@ -11,6 +11,18 @@ module GdsApi
 
       PUBLISHING_API_ENDPOINT = Plek.current.find('publishing-api')
 
+      def stub_publishing_api_unreserve_path(base_path, publishing_app)
+        stub_publishing_api_unreserve_path_with_code(base_path, publishing_app, 200)
+      end
+
+      def stub_publishing_api_unreserve_path_not_found(base_path, publishing_app)
+        stub_publishing_api_unreserve_path_with_code(base_path, publishing_app, 404)
+      end
+
+      def stub_publishing_api_unreserve_path_invalid(base_path, publishing_app)
+        stub_publishing_api_unreserve_path_with_code(base_path, publishing_app, 422)
+      end
+
       def stub_publishing_api_put_intent(base_path, body = intent_for_publishing_api(base_path))
         url = PUBLISHING_API_ENDPOINT + "/publish-intent" + base_path
         body = body.to_json unless body.is_a?(String)
@@ -100,6 +112,12 @@ module GdsApi
       alias_method :publishing_api_returns_path_reservation_validation_error_for, :stub_publishing_api_returns_path_reservation_validation_error_for
 
     private
+
+      def stub_publishing_api_unreserve_path_with_code(base_path, publishing_app, code)
+        url = PUBLISHING_API_ENDPOINT + "/paths" + base_path
+        body = { publishing_app: publishing_app }
+        stub_request(:delete, url).with(body: body).to_return(status: code, body: '{}', headers: { "Content-Type" => "application/json; charset=utf-8" })
+      end
 
       def values_match_recursively(expected_value, actual_value)
         case expected_value

--- a/test/json_client_test.rb
+++ b/test/json_client_test.rb
@@ -425,7 +425,8 @@ class JsonClientTest < MiniTest::Spec
     stub_request(:delete, "http://some.other.endpoint/some.json").to_return(status: 200)
 
     GdsApi::JsonClient.new.delete_json("http://some.other.endpoint/some.json",
-                                                  "HEADER-A" => "B", "HEADER-C" => "D")
+                                       {},
+                                       "HEADER-A" => "B", "HEADER-C" => "D")
 
     assert_requested(:delete, %r{/some.json}) do |request|
       headers_with_uppercase_names = Hash[request.headers.collect { |key, value| [key.upcase, value] }]

--- a/test/publishing_api_test.rb
+++ b/test/publishing_api_test.rb
@@ -62,9 +62,9 @@ describe GdsApi::PublishingApi do
           },
         )
 
-       assert_raises GdsApi::HTTPNotFound do
-         @api_client.unreserve_path(base_path, publishing_app)
-       end
+      assert_raises GdsApi::HTTPNotFound do
+        @api_client.unreserve_path(base_path, publishing_app)
+      end
     end
 
     it "raises an error if the reservation is with another app" do
@@ -90,9 +90,9 @@ describe GdsApi::PublishingApi do
           },
         )
 
-       assert_raises GdsApi::HTTPUnprocessableEntity do
-         @api_client.unreserve_path(base_path, publishing_app)
-       end
+      assert_raises GdsApi::HTTPUnprocessableEntity do
+        @api_client.unreserve_path(base_path, publishing_app)
+      end
     end
   end
 

--- a/test/publishing_api_test.rb
+++ b/test/publishing_api_test.rb
@@ -11,6 +11,91 @@ describe GdsApi::PublishingApi do
     @api_client = GdsApi::PublishingApi.new(publishing_api_host)
   end
 
+  describe "#unreserve_path" do
+    it "responds with 200 OK if reservation is owned by the app" do
+      publishing_app = "publisher"
+      base_path = "/test-item"
+
+      publishing_api
+        .given("/test-item has been reserved by the Publisher application")
+        .upon_receiving("a request to unreserve a path")
+        .with(
+          method: :delete,
+          path: "/paths#{base_path}",
+          body: { publishing_app: publishing_app },
+          headers: {
+            "Content-Type" => "application/json"
+          },
+        )
+        .will_respond_with(
+          status: 200,
+          body: {},
+          headers: {
+            "Content-Type" => "application/json; charset=utf-8"
+          },
+        )
+
+      response = @api_client.unreserve_path(base_path, publishing_app)
+      assert_equal 200, response.code
+    end
+
+    it "raises an error if the reservation does not exist" do
+      publishing_app = "publisher"
+      base_path = "/test-item"
+
+      publishing_api
+        .given("no content exists")
+        .upon_receiving("a request to unreserve a non-existant path")
+        .with(
+          method: :delete,
+          path: "/paths#{base_path}",
+          body: { publishing_app: publishing_app },
+          headers: {
+            "Content-Type" => "application/json"
+          },
+        )
+        .will_respond_with(
+          status: 404,
+          body: {},
+          headers: {
+            "Content-Type" => "application/json; charset=utf-8"
+          },
+        )
+
+       assert_raises GdsApi::HTTPNotFound do
+         @api_client.unreserve_path(base_path, publishing_app)
+       end
+    end
+
+    it "raises an error if the reservation is with another app" do
+      publishing_app = "whitehall"
+      base_path = "/test-item"
+
+      publishing_api
+        .given("/test-item has been reserved by the Publisher application")
+        .upon_receiving("a request to unreserve a path owned by another app")
+        .with(
+          method: :delete,
+          path: "/paths#{base_path}",
+          body: { publishing_app: "whitehall" },
+          headers: {
+            "Content-Type" => "application/json"
+          },
+        )
+        .will_respond_with(
+          status: 422,
+          body: {},
+          headers: {
+            "Content-Type" => "application/json; charset=utf-8"
+          },
+        )
+
+       assert_raises GdsApi::HTTPUnprocessableEntity do
+         @api_client.unreserve_path(base_path, publishing_app)
+       end
+    end
+  end
+
   describe "#put_intent" do
     it "responds with 200 OK if publish intent is valid" do
       base_path = "/test-intent"

--- a/test/test_helpers/publishing_api_test.rb
+++ b/test/test_helpers/publishing_api_test.rb
@@ -13,6 +13,12 @@ describe GdsApi::TestHelpers::PublishingApi do
       api_response = publishing_api.unreserve_path("/foo", "myapp")
       assert_equal(api_response.code, 200)
     end
+
+    it "stubs for any app if not specified" do
+      stub_publishing_api_unreserve_path("/foo")
+      api_response = publishing_api.unreserve_path("/foo", "myapp")
+      assert_equal(api_response.code, 200)
+    end
   end
 
   describe "#stub_publishing_api_unreserve_path_not_found" do
@@ -23,11 +29,27 @@ describe GdsApi::TestHelpers::PublishingApi do
         publishing_api.unreserve_path("/foo", "myapp")
       end
     end
+
+    it "stubs for any app if not specified" do
+      stub_publishing_api_unreserve_path_not_found("/foo")
+
+      assert_raises GdsApi::HTTPNotFound do
+        publishing_api.unreserve_path("/foo", "myapp")
+      end
+    end
   end
 
   describe "#stub_publishing_api_unreserve_path_invalid" do
     it "stubs the unreserve path API call" do
       stub_publishing_api_unreserve_path_invalid("/foo", "myapp")
+
+      assert_raises GdsApi::HTTPUnprocessableEntity do
+        publishing_api.unreserve_path("/foo", "myapp")
+      end
+    end
+
+    it "stubs for any app if not specified" do
+      stub_publishing_api_unreserve_path_invalid("/foo")
 
       assert_raises GdsApi::HTTPUnprocessableEntity do
         publishing_api.unreserve_path("/foo", "myapp")

--- a/test/test_helpers/publishing_api_test.rb
+++ b/test/test_helpers/publishing_api_test.rb
@@ -7,6 +7,34 @@ describe GdsApi::TestHelpers::PublishingApi do
   let(:base_api_url) { Plek.current.find("publishing-api") }
   let(:publishing_api) { GdsApi::PublishingApi.new(base_api_url) }
 
+  describe "#stub_publishing_api_unreserve_path" do
+    it "stubs the unreserve path API call" do
+      stub_publishing_api_unreserve_path("/foo", "myapp")
+      api_response = publishing_api.unreserve_path("/foo", "myapp")
+      assert_equal(api_response.code, 200)
+    end
+  end
+
+  describe "#stub_publishing_api_unreserve_path_not_found" do
+    it "stubs the unreserve path API call" do
+      stub_publishing_api_unreserve_path_not_found("/foo", "myapp")
+
+      assert_raises GdsApi::HTTPNotFound do
+        publishing_api.unreserve_path("/foo", "myapp")
+      end
+    end
+  end
+
+  describe "#stub_publishing_api_unreserve_path_invalid" do
+    it "stubs the unreserve path API call" do
+      stub_publishing_api_unreserve_path_invalid("/foo", "myapp")
+
+      assert_raises GdsApi::HTTPUnprocessableEntity do
+        publishing_api.unreserve_path("/foo", "myapp")
+      end
+    end
+  end
+
   describe '#request_json_matching predicate' do
     describe "nested required attribute" do
       let(:matcher) { request_json_matching("a" => { "b" => 1 }) }


### PR DESCRIPTION
https://trello.com/c/6s9Bhzyj/632-delete-publishing-api-path-reservations-when-we-discard-drafts

This complements the new Publishing API endpoint to unreserve a path (https://github.com/alphagov/publishing-api/pull/1468).