### PR TITLE
Add combine_mode param to find_subscriber_list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Adds `combine_mode` parameter to Email Alert API `find_subscriber_list` method
+
 # 59.4.0
 
 * Adds `stub_email_alert_api_has_subscriptions` test helper method.

--- a/lib/gds_api/email_alert_api.rb
+++ b/lib/gds_api/email_alert_api.rb
@@ -25,6 +25,7 @@ class GdsApi::EmailAlertApi < GdsApi::Base
     email_document_supertype = attributes["email_document_supertype"]
     government_document_supertype = attributes["government_document_supertype"]
     gov_delivery_id = attributes["gov_delivery_id"]
+    combine_mode = attributes["combine_mode"]
 
     if tags && links
       message = "please provide either tags or links (or neither), but not both"
@@ -38,6 +39,7 @@ class GdsApi::EmailAlertApi < GdsApi::Base
     params[:email_document_supertype] = email_document_supertype if email_document_supertype
     params[:government_document_supertype] = government_document_supertype if government_document_supertype
     params[:gov_delivery_id] = gov_delivery_id if gov_delivery_id
+    params[:combine_mode] = combine_mode if combine_mode
 
     query_string = nested_query_string(params)
     get_json("#{endpoint}/subscriber-lists?" + query_string)


### PR DESCRIPTION
We need to ensure that we can differentiate between a
subscriber list with the same facets but different
combine_modes when checking if they exist.
This ensures that combine_mode is passed so
email-alert-api can differentiate between the two

Trello: https://trello.com/c/y6ZhETsr/130-implement-a-joined-subscriber-list-model-in-email-alert-api-recommended-%F0%9F%8D%90