### PR TITLE
Rename the Email Alert API send_alert method to create_content_change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   related test helper methods) to reflect a change in the underling endpoint.
   **Note:** this is a breaking change for users of the Email Alert API
   adapters.
+* Adds `create_email` Email Alert API method to send individual emails.
 
 # 59.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Unreleased
+
+* Renames the Email Alert API `send_alert` method to `create_content_change` (and
+  related test helper methods) to reflect a change in the underling endpoint.
+  **Note:** this is a breaking change for users of the Email Alert API
+  adapters.
+
 # 59.6.0
 
 * Adds content_id to worldwide location test helper

--- a/lib/gds_api/email_alert_api.rb
+++ b/lib/gds_api/email_alert_api.rb
@@ -62,7 +62,7 @@ class GdsApi::EmailAlertApi < GdsApi::Base
   # Send email
   #
   # @param email_params [Hash] address, subject, body
-  def send_email(email_params)
+  def create_email(email_params)
     post_json("#{endpoint}/emails", email_params)
   end
 

--- a/lib/gds_api/email_alert_api.rb
+++ b/lib/gds_api/email_alert_api.rb
@@ -52,11 +52,11 @@ class GdsApi::EmailAlertApi < GdsApi::Base
     post_json("#{endpoint}/subscriber-lists", attributes)
   end
 
-  # Post notification
+  # Post a content change
   #
-  # @param publication [Hash] Valid publication attributes
-  def send_alert(publication, headers = {})
-    post_json("#{endpoint}/notifications", publication, headers)
+  # @param content_change [Hash] Valid content change attributes
+  def create_content_change(content_change, headers = {})
+    post_json("#{endpoint}/content-changes", content_change, headers)
   end
 
   # Send email

--- a/lib/gds_api/test_helpers/email_alert_api.rb
+++ b/lib/gds_api/test_helpers/email_alert_api.rb
@@ -148,8 +148,8 @@ module GdsApi
           .to_return(status: 202, body: {}.to_json)
       end
 
-      def stub_email_alert_api_accepts_alert
-        stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/notifications")
+      def stub_email_alert_api_accepts_content_change
+        stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/content-changes")
           .to_return(status: 202, body: {}.to_json)
       end
 
@@ -162,7 +162,7 @@ module GdsApi
         stub_request(:any, %r{\A#{EMAIL_ALERT_API_ENDPOINT}})
       end
 
-      def assert_email_alert_sent(attributes = nil)
+      def assert_email_alert_api_content_change_created(attributes = nil)
         if attributes
           matcher = ->(request) do
             payload = JSON.parse(request.body)
@@ -170,7 +170,7 @@ module GdsApi
           end
         end
 
-        assert_requested(:post, "#{EMAIL_ALERT_API_ENDPOINT}/notifications", times: 1, &matcher)
+        assert_requested(:post, "#{EMAIL_ALERT_API_ENDPOINT}/content-changes", times: 1, &matcher)
       end
 
       def stub_email_alert_api_has_notifications(notifications, start_at = nil)
@@ -288,7 +288,6 @@ module GdsApi
       alias_method :email_alert_api_creates_subscriber_list, :stub_email_alert_api_creates_subscriber_list
       alias_method :email_alert_api_refuses_to_create_subscriber_list, :stub_email_alert_api_refuses_to_create_subscriber_list
       alias_method :email_alert_api_accepts_unpublishing_message, :stub_email_alert_api_accepts_unpublishing_message
-      alias_method :email_alert_api_accepts_alert, :stub_email_alert_api_accepts_alert
       alias_method :email_alert_api_has_notifications, :stub_email_alert_api_has_notifications
       alias_method :email_alert_api_has_notification, :stub_email_alert_api_has_notification
       alias_method :email_alert_api_unsubscribes_a_subscription, :stub_email_alert_api_unsubscribes_a_subscription

--- a/lib/gds_api/test_helpers/email_alert_api.rb
+++ b/lib/gds_api/test_helpers/email_alert_api.rb
@@ -153,7 +153,7 @@ module GdsApi
           .to_return(status: 202, body: {}.to_json)
       end
 
-      def stub_email_alert_api_accepts_send_email
+      def stub_email_alert_api_accepts_email
         stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/emails")
           .to_return(status: 202, body: {}.to_json)
       end

--- a/lib/gds_api/test_helpers/email_alert_api.rb
+++ b/lib/gds_api/test_helpers/email_alert_api.rb
@@ -173,27 +173,6 @@ module GdsApi
         assert_requested(:post, "#{EMAIL_ALERT_API_ENDPOINT}/content-changes", times: 1, &matcher)
       end
 
-      def stub_email_alert_api_has_notifications(notifications, start_at = nil)
-        url = "#{EMAIL_ALERT_API_ENDPOINT}/notifications"
-        url += "?start_at=#{start_at}" if start_at
-        url_regexp = Regexp.new("^#{Regexp.escape(url)}$")
-
-        stub_request(:get, url_regexp)
-          .to_return(
-            status: 200,
-            body: notifications.to_json
-          )
-      end
-
-      def stub_email_alert_api_has_notification(notification)
-        url = "#{EMAIL_ALERT_API_ENDPOINT}/notifications/#{notification['web_service_bulletin']['to_param']}"
-
-        stub_request(:get, url).to_return(
-          status: 200,
-          body: notification.to_json
-        )
-      end
-
       def stub_email_alert_api_unsubscribes_a_subscription(uuid)
         stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/unsubscribe/#{uuid}")
           .with(body: "{}")
@@ -288,8 +267,6 @@ module GdsApi
       alias_method :email_alert_api_creates_subscriber_list, :stub_email_alert_api_creates_subscriber_list
       alias_method :email_alert_api_refuses_to_create_subscriber_list, :stub_email_alert_api_refuses_to_create_subscriber_list
       alias_method :email_alert_api_accepts_unpublishing_message, :stub_email_alert_api_accepts_unpublishing_message
-      alias_method :email_alert_api_has_notifications, :stub_email_alert_api_has_notifications
-      alias_method :email_alert_api_has_notification, :stub_email_alert_api_has_notification
       alias_method :email_alert_api_unsubscribes_a_subscription, :stub_email_alert_api_unsubscribes_a_subscription
       alias_method :email_alert_api_has_no_subscription_for_uuid, :stub_email_alert_api_has_no_subscription_for_uuid
       alias_method :email_alert_api_unsubscribes_a_subscriber, :stub_email_alert_api_unsubscribes_a_subscriber

--- a/test/email_alert_api_test.rb
+++ b/test/email_alert_api_test.rb
@@ -49,10 +49,10 @@ describe GdsApi::EmailAlertApi do
   end
 
   it "posts a new email" do
-    stub_email_alert_api_accepts_send_email
+    stub_email_alert_api_accepts_email
     email_params = { address: 'test@test.com', subject: 'Subject', body: 'Description of thing' }
 
-    assert api_client.send_email(email_params)
+    assert api_client.create_email(email_params)
 
     assert_requested(:post, "#{base_url}/emails", body: email_params.to_json)
   end

--- a/test/email_alert_api_test.rb
+++ b/test/email_alert_api_test.rb
@@ -26,24 +26,24 @@ describe GdsApi::EmailAlertApi do
     }
 
     before do
-      stub_email_alert_api_accepts_alert
+      stub_email_alert_api_accepts_content_change
     end
 
     it "posts a new alert" do
-      assert api_client.send_alert(publication_params)
+      assert api_client.create_content_change(publication_params)
 
-      assert_requested(:post, "#{base_url}/notifications", body: publication_params.to_json)
+      assert_requested(:post, "#{base_url}/content-changes", body: publication_params.to_json)
     end
 
     it "returns the an empty response" do
-      assert api_client.send_alert(publication_params).to_hash.empty?
+      assert api_client.create_content_change(publication_params).to_hash.empty?
     end
 
     describe "when custom headers are passed in" do
       it "posts a new alert with the custom headers" do
-        assert api_client.send_alert(publication_params, govuk_request_id: 'aaaaaaa-1111111')
+        assert api_client.create_content_change(publication_params, govuk_request_id: 'aaaaaaa-1111111')
 
-        assert_requested(:post, "#{base_url}/notifications", body: publication_params.to_json, headers: { 'Govuk-Request-Id' => 'aaaaaaa-1111111' })
+        assert_requested(:post, "#{base_url}/content-changes", body: publication_params.to_json, headers: { 'Govuk-Request-Id' => 'aaaaaaa-1111111' })
       end
     end
   end

--- a/test/test_helpers/email_alert_api_test.rb
+++ b/test/test_helpers/email_alert_api_test.rb
@@ -8,17 +8,17 @@ describe GdsApi::TestHelpers::EmailAlertApi do
   let(:base_api_url) { Plek.current.find("email-alert-api") }
   let(:email_alert_api) { GdsApi::EmailAlertApi.new(base_api_url) }
 
-  describe "#assert_email_alert_sent" do
+  describe "#assert_email_alert_api_content_change_created" do
     before { stub_any_email_alert_api_call }
 
     it "matches a post request with any empty attributes by default" do
-      email_alert_api.send_alert("foo" => "bar")
-      assert_email_alert_sent
+      email_alert_api.create_content_change("foo" => "bar")
+      assert_email_alert_api_content_change_created
     end
 
     it "matches a post request subset of attributes" do
-      email_alert_api.send_alert("foo" => "bar", "baz" => "qux")
-      assert_email_alert_sent("foo" => "bar")
+      email_alert_api.create_content_change("foo" => "bar", "baz" => "qux")
+      assert_email_alert_api_content_change_created("foo" => "bar")
     end
   end
 end


### PR DESCRIPTION
It also renames the associated test helper method. This reflects a change in the underling endpoint from `/notifications` to `/content-changes`. https://github.com/alphagov/email-alert-api/pull/931

This is a breaking change for users of the Email Alert API adapters. I've decided to make it a breaking change rather than deprecrate the old method because there aren't too many apps which talk to email-alert-api so it should be pretty quick to fix them one by one.

[Trello Card](https://trello.com/c/5rtAmAjc/54-finish-the-messages-endpoint-work-in-email-alert-api)