### PR TITLE
Bump to version 59.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 59.0.0
 
 * Expect applications to access the bank holidays API via the public website
   and not internally via the calendars app.

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '58.0.0'.freeze
+  VERSION = '59.0.0'.freeze
 end


### PR DESCRIPTION
I decided to call this a major change because it is technically a breaking change for users of the calendars adapters, even if that may only be one or two apps.

Includes #916.