### PR TITLE
Bump to version 61.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 61.0.0
 
 * Removes publishing pacts for released versions as they incorrectly referenced
   unreleased changes

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = "60.1.0".freeze
+  VERSION = "61.0.0".freeze
 end


### PR DESCRIPTION
Whitehall has been deployed with the advanced search usage removed, so the gem should be updated now.