### PR TITLE
Forward X-Govuk-Authenticated-User-Organisation header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+* Adds middleware to allow the header `X-Govuk-Authenticated-User-Organisation`
+  to be passed along to content-store.
+
 # 59.5.1
 
 * Adds `combine_mode` parameter to Email Alert API test helpers

--- a/lib/gds_api/railtie.rb
+++ b/lib/gds_api/railtie.rb
@@ -17,6 +17,11 @@ module GdsApi
       app.middleware.use GdsApi::GovukHeaderSniffer, 'HTTP_X_GOVUK_AUTHENTICATED_USER'
     end
 
+    initializer "gds_api.initialize_govuk_authenticated_user_organisation_sniffer" do |app|
+      Rails.logger.info "Using middleware GdsApi::GovukHeaderSniffer to sniff for X-Govuk-Authenticated-User-Organisation header"
+      app.middleware.use GdsApi::GovukHeaderSniffer, 'HTTP_X_GOVUK_AUTHENTICATED_USER_ORGANISATION'
+    end
+
     initializer "gds_api.initialize_govuk_content_id_sniffer" do |app|
       Rails.logger.info "Using middleware GdsApi::GovukHeaderSniffer to sniff for GOVUK-Auth-Bypass-Id header"
       app.middleware.use GdsApi::GovukHeaderSniffer, 'HTTP_GOVUK_AUTH_BYPASS_ID'

--- a/lib/gds_api/railtie.rb
+++ b/lib/gds_api/railtie.rb
@@ -13,7 +13,7 @@ module GdsApi
     end
 
     initializer "gds_api.initialize_govuk_authenticated_user_sniffer" do |app|
-      Rails.logger.info "Using middleware GdsApi::GovukHeaderSniffer to sniff for X-GOVUK-Authenticated-User header"
+      Rails.logger.info "Using middleware GdsApi::GovukHeaderSniffer to sniff for X-Govuk-Authenticated-User header"
       app.middleware.use GdsApi::GovukHeaderSniffer, 'HTTP_X_GOVUK_AUTHENTICATED_USER'
     end
 
@@ -23,7 +23,7 @@ module GdsApi
     end
 
     initializer "gds_api.initialize_govuk_content_id_sniffer" do |app|
-      Rails.logger.info "Using middleware GdsApi::GovukHeaderSniffer to sniff for GOVUK-Auth-Bypass-Id header"
+      Rails.logger.info "Using middleware GdsApi::GovukHeaderSniffer to sniff for Govuk-Auth-Bypass-Id header"
       app.middleware.use GdsApi::GovukHeaderSniffer, 'HTTP_GOVUK_AUTH_BYPASS_ID'
     end
   end


### PR DESCRIPTION
This middleware is added to allow
`X-Govuk-Authenticated-User-Organisation` to be passed to the
content-store when a user try's to access the draft gov.uk stack.

This header is passed from the authenticating-proxy after a user is
authenticated against signon, it contains the users organisation
content-id. This is needed as content-publisher is changing the way
access limiting of a document works by storing the access limited
organisation on the piece of content instead of storing all the users
uid's for an organisation on the content, although this will be still
possible.

Trello:
https://trello.com/c/wxp1XkSg/969-update-govuk-to-support-access-limiting-by-organisation