### PR TITLE
Add and extend stubs for email-alert-api

### DIFF
--- a/lib/gds_api/test_helpers/email_alert_api.rb
+++ b/lib/gds_api/test_helpers/email_alert_api.rb
@@ -37,11 +37,13 @@ module GdsApi
           .to_return(status: 404)
       end
 
-      def stub_email_alert_api_has_subscriber_subscriptions(id, address, order)
-        stub_request(:get, "#{EMAIL_ALERT_API_ENDPOINT}/subscribers/#{id}/subscriptions?order=#{order}")
+      def stub_email_alert_api_has_subscriber_subscriptions(id, address, order = nil, subscriptions: nil)
+        params = order ? "?order=#{order}" : ""
+
+        stub_request(:get, "#{EMAIL_ALERT_API_ENDPOINT}/subscribers/#{id}/subscriptions#{params}")
           .to_return(
             status: 200,
-            body: get_subscriber_subscriptions_response(id, address).to_json,
+            body: get_subscriber_subscriptions_response(id, address, subscriptions: subscriptions).to_json,
           )
       end
 
@@ -348,13 +350,13 @@ module GdsApi
         }
       end
 
-      def get_subscriber_subscriptions_response(id, address)
+      def get_subscriber_subscriptions_response(id, address, subscriptions:)
         {
           "subscriber" => {
             "id" => id,
             "address" => address,
           },
-          "subscriptions" => [
+          "subscriptions" => subscriptions || [
             {
               "subscriber_id" => 1,
               "subscriber_list_id" => 1000,

--- a/lib/gds_api/test_helpers/email_alert_api.rb
+++ b/lib/gds_api/test_helpers/email_alert_api.rb
@@ -19,6 +19,11 @@ module GdsApi
           .to_return(status: 404)
       end
 
+      def stub_email_alert_api_invalid_update_subscriber(id)
+        stub_request(:patch, "#{EMAIL_ALERT_API_ENDPOINT}/subscribers/#{id}")
+          .to_return(status: 422)
+      end
+
       def stub_email_alert_api_has_updated_subscription(subscription_id, frequency)
         stub_request(:patch, "#{EMAIL_ALERT_API_ENDPOINT}/subscriptions/#{subscription_id}")
           .to_return(
@@ -238,6 +243,16 @@ module GdsApi
             status: 201,
             body: get_subscriber_response(subscriber_id, address).to_json,
           )
+      end
+
+      def stub_email_alert_api_invalid_auth_token
+        stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscribers/auth-token")
+          .to_return(status: 422)
+      end
+
+      def stub_email_alert_api_auth_token_no_subscriber
+        stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscribers/auth-token")
+          .to_return(status: 404)
       end
 
       def assert_unsubscribed(uuid)

--- a/test/test_helpers/email_alert_api_test.rb
+++ b/test/test_helpers/email_alert_api_test.rb
@@ -35,4 +35,32 @@ describe GdsApi::TestHelpers::EmailAlertApi do
       assert_email_alert_api_message_created("foo" => "bar")
     end
   end
+
+  describe "#stub_email_alert_api_has_subscriber_subscriptions" do
+    let(:id) { SecureRandom.uuid }
+    let(:address) { "test@example.com" }
+
+    it "stubs with a single subscription by default" do
+      stub_email_alert_api_has_subscriber_subscriptions(id, address)
+      result = email_alert_api.get_subscriptions(id: id)
+      assert_equal(1, result["subscriptions"].count)
+    end
+
+    it "stubs subscriptions with an optional ordering" do
+      stub_email_alert_api_has_subscriber_subscriptions(id, address, "-title")
+      result = email_alert_api.get_subscriptions(id: id, order: "-title")
+      assert_equal(1, result["subscriptions"].count)
+    end
+
+    it "stubs subscriptions with specific ones" do
+      stub_email_alert_api_has_subscriber_subscriptions(
+        id,
+        address,
+        subscriptions: %w(one two),
+      )
+
+      result = email_alert_api.get_subscriptions(id: id)
+      assert_equal(2, result["subscriptions"].count)
+    end
+  end
 end


### PR DESCRIPTION
https://trello.com/c/dIAlk2dp/278-double-opt-in-create-a-subscription-before-the-success-page

This extends one of the existing stubs to make it more flexible,
as well as adding a few more for edge case scenarios.

I was tempted to just have a generic 'stub_request' one-liner for
the edge case stubs, but on reflection think it's better if the
stubs fully communicate the realistic API behaviour.