### PR TITLE
Exponential backoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Add get_json_with_retries to json_client to permit retrying requests.
+
 # 59.2.1
 
 * Warn when `GdsApi::Rummager` is initialised and `GdsApi::TestHelpersRummager`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Retry search requests three times if we receive a server error from search-api.
 * Add get_json_with_retries to json_client to permit retrying requests.
 
 # 59.2.1

--- a/lib/gds_api/base.rb
+++ b/lib/gds_api/base.rb
@@ -20,6 +20,7 @@ class GdsApi::Base
 
   def_delegators :client,
                  :get_json,
+                 :get_json_with_retries,
                  :post_json,
                  :put_json,
                  :patch_json,

--- a/lib/gds_api/search.rb
+++ b/lib/gds_api/search.rb
@@ -70,7 +70,7 @@ module GdsApi
     # @see https://github.com/alphagov/search-api/blob/master/doc/search-api.md
     def search(args, additional_headers = {})
       request_url = "#{base_url}/search.json?#{Rack::Utils.build_nested_query(args)}"
-      get_json(request_url, additional_headers)
+      get_json_with_retries(request_url, additional_headers)
     end
 
     # Perform a batch search.
@@ -84,7 +84,7 @@ module GdsApi
       end
       searches_query = { search: url_friendly_searches }
       request_url = "#{base_url}/batch_search.json?#{Rack::Utils.build_nested_query(searches_query)}"
-      get_json(request_url, additional_headers)
+      get_json_with_retries(request_url, additional_headers)
     end
 
     # Perform a search, returning the results as an enumerator.

--- a/test/search.rb
+++ b/test/search.rb
@@ -74,6 +74,11 @@ describe GdsApi::Search do
     end
   end
 
+  it "#search should not raise an exception if the service responds 500 but eventually 200" do
+    stub_request(:get, /example.com\/search.json/).to_return(status: [500, "Internal Server Error"]).times(2).and_then_return(status: 200)
+    assert_equal 200, GdsApi::Search.new("http://example.com").search(q: "query").code
+  end
+
   it "#search should raise an exception if the service at the search URI returns a 404" do
     stub_request(:get, /example.com\/search/).to_return(status: [404, "Not Found"])
     assert_raises(GdsApi::HTTPNotFound) do


### PR DESCRIPTION
This enables us to retry requests that return a 5XX on a GET request. It will exponentially increase the wait time between making repeated requests.

This will retry search requests a few times (with exponential backoff) if the search query responds with a 500.

The motivation for this is that we see a fair number of GdsApi::HTTPInternalServerError errors in our logs. I've seen these are happening around deploys, but they shouldn't ever happen, as they return the error to the user, telling them to repeat the request.

I'd be interested in people's thoughts on this in general and on the implementation. If you can recommend a gem we can use for this I'd be keen (from what I can see the rest client we use doesn't have a component for retries). 

Trello: https://trello.com/c/cj9a4QSa/736-retry-failed-search-queries-if-we-get-a-server-error-from-search-api