### PR TITLE
Bump version to v57.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 57.5.0
+
+* Support new unreserve_path endpoint for Publishing API (v1) adapter
 * Remove reject_content_purpose_supergroup as optional email alert api subscriber list param
 
 # 57.4.2

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '57.4.2'.freeze
+  VERSION = '57.5.0'.freeze
 end


### PR DESCRIPTION
https://trello.com/c/6s9Bhzyj/632-delete-publishing-api-path-reservations-when-we-discard-drafts