### PR TITLE
Adds 'stub_email_alert_api_has_subscriptions' test method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+* Adds `stub_email_alert_api_has_subscriptions` test helper method.
+* Ensures that `stub_email_alert_api_has_subscription` also stubs the `/latest` endpoint.
+
 # 59.3.0
 
 * Add `get_latest_matching_subscription` method to `GdsApi::EmailAlertApi`.

--- a/lib/gds_api/test_helpers/email_alert_api.rb
+++ b/lib/gds_api/test_helpers/email_alert_api.rb
@@ -53,18 +53,19 @@ module GdsApi
         subscriber_list_id: 1000,
         ended: false
       )
+        response = get_subscription_response(
+          id,
+          frequency: frequency,
+          title: title,
+          subscriber_id: subscriber_id,
+          subscriber_list_id: subscriber_list_id,
+          ended: ended,
+        ).to_json
+
         stub_request(:get, "#{EMAIL_ALERT_API_ENDPOINT}/subscriptions/#{id}")
-          .to_return(
-            status: 200,
-            body: get_subscription_response(
-              id,
-              frequency: frequency,
-              title: title,
-              subscriber_id: subscriber_id,
-              subscriber_list_id: subscriber_list_id,
-              ended: ended,
-            ).to_json,
-          )
+          .to_return(status: 200, body: response)
+        stub_request(:get, "#{EMAIL_ALERT_API_ENDPOINT}/subscriptions/#{id}/latest")
+          .to_return(status: 200, body: response)
       end
 
       def stub_email_alert_api_has_subscriber_list(attributes)

--- a/lib/gds_api/test_helpers/email_alert_api.rb
+++ b/lib/gds_api/test_helpers/email_alert_api.rb
@@ -271,7 +271,7 @@ module GdsApi
             "id" => id,
             "frequency" => frequency,
             "source" => "user_signed_up",
-            "ended_at" => ended ? Time.now.rfc3339 : nil,
+            "ended_at" => ended ? Time.now.to_datetime.rfc3339 : nil,
             "ended_reason" => ended ? "unsubscribed" : nil,
             "subscriber" => {
               "id" => subscriber_id,

--- a/test/email_alert_api_test.rb
+++ b/test/email_alert_api_test.rb
@@ -79,6 +79,14 @@ describe GdsApi::EmailAlertApi do
 
         assert_equal("weekly", subscription_attrs.fetch("frequency"))
       end
+
+      it "returns the subscription attributes on /latest" do
+        subscription_attrs = api_client.get_latest_matching_subscription(1)
+          .to_hash
+          .fetch("subscription")
+
+         assert_equal(1, subscription_attrs.fetch("id"))
+      end
     end
   end
 


### PR DESCRIPTION
Trello card: https://trello.com/c/VlnvU2Dl
Depended on by: https://github.com/alphagov/email-alert-frontend/pull/474 (please read that for more context)

## What
- Adds a `stub_email_alert_api_has_subscriptions` method, which takes an array of subscriptions to stub, so that we can test [like so](https://github.com/alphagov/email-alert-frontend/pull/474/files#diff-20c575b223c5b129c1750d0f400abda8R64).
- Ensures that `stub_email_alert_api_has_subscription` stubs the '/latest' endpoint (this is needed if we're only stubbing one subscription response).
- Refactors the shared code between these methods into a new `fill_gaps_with_default_values` method.
- Writes tests for `stub_email_alert_api_has_subscriptions`.

## Why
We added a `get_latest_matching_subscription` method in https://github.com/alphagov/gds-api-adapters/pull/928 (v59.3.0), which takes a subscription ID and returns the latest matching subscription response (e.g. a user changing frequency from Daily to Weekly, if we query '/latest' on the Daily subscription, it will return the Weekly one as that is the most recent).

Consequently, the return value of '/latest' depends upon whether or not a newer subscription has been stubbed. It was very difficult / hacky / impossible to test the '/latest' method behaviour with the `get_latest_matching_subscription` method alone, so I've added a `stub_email_alert_api_has_subscriptions` which takes an array of subscriptions and stubs them in the order they are added.

I.e. if you pass `stub_email_alert_api_has_subscriptions([subscription1, subscription2])` and then query '/latest' on `subscription1`, the response for `subscription2` should be returned.

## Note
It was quite difficult to write 'clean' code here because the `stub_email_alert_api_has_subscription` method takes three parameters (`id`, `frequency`, `'hash of options'`), which means you cannot pass `{ id: 1, frequency: 'weekly', ended: false }` etc directly but have to instead remove the options that are not explicitly allowed in that third parameter.

Consequently, I was unable to simply call `stub_email_alert_api_has_subscription` from within `stub_email_alert_api_has_subscriptions` without hacking the options parameter, and it was cleaner to simply implement the `stub_request` method in place. I also have had to return `[id, parameters]`, rather than simply `parameters` (containing `:id`) as again, this otherwise leads to a `ArgumentError: unknown keyword: id`.

In the long term, it would be great to update `stub_email_alert_api_has_subscription` to take a single hash rather than 3 params, but this will involve a change to the email-alert-frontend tests which rely upon the method. Doing this should delete several lines of code and improve code readability and consistency.