### PR TITLE
Update gds-api-adapters for get_subscriptions endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Update get_subscriptions endpoint for email-alert-api to accept order param
+
 # 60.0.0
 
 * Renames the Email Alert API `send_alert` method to `create_content_change` (and

--- a/lib/gds_api/email_alert_api.rb
+++ b/lib/gds_api/email_alert_api.rb
@@ -183,10 +183,15 @@ class GdsApi::EmailAlertApi < GdsApi::Base
   # Get Subscriptions for a Subscriber
   #
   # @param [integer] Subscriber id
+  # @param [string] Subscription order - title, created_at
   #
   # @return [Hash] subscriber, subscriptions
-  def get_subscriptions(id:)
-    get_json("#{endpoint}/subscribers/#{id}/subscriptions")
+  def get_subscriptions(id:, order: nil)
+    if order
+      get_json("#{endpoint}/subscribers/#{id}/subscriptions?order=#{order}")
+    else
+      get_json("#{endpoint}/subscribers/#{id}/subscriptions")
+    end
   end
 
   # Patch a Subscriber

--- a/lib/gds_api/test_helpers/email_alert_api.rb
+++ b/lib/gds_api/test_helpers/email_alert_api.rb
@@ -32,8 +32,8 @@ module GdsApi
           .to_return(status: 404)
       end
 
-      def stub_email_alert_api_has_subscriber_subscriptions(id, address)
-        stub_request(:get, "#{EMAIL_ALERT_API_ENDPOINT}/subscribers/#{id}/subscriptions")
+      def stub_email_alert_api_has_subscriber_subscriptions(id, address, order)
+        stub_request(:get, "#{EMAIL_ALERT_API_ENDPOINT}/subscribers/#{id}/subscriptions?order=#{order}")
           .to_return(
             status: 200,
             body: get_subscriber_subscriptions_response(id, address).to_json,

--- a/test/email_alert_api_test.rb
+++ b/test/email_alert_api_test.rb
@@ -597,8 +597,8 @@ describe GdsApi::EmailAlertApi do
 
   describe "get_subscriptions when a subscriber exists" do
     it "returns it" do
-      stub_email_alert_api_has_subscriber_subscriptions(1, "test@example.com")
-      api_response = api_client.get_subscriptions(id: 1)
+      stub_email_alert_api_has_subscriber_subscriptions(1, "test@example.com", "-title")
+      api_response = api_client.get_subscriptions(id: 1, order: "-title")
       assert_equal(200, api_response.code)
       parsed_body = api_response.to_h
       assert_equal("some-thing", parsed_body["subscriptions"][0]["subscriber_list"]["slug"])


### PR DESCRIPTION
This now allows an order param to be passed in.

Depends on PR:
https://github.com/alphagov/email-alert-api/pull/977