### PR TITLE
Allow stubbing of email-alert-api requests that use combine_mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 59.5.1
 
 * Adds `combine_mode` parameter to Email Alert API test helpers
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Adds `combine_mode` parameter to Email Alert API test helpers
+
 # 59.5.0
 
 * Adds `combine_mode` parameter to Email Alert API `find_subscriber_list` method

--- a/lib/gds_api/test_helpers/email_alert_api.rb
+++ b/lib/gds_api/test_helpers/email_alert_api.rb
@@ -380,6 +380,7 @@ module GdsApi
           government_document_supertype = attributes["government_document_supertype"]
           gov_delivery_id = attributes["gov_delivery_id"]
           content_purpose_supergroup = attributes["content_purpose_supergroup"]
+          combine_mode = attributes["combine_mode"]
 
           params = {}
           params[:tags] = tags if tags
@@ -389,6 +390,7 @@ module GdsApi
           params[:government_document_supertype] = government_document_supertype if government_document_supertype
           params[:gov_delivery_id] = gov_delivery_id if gov_delivery_id
           params[:content_purpose_supergroup] = content_purpose_supergroup if content_purpose_supergroup
+          params[:combine_mode] = combine_mode if combine_mode
 
           query = Rack::Utils.build_nested_query(params)
         end


### PR DESCRIPTION
Add `combine_mode` parameter to `build_subscriber_lists_url` to allow us to stub requests to email-alert-api where a value for `combine_mode` has been specified.