### PR TITLE
Release version 60

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 60.0.0
 
 * Renames the Email Alert API `send_alert` method to `create_content_change` (and
   related test helper methods) to reflect a change in the underling endpoint.

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = '59.6.0'.freeze
+  VERSION = '60.0.0'.freeze
 end


### PR DESCRIPTION
Includes a breaking rename of the `send_alert` Email Alert API method to `create_content_change` #948, a new `create_email` method #949 and a new `create_message` #952.