### PR TITLE
Expect apps to use public bank holidays API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+* Expect applications to access the bank holidays API via the public website
+  and not internally via the calendars app.
+
 # 58.0.0
 
 * Rename references of subscribable to subscriber_list in Email Alert API. Note

--- a/lib/gds_api.rb
+++ b/lib/gds_api.rb
@@ -37,7 +37,7 @@ module GdsApi
   #
   # @return [GdsApi::Calendars]
   def self.calendars(options = {})
-    GdsApi::Calendars.new(Plek.find('calendars'), options)
+    GdsApi::Calendars.new(Plek.new.website_root, options)
   end
 
   # Creates a GdsApi::ContentStore adapter

--- a/lib/gds_api/test_helpers/calendars.rb
+++ b/lib/gds_api/test_helpers/calendars.rb
@@ -1,11 +1,8 @@
 module GdsApi
   module TestHelpers
     module Calendars
-      CALENDARS_ENDPOINT = Plek.current.find('calendars')
-
-
       def stub_calendars_endpoint(in_division: nil)
-        endpoint = "#{CALENDARS_ENDPOINT}/bank-holidays"
+        endpoint = "#{Plek.new.website_root}/bank-holidays"
         endpoint += "/#{in_division}" unless in_division.nil?
         endpoint + '.json'
       end

--- a/test/calendars_test.rb
+++ b/test/calendars_test.rb
@@ -6,7 +6,7 @@ describe GdsApi::Calendars do
   include GdsApi::TestHelpers::Calendars
 
   before do
-    @host = Plek.current.find("calendars")
+    @host = Plek.new.website_root
     @api = GdsApi::Calendars.new(@host)
   end
 


### PR DESCRIPTION
Instead of talking directly to Calendars, we should make apps talk via the public API. This is similar to https://github.com/alphagov/gds-api-adapters/pull/857.

When migrating the frontend apps to AWS, we noticed that Mainstream Publisher talks directly to Calendars rather than going through the public API which meant we had to set up a specific route for this app.

[Trello Card](https://trello.com/c/qDW6cUad/129-mainstream-publisher-talks-to-calendars)