### PR TITLE
Stop publishing released version pact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+* Removes publishing pacts for released versions as they incorrectly referenced
+  unreleased changes
+
 # 60.1.0
 
 * Update get_subscriptions endpoint for email-alert-api to accept order param

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,10 +36,6 @@ node {
 def publishPacts(govuk, releasedVersion) {
   stage("Publish pacts") {
     govuk.runRakeTask("pact:publish:branch")
-
-    if (releasedVersion) {
-      govuk.runRakeTask("pact:publish:released_version")
-    }
   }
 }
 

--- a/Rakefile
+++ b/Rakefile
@@ -29,12 +29,6 @@ PactBroker::Client::PublicationTask.new("branch") do |task|
   configure_pact_broker_location(task)
 end
 
-PactBroker::Client::PublicationTask.new("released_version") do |task|
-  require 'gds_api/version'
-  task.consumer_version = GdsApi::VERSION
-  configure_pact_broker_location(task)
-end
-
 desc "Run the linter against changed files"
 task :lint do
   sh "bundle exec govuk-lint-ruby --format clang lib test"


### PR DESCRIPTION
There was an intention that we would have pact versions stored that
reflected each version of the gem that was published. So we have a pact
for version 59.5.1 of GDS API Adapters published [1] and that correlates
to version 59.5.1 of the gem.

This however is incorrect, the pact is published any time master builds
which is often numerous times before a release. This means that the
pacts are overridden with changes made after their release.

To resolve this we could set up some sort of checks to see if the pact
is already published or not but this feels unnecessary since it doesn't
appear that Publishing API uses any of these.

[1]: https://pact-broker.cloudapps.digital/hal-browser/browser.html#/pacticipants/GDS%20API%20Adapters/versions/59.5.1