### PR TITLE
Revert "Permit content_purpose_supergroup as attribute for find_subscriber_list"

### DIFF
--- a/lib/gds_api/email_alert_api.rb
+++ b/lib/gds_api/email_alert_api.rb
@@ -25,7 +25,6 @@ class GdsApi::EmailAlertApi < GdsApi::Base
     email_document_supertype = attributes["email_document_supertype"]
     government_document_supertype = attributes["government_document_supertype"]
     gov_delivery_id = attributes["gov_delivery_id"]
-    content_purpose_supergroup = attributes["content_purpose_supergroup"]
 
     if tags && links
       message = "please provide either tags or links (or neither), but not both"
@@ -39,7 +38,6 @@ class GdsApi::EmailAlertApi < GdsApi::Base
     params[:email_document_supertype] = email_document_supertype if email_document_supertype
     params[:government_document_supertype] = government_document_supertype if government_document_supertype
     params[:gov_delivery_id] = gov_delivery_id if gov_delivery_id
-    params[:content_purpose_supergroup] = content_purpose_supergroup if content_purpose_supergroup
 
     query_string = nested_query_string(params)
     get_json("#{endpoint}/subscriber-lists?" + query_string)


### PR DESCRIPTION
Reverts alphagov/gds-api-adapters#893

We are handling content purpose supergroups as part of tags now so we can remove this field.

See also: 
https://github.com/alphagov/email-alert-api/pull/848
https://github.com/alphagov/email-alert-api/pull/846

Trello: https://trello.com/c/NPTRaB1e/618-remove-supergroup-attribute-from-subscriber-lists-in-email-alert-api