### PR TITLE
Add `create_message` method to send out message emails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
   **Note:** this is a breaking change for users of the Email Alert API
   adapters.
 * Adds `create_email` Email Alert API method to send individual emails.
+* Adds `create_message` Email Alert API method to send message emails out to a
+  subscriber list.
 
 # 59.6.0
 

--- a/lib/gds_api/email_alert_api.rb
+++ b/lib/gds_api/email_alert_api.rb
@@ -59,6 +59,13 @@ class GdsApi::EmailAlertApi < GdsApi::Base
     post_json("#{endpoint}/content-changes", content_change, headers)
   end
 
+  # Post a message
+  #
+  # @param message [Hash] Valid message attributes
+  def create_message(message, headers = {})
+    post_json("#{endpoint}/messages", message, headers)
+  end
+
   # Send email
   #
   # @param email_params [Hash] address, subject, body

--- a/lib/gds_api/test_helpers/email_alert_api.rb
+++ b/lib/gds_api/test_helpers/email_alert_api.rb
@@ -153,6 +153,11 @@ module GdsApi
           .to_return(status: 202, body: {}.to_json)
       end
 
+      def stub_email_alert_api_accepts_message
+        stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/messages")
+          .to_return(status: 202, body: {}.to_json)
+      end
+
       def stub_email_alert_api_accepts_email
         stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/emails")
           .to_return(status: 202, body: {}.to_json)
@@ -171,6 +176,17 @@ module GdsApi
         end
 
         assert_requested(:post, "#{EMAIL_ALERT_API_ENDPOINT}/content-changes", times: 1, &matcher)
+      end
+
+      def assert_email_alert_api_message_created(attributes = nil)
+        if attributes
+          matcher = ->(request) do
+            payload = JSON.parse(request.body)
+            payload.select { |k, _| attributes.key?(k) } == attributes
+          end
+        end
+
+        assert_requested(:post, "#{EMAIL_ALERT_API_ENDPOINT}/messages", times: 1, &matcher)
       end
 
       def stub_email_alert_api_unsubscribes_a_subscription(uuid)

--- a/test/email_alert_api_test.rb
+++ b/test/email_alert_api_test.rb
@@ -15,7 +15,7 @@ describe GdsApi::EmailAlertApi do
     }
   }
 
-  describe "alerts" do
+  describe "content changes" do
     let(:subject) { "Email subject" }
     let(:publication_params) {
       {
@@ -45,6 +45,31 @@ describe GdsApi::EmailAlertApi do
 
         assert_requested(:post, "#{base_url}/content-changes", body: publication_params.to_json, headers: { 'Govuk-Request-Id' => 'aaaaaaa-1111111' })
       end
+    end
+  end
+
+  describe "messages" do
+    let(:subject) { "Email subject" }
+    let(:message_params) {
+      {
+        "subject" => subject,
+        "body" => "Body",
+        "tags" => tags,
+      }
+    }
+
+    before do
+      stub_email_alert_api_accepts_message
+    end
+
+    it "posts a new message" do
+      assert api_client.create_message(message_params)
+
+      assert_requested(:post, "#{base_url}/messages", body: message_params.to_json)
+    end
+
+    it "returns the an empty response" do
+      assert api_client.create_message(message_params).to_hash.empty?
     end
   end
 

--- a/test/test_helpers/email_alert_api_test.rb
+++ b/test/test_helpers/email_alert_api_test.rb
@@ -21,4 +21,18 @@ describe GdsApi::TestHelpers::EmailAlertApi do
       assert_email_alert_api_content_change_created("foo" => "bar")
     end
   end
+
+  describe "#assert_email_alert_api_message_created" do
+    before { stub_any_email_alert_api_call }
+
+    it "matches a post request with any empty attributes by default" do
+      email_alert_api.create_message("foo" => "bar")
+      assert_email_alert_api_message_created
+    end
+
+    it "matches a post request subset of attributes" do
+      email_alert_api.create_message("foo" => "bar", "baz" => "qux")
+      assert_email_alert_api_message_created("foo" => "bar")
+    end
+  end
 end


### PR DESCRIPTION
This will correspond to the new `/messages` endpoint being added to Email Alert API which will be used to send out custom emails to subscriber lists.

The endpoint will be added in https://github.com/alphagov/email-alert-api/pull/936.

[Trello Card](https://trello.com/c/5rtAmAjc/54-finish-the-messages-endpoint-work-in-email-alert-api)