### PR TITLE
Remove non-required pact field

### DIFF
--- a/test/publishing_api_v2_test.rb
+++ b/test/publishing_api_v2_test.rb
@@ -380,7 +380,6 @@ describe GdsApi::PublishingApiV2 do
                 "rendering_app" => Pact.like("frontend"),
                 "locale" => Pact.like("en"),
                 "routes" => Pact.like([{}]),
-                "public_updated_at" => Pact.like("2015-07-30T13:58:11.000Z"),
                 "details" => Pact.like({}),
                 "publication_state" => "draft"
               },


### PR DESCRIPTION
The Publishing API does not always return a public_updated_at field for
draft items, it is only present on editions that have already been
published. This test begins to fail for a FactoryBot change where
public_updated_at is not set by default.