### PR TITLE
Use POST for anonymous feedback queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+* Use `POST` rather than `GET` to perform anonymous feedback queries with
+  support-api.
+
 # 59.0.0
 
 * Expect applications to access the bank holidays API via the public website

--- a/lib/gds_api/support_api.rb
+++ b/lib/gds_api/support_api.rb
@@ -51,9 +51,8 @@ class GdsApi::SupportApi < GdsApi::Base
     post_json("#{endpoint}/anonymous-feedback/content_improvement", params)
   end
 
-  def anonymous_feedback(options = {})
-    uri = "#{endpoint}/anonymous-feedback" + query_string(options)
-    get_json(uri)
+  def anonymous_feedback(params = {})
+    post_json("#{endpoint}/anonymous-feedback", params)
   end
 
   def organisation_summary(organisation_slug, options = {})

--- a/lib/gds_api/test_helpers/support_api.rb
+++ b/lib/gds_api/test_helpers/support_api.rb
@@ -79,9 +79,9 @@ module GdsApi
       end
 
       def stub_support_api_anonymous_feedback(params, response_body = {})
-        stub_http_request(:get, "#{SUPPORT_API_ENDPOINT}/anonymous-feedback").
-          with(query: params).
-          to_return(status: 200, body: response_body.to_json)
+        stub_http_request(:post, "#{SUPPORT_API_ENDPOINT}/anonymous-feedback")
+          .with(body: params)
+          .to_return(status: 200, body: response_body.to_json)
       end
 
       def stub_support_api_anonymous_feedback_organisation_summary(slug, ordering = nil, response_body = {})


### PR DESCRIPTION
The support-api app now supports querying for anonymous feedback using POST other than GET to allow for more query parameters. This updates gds-api-adapters to also perform the query using POST.

[Trello Card](https://trello.com/c/EGvu5WoK/757-make-feedex-able-to-return-results-for-larger-sets-of-urls-by-changing-request-from-get-to-post)