### PR TITLE
Replace govuk-lint

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,7 @@
+inherit_gem:
+  rubocop-govuk:
+    - config/default.yml
+
 AllCops:
   TargetRubyVersion: 2.3
 

--- a/Rakefile
+++ b/Rakefile
@@ -31,5 +31,5 @@ end
 
 desc "Run the linter against changed files"
 task :lint do
-  sh "bundle exec govuk-lint-ruby --format clang lib test"
+  sh "bundle exec rubocop --format clang lib test"
 end

--- a/gds-api-adapters.gemspec
+++ b/gds-api-adapters.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'climate_control', '~> 0.2'
   s.add_development_dependency 'govuk-content-schema-test-helpers', '~> 1.6'
-  s.add_development_dependency 'govuk-lint', '~> 4.2'
   s.add_development_dependency 'minitest', '~> 5.11'
   s.add_development_dependency 'minitest-around', '~> 0.5'
   s.add_development_dependency 'mocha', '~> 1.3'
@@ -39,6 +38,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rack', '~> 2.0'
   s.add_development_dependency 'rack-test'
   s.add_development_dependency 'rake', '~> 12.3'
+  s.add_development_dependency 'rubocop-govuk'
   s.add_development_dependency 'simplecov', '~> 0.16'
   s.add_development_dependency 'simplecov-rcov'
   s.add_development_dependency 'timecop', '~> 0.9'


### PR DESCRIPTION
- The GOV.UK Lint gem is deprecated in favour of using Rubocop directly
  with a set of shared configs.
- See https://github.com/alphagov/govuk-rfcs/pull/ 100 for more context.

https://trello.com/c/CdBFg6yw/1521-replace-govuk-lint-with-rubocop-govuk