### PR TITLE
Add email-alert-api endpoint to send an email

### DIFF
--- a/lib/gds_api/email_alert_api.rb
+++ b/lib/gds_api/email_alert_api.rb
@@ -59,6 +59,13 @@ class GdsApi::EmailAlertApi < GdsApi::Base
     post_json("#{endpoint}/notifications", publication, headers)
   end
 
+  # Send email
+  #
+  # @param email_params [Hash] address, subject, body
+  def send_email(email_params)
+    post_json("#{endpoint}/emails", email_params)
+  end
+
   # Unpublishing alert
   #
   # @param message [Hash] content_id

--- a/lib/gds_api/test_helpers/email_alert_api.rb
+++ b/lib/gds_api/test_helpers/email_alert_api.rb
@@ -153,6 +153,11 @@ module GdsApi
           .to_return(status: 202, body: {}.to_json)
       end
 
+      def stub_email_alert_api_accepts_send_email
+        stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/emails")
+          .to_return(status: 202, body: {}.to_json)
+      end
+
       def stub_any_email_alert_api_call
         stub_request(:any, %r{\A#{EMAIL_ALERT_API_ENDPOINT}})
       end

--- a/test/email_alert_api_test.rb
+++ b/test/email_alert_api_test.rb
@@ -48,6 +48,15 @@ describe GdsApi::EmailAlertApi do
     end
   end
 
+  it "posts a new email" do
+    stub_email_alert_api_accepts_send_email
+    email_params = { address: 'test@test.com', subject: 'Subject', body: 'Description of thing' }
+
+    assert api_client.send_email(email_params)
+
+    assert_requested(:post, "#{base_url}/emails", body: email_params.to_json)
+  end
+
   let(:unpublish_message) {
     {
       "content_id" => "content-id"


### PR DESCRIPTION
Related PR:
https://github.com/alphagov/email-alert-api/pull/935

Trello:
https://trello.com/c/68dWZW80/46-create-endpoint-on-email-alert-api-to-send-single-email