### PR TITLE
Bump to version 59.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 59.1.0
 
 * Use `POST` rather than `GET` to perform anonymous feedback queries with
   support-api.

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '59.0.0'.freeze
+  VERSION = '59.1.0'.freeze
 end


### PR DESCRIPTION
Includes #920.

[Trello Card](https://trello.com/c/EGvu5WoK/757-make-feedex-able-to-return-results-for-larger-sets-of-urls-by-changing-request-from-get-to-post)