### PR TITLE
Adds 'get_latest_matching_subscription' method

### DIFF
--- a/lib/gds_api/email_alert_api.rb
+++ b/lib/gds_api/email_alert_api.rb
@@ -145,6 +145,25 @@ class GdsApi::EmailAlertApi < GdsApi::Base
     get_json("#{endpoint}/subscriptions/#{id}")
   end
 
+  # Get the latest Subscription that has the same subscriber_list
+  # and email as the Subscription associated with the `id` passed.
+  # This may or may not be the same Subscription.
+  #
+  # @return [Hash] subscription: {
+  #  id
+  #  subscriber_list
+  #  subscriber
+  #  created_at
+  #  updated_at
+  #  ended_at
+  #  ended_reason
+  #  frequency
+  #  source
+  # }
+  def get_latest_matching_subscription(id)
+    get_json("#{endpoint}/subscriptions/#{id}/latest")
+  end
+
   # Get Subscriptions for a Subscriber
   #
   # @param [integer] Subscriber id


### PR DESCRIPTION
Trello card: https://trello.com/c/VlnvU2Dl

Adds a helper method for calling the query added in https://github.com/alphagov/email-alert-api/pull/856. Depended on by: https://github.com/alphagov/email-alert-frontend/pull/474.

This method is required for the latest unsubscribe logic, to enable subscription links from old emails to apply to newer subscriptions, provided the frequency matches.