### PR TITLE
Use debug level for logger when forwarding headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Adds middleware to allow the header `X-Govuk-Authenticated-User-Organisation`
   to be passed along to content-store.
+* Changes logging level about header forwarding from info to debug
 
 # 59.5.1
 

--- a/lib/gds_api/railtie.rb
+++ b/lib/gds_api/railtie.rb
@@ -3,27 +3,27 @@ require_relative 'middleware/govuk_header_sniffer'
 module GdsApi
   class Railtie < Rails::Railtie
     initializer "gds_api.initialize_govuk_request_id_sniffer" do |app|
-      Rails.logger.info "Using middleware GdsApi::GovukHeaderSniffer to sniff for GOVUK-Request-Id header"
+      Rails.logger.debug "Using middleware GdsApi::GovukHeaderSniffer to sniff for GOVUK-Request-Id header"
       app.middleware.use GdsApi::GovukHeaderSniffer, 'HTTP_GOVUK_REQUEST_ID'
     end
 
     initializer "gds_api.initialize_govuk_original_url_sniffer" do |app|
-      Rails.logger.info "Using middleware GdsApi::GovukHeaderSniffer to sniff for GOVUK-Original-Url header"
+      Rails.logger.debug "Using middleware GdsApi::GovukHeaderSniffer to sniff for GOVUK-Original-Url header"
       app.middleware.use GdsApi::GovukHeaderSniffer, 'HTTP_GOVUK_ORIGINAL_URL'
     end
 
     initializer "gds_api.initialize_govuk_authenticated_user_sniffer" do |app|
-      Rails.logger.info "Using middleware GdsApi::GovukHeaderSniffer to sniff for X-Govuk-Authenticated-User header"
+      Rails.logger.debug "Using middleware GdsApi::GovukHeaderSniffer to sniff for X-Govuk-Authenticated-User header"
       app.middleware.use GdsApi::GovukHeaderSniffer, 'HTTP_X_GOVUK_AUTHENTICATED_USER'
     end
 
     initializer "gds_api.initialize_govuk_authenticated_user_organisation_sniffer" do |app|
-      Rails.logger.info "Using middleware GdsApi::GovukHeaderSniffer to sniff for X-Govuk-Authenticated-User-Organisation header"
+      Rails.logger.debug "Using middleware GdsApi::GovukHeaderSniffer to sniff for X-Govuk-Authenticated-User-Organisation header"
       app.middleware.use GdsApi::GovukHeaderSniffer, 'HTTP_X_GOVUK_AUTHENTICATED_USER_ORGANISATION'
     end
 
     initializer "gds_api.initialize_govuk_content_id_sniffer" do |app|
-      Rails.logger.info "Using middleware GdsApi::GovukHeaderSniffer to sniff for Govuk-Auth-Bypass-Id header"
+      Rails.logger.debug "Using middleware GdsApi::GovukHeaderSniffer to sniff for Govuk-Auth-Bypass-Id header"
       app.middleware.use GdsApi::GovukHeaderSniffer, 'HTTP_GOVUK_AUTH_BYPASS_ID'
     end
   end

--- a/lib/gds_api/railtie.rb
+++ b/lib/gds_api/railtie.rb
@@ -3,12 +3,12 @@ require_relative 'middleware/govuk_header_sniffer'
 module GdsApi
   class Railtie < Rails::Railtie
     initializer "gds_api.initialize_govuk_request_id_sniffer" do |app|
-      Rails.logger.debug "Using middleware GdsApi::GovukHeaderSniffer to sniff for GOVUK-Request-Id header"
+      Rails.logger.debug "Using middleware GdsApi::GovukHeaderSniffer to sniff for Govuk-Request-Id header"
       app.middleware.use GdsApi::GovukHeaderSniffer, 'HTTP_GOVUK_REQUEST_ID'
     end
 
     initializer "gds_api.initialize_govuk_original_url_sniffer" do |app|
-      Rails.logger.debug "Using middleware GdsApi::GovukHeaderSniffer to sniff for GOVUK-Original-Url header"
+      Rails.logger.debug "Using middleware GdsApi::GovukHeaderSniffer to sniff for Govuk-Original-Url header"
       app.middleware.use GdsApi::GovukHeaderSniffer, 'HTTP_GOVUK_ORIGINAL_URL'
     end
 


### PR DESCRIPTION
The changes the existing logging at info level to debug level to prevent noisy logging. Also fixed header casing.