### PR TITLE
Prevent warnings whenever gem is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+* Warn when `GdsApi::Rummager` is initialised and `GdsApi::TestHelpersRummager`
+  is included.
+
 # 59.2.0
 
 * Add `GdsApi::Search`, deprecate `GdsApi::Rummager`.

--- a/lib/gds_api.rb
+++ b/lib/gds_api.rb
@@ -169,8 +169,6 @@ module GdsApi
   #
   # @return [GdsApi::Rummager]
   def self.rummager(options = {})
-    warn "GdsApi.rummager is deprecated.  Use GdsApi.search instead."
-
     GdsApi::Rummager.new(Plek.find('search'), options)
   end
 

--- a/lib/gds_api/rummager.rb
+++ b/lib/gds_api/rummager.rb
@@ -2,6 +2,9 @@ require 'gds_api/search'
 
 module GdsApi
   class Rummager < Search
-    warn "GdsApi::Rummager is deprecated.  Use GdsApi::Search instead."
+    def initialize(*args)
+      warn "GdsApi::Rummager is deprecated.  Use GdsApi::Search instead."
+      super
+    end
   end
 end

--- a/lib/gds_api/test_helpers/rummager.rb
+++ b/lib/gds_api/test_helpers/rummager.rb
@@ -5,9 +5,11 @@ require 'gds_api/test_helpers/search'
 module GdsApi
   module TestHelpers
     module Rummager
-      warn "GdsApi::TestHelpers::Rummager is deprecated.  Use GdsApi::TestHelpers::Search instead."
-
       include GdsApi::TestHelpers::Search
+
+      def self.included(_base)
+        warn "GdsApi::TestHelpers::Rummager is deprecated.  Use GdsApi::TestHelpers::Search instead."
+      end
 
       RUMMAGER_ENDPOINT = SEARCH_ENDPOINT
 


### PR DESCRIPTION
As the root file requires gds_api/rummager a warning in that class means
that every application that uses this gem receives a warning. This
changes this so that the warning only occurs when you initialise the
class. I removed the warning from the GdsApi.rummager method since you'd
receive one anyway by the call to new.

This also moves the warning for the test helper to only occur when this
module is included rather than any time the file is required. This
allows requiring the file without a warning but mixing this into
something else will trigger a warning.