### PR TITLE
Adds 'content_id' to the world locations test helper

### DIFF
--- a/lib/gds_api/test_helpers/worldwide.rb
+++ b/lib/gds_api/test_helpers/worldwide.rb
@@ -107,6 +107,7 @@ module GdsApi
             "id" => "https://www.gov.uk/api/world-locations/#{slug}/organisations",
             "web_url" => "https://www.gov.uk/government/world/#{slug}#organisations"
           },
+          "content_id" => "content_id_for_#{slug}"
         }
       end
 


### PR DESCRIPTION
This recently got added, see: https://github.com/alphagov/whitehall/pull/4915