### PR TITLE
Remove Search#advanced_search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Removes publishing pacts for released versions as they incorrectly referenced
   unreleased changes
+* Removes `Search#advanced_search`
 
 # 60.1.0
 

--- a/lib/gds_api/search.rb
+++ b/lib/gds_api/search.rb
@@ -111,16 +111,6 @@ module GdsApi
       end
     end
 
-    # Advanced search.
-    #
-    # @deprecated Only in use by Whitehall. Use the `#search` method.
-    def advanced_search(args)
-      raise ArgumentError.new("Args cannot be blank") if args.nil? || args.empty?
-
-      request_path = "#{base_url}/advanced_search?#{Rack::Utils.build_nested_query(args)}"
-      get_json(request_path)
-    end
-
     # Add a document to the search index.
     #
     # @param type [String] The search-api document type.

--- a/test/rummager_test.rb
+++ b/test/rummager_test.rb
@@ -3,66 +3,8 @@ require "gds_api/rummager"
 
 describe GdsApi::Rummager do
   before(:each) do
-    stub_request(:get, /example.com\/advanced_search/).to_return(body: "[]")
     stub_request(:get, /example.com\/search/).to_return(body: "[]")
     stub_request(:get, /example.com\/batch_search/).to_return(body: "[]")
-  end
-
-  # tests for #advanced_search
-
-  it "#advanced_search should raise an exception if the service at the search URI returns a 500" do
-    stub_request(:get, /example.com\/advanced_search/).to_return(status: [500, "Internal Server Error"])
-    assert_raises(GdsApi::HTTPServerError) do
-      GdsApi::Rummager.new("http://example.com").advanced_search(keywords: "query")
-    end
-  end
-
-  it "#advanced_search should raise an exception if the service at the search URI returns a 404" do
-    stub_request(:get, /example.com\/advanced_search/).to_return(status: [404, "Not Found"])
-    assert_raises(GdsApi::HTTPNotFound) do
-      GdsApi::Rummager.new("http://example.com").advanced_search(keywords: "query")
-    end
-  end
-
-  it "#advanced_search should raise an exception if the service at the search URI times out" do
-    stub_request(:get, /example.com\/advanced_search/).to_timeout
-    assert_raises(GdsApi::TimedOutException) do
-      GdsApi::Rummager.new("http://example.com").advanced_search(keywords: "query")
-    end
-  end
-
-  it "#advanced_search should return the search deserialized from json" do
-    search_results = [{ "title" => "document-title" }]
-    stub_request(:get, /example.com\/advanced_search/).to_return(body: search_results.to_json)
-    results = GdsApi::Rummager.new("http://example.com").advanced_search(keywords: "query")
-
-    assert_equal search_results, results.to_hash
-  end
-
-  it "#advanced_search should return an empty set of results without making request if arguments are empty" do
-    assert_raises(ArgumentError) do
-      GdsApi::Rummager.new("http://example.com").advanced_search({})
-    end
-  end
-
-  it "#advanced_search should return an empty set of results without making request if arguments is nil" do
-    assert_raises(ArgumentError) do
-      GdsApi::Rummager.new("http://example.com").advanced_search(nil)
-    end
-  end
-
-  it "#advanced_search should request the search results in JSON format" do
-    GdsApi::Rummager.new("http://example.com").advanced_search(keywords: "query")
-
-    assert_requested :get, /.*/, headers: { "Accept" => "application/json" }
-  end
-
-  it "#advanced_search should issue a request for all the params supplied" do
-    GdsApi::Rummager.new("http://example.com").advanced_search(keywords: "query & stuff", topics: %w(1 2), order: { public_timestamp: "desc" })
-
-    assert_requested :get, /keywords=query%20%26%20stuff/
-    assert_requested :get, /topics\[\]=1&topics\[\]=2/
-    assert_requested :get, /order\[public_timestamp\]=desc/
   end
 
   # tests for search

--- a/test/search.rb
+++ b/test/search.rb
@@ -3,66 +3,8 @@ require "gds_api/search"
 
 describe GdsApi::Search do
   before(:each) do
-    stub_request(:get, /example.com\/advanced_search/).to_return(body: "[]")
     stub_request(:get, /example.com\/search/).to_return(body: "[]")
     stub_request(:get, /example.com\/batch_search/).to_return(body: "[]")
-  end
-
-  # tests for #advanced_search
-
-  it "#advanced_search should raise an exception if the service at the search URI returns a 500" do
-    stub_request(:get, /example.com\/advanced_search/).to_return(status: [500, "Internal Server Error"])
-    assert_raises(GdsApi::HTTPServerError) do
-      GdsApi::Search.new("http://example.com").advanced_search(keywords: "query")
-    end
-  end
-
-  it "#advanced_search should raise an exception if the service at the search URI returns a 404" do
-    stub_request(:get, /example.com\/advanced_search/).to_return(status: [404, "Not Found"])
-    assert_raises(GdsApi::HTTPNotFound) do
-      GdsApi::Search.new("http://example.com").advanced_search(keywords: "query")
-    end
-  end
-
-  it "#advanced_search should raise an exception if the service at the search URI times out" do
-    stub_request(:get, /example.com\/advanced_search/).to_timeout
-    assert_raises(GdsApi::TimedOutException) do
-      GdsApi::Search.new("http://example.com").advanced_search(keywords: "query")
-    end
-  end
-
-  it "#advanced_search should return the search deserialized from json" do
-    search_results = [{ "title" => "document-title" }]
-    stub_request(:get, /example.com\/advanced_search/).to_return(body: search_results.to_json)
-    results = GdsApi::Search.new("http://example.com").advanced_search(keywords: "query")
-
-    assert_equal search_results, results.to_hash
-  end
-
-  it "#advanced_search should return an empty set of results without making request if arguments are empty" do
-    assert_raises(ArgumentError) do
-      GdsApi::Search.new("http://example.com").advanced_search({})
-    end
-  end
-
-  it "#advanced_search should return an empty set of results without making request if arguments is nil" do
-    assert_raises(ArgumentError) do
-      GdsApi::Search.new("http://example.com").advanced_search(nil)
-    end
-  end
-
-  it "#advanced_search should request the search results in JSON format" do
-    GdsApi::Search.new("http://example.com").advanced_search(keywords: "query")
-
-    assert_requested :get, /.*/, headers: { "Accept" => "application/json" }
-  end
-
-  it "#advanced_search should issue a request for all the params supplied" do
-    GdsApi::Search.new("http://example.com").advanced_search(keywords: "query & stuff", topics: %w(1 2), order: { public_timestamp: "desc" })
-
-    assert_requested :get, /keywords=query%20%26%20stuff/
-    assert_requested :get, /topics\[\]=1&topics\[\]=2/
-    assert_requested :get, /order\[public_timestamp\]=desc/
   end
 
   # tests for search


### PR DESCRIPTION
Whitehall no longer uses this endpoint (whitehall#5122), and this
endpoint is being removed from search-api (search-api#1776).

---

[Trello card](https://trello.com/c/kWUWnvcz/1120-spike-kill-off-search-apis-advanced-search-endpoint)