### PR TITLE
Creates subscriber and subscription verification adapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+* BREAKING: rename Email Alert API adapter method to create auth token
+* Add Email Alert API adapter method to send subscription verification email
+
 # 61.1.0
 
 * Add stubs for email-alert-api edge cases (auth token and subscriber update)

--- a/lib/gds_api/email_alert_api.rb
+++ b/lib/gds_api/email_alert_api.rb
@@ -222,7 +222,7 @@ class GdsApi::EmailAlertApi < GdsApi::Base
 
   # Verify a subscriber has control of a provided email
   #
-  # @param [string]       address       Email address of subscriber to create token for
+  # @param [string]       address       Address to send verification email to
   # @param [string]       destination   Path on GOV.UK that subscriber will be emailed
   # @param [string, nil]  redirect      Path on GOV.UK to be encoded into the token for redirecting
   #
@@ -234,6 +234,23 @@ class GdsApi::EmailAlertApi < GdsApi::Base
       address: address,
       destination: destination,
       redirect: redirect,
+    )
+  end
+
+  # Verify a subscriber intends to be added to a subscription
+  #
+  # @param [string]       address       Address to send verification email to
+  # @param [string]       frequency     How often the subscriber wishes to be notified of new items
+  # @param [string]       topic_id      The slugs/ID for the topic being subscribed to
+  #
+  # return [Hash]  subscription
+  #
+  def send_subscription_verification_email(address:, frequency:, topic_id:)
+    post_json(
+      "#{endpoint}/subscriptions/auth-token",
+      address: address,
+      frequency: frequency,
+      topic_id: topic_id,
     )
   end
 

--- a/lib/gds_api/email_alert_api.rb
+++ b/lib/gds_api/email_alert_api.rb
@@ -220,7 +220,7 @@ class GdsApi::EmailAlertApi < GdsApi::Base
     )
   end
 
-  # Create an authentication token for a subscriber
+  # Verify a subscriber has control of a provided email
   #
   # @param [string]       address       Email address of subscriber to create token for
   # @param [string]       destination   Path on GOV.UK that subscriber will be emailed
@@ -228,7 +228,7 @@ class GdsApi::EmailAlertApi < GdsApi::Base
   #
   # @return [Hash]  subscriber
   #
-  def create_auth_token(address:, destination:, redirect: nil)
+  def send_subscriber_verification_email(address:, destination:, redirect: nil)
     post_json(
       "#{endpoint}/subscribers/auth-token",
       address: address,

--- a/lib/gds_api/test_helpers/email_alert_api.rb
+++ b/lib/gds_api/test_helpers/email_alert_api.rb
@@ -239,7 +239,8 @@ module GdsApi
         ).to_return(status: 422)
       end
 
-      def stub_email_alert_api_creates_an_auth_token(subscriber_id, address)
+
+      def stub_email_alert_api_sends_subscriber_verification_email(subscriber_id, address)
         stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscribers/auth-token")
           .to_return(
             status: 201,
@@ -247,12 +248,12 @@ module GdsApi
           )
       end
 
-      def stub_email_alert_api_invalid_auth_token
+      def stub_email_alert_api_subscriber_verification_email_invalid
         stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscribers/auth-token")
           .to_return(status: 422)
       end
 
-      def stub_email_alert_api_auth_token_no_subscriber
+      def stub_email_alert_api_subscriber_verification_email_no_subscriber
         stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscribers/auth-token")
           .to_return(status: 404)
       end
@@ -307,7 +308,6 @@ module GdsApi
       alias_method :email_alert_api_creates_a_subscription, :stub_email_alert_api_creates_a_subscription
       alias_method :email_alert_api_creates_an_existing_subscription, :stub_email_alert_api_creates_an_existing_subscription
       alias_method :email_alert_api_refuses_to_create_subscription, :stub_email_alert_api_refuses_to_create_subscription
-      alias_method :email_alert_api_creates_an_auth_token, :stub_email_alert_api_creates_an_auth_token
       alias_method :email_alert_api_has_subscriber_list_by_slug, :stub_email_alert_api_has_subscriber_list_by_slug
       alias_method :email_alert_api_does_not_have_subscriber_list_by_slug, :stub_email_alert_api_does_not_have_subscriber_list_by_slug
 

--- a/lib/gds_api/test_helpers/email_alert_api.rb
+++ b/lib/gds_api/test_helpers/email_alert_api.rb
@@ -239,6 +239,19 @@ module GdsApi
         ).to_return(status: 422)
       end
 
+      def stub_email_alert_api_sends_subscription_verification_email(address, frequency, topic_id)
+        stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscriptions/auth-token")
+          .with(
+            body: { address: address, frequency: frequency, topic_id: topic_id }.to_json,
+          ).to_return(status: 200)
+      end
+
+      def stub_email_alert_api_subscription_verification_email_invalid(address, frequency, topic_id)
+        stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscriptions/auth-token")
+          .with(
+            body: { address: address, frequency: frequency, topic_id: topic_id }.to_json,
+          ).to_return(status: 422)
+      end
 
       def stub_email_alert_api_sends_subscriber_verification_email(subscriber_id, address)
         stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscribers/auth-token")

--- a/test/email_alert_api_test.rb
+++ b/test/email_alert_api_test.rb
@@ -615,6 +615,14 @@ describe GdsApi::EmailAlertApi do
     end
   end
 
+  describe "send_subscription_verification_email" do
+    it "returns 200" do
+      stub_email_alert_api_sends_subscription_verification_email("test@example.com", "immediately", "topic")
+      api_response = api_client.send_subscription_verification_email(address: "test@example.com", frequency: "immediately", topic_id: "topic")
+      assert_equal(200, api_response.code)
+    end
+  end
+
   describe "send_subscriber_verification_email" do
     it "returns 201" do
       stub_email_alert_api_sends_subscriber_verification_email(1, "test@example.com")

--- a/test/email_alert_api_test.rb
+++ b/test/email_alert_api_test.rb
@@ -615,10 +615,10 @@ describe GdsApi::EmailAlertApi do
     end
   end
 
-  describe "create an auth token" do
+  describe "send_subscriber_verification_email" do
     it "returns 201" do
-      stub_email_alert_api_creates_an_auth_token(1, "test@example.com")
-      api_response = api_client.create_auth_token(address: 1, destination: "/test")
+      stub_email_alert_api_sends_subscriber_verification_email(1, "test@example.com")
+      api_response = api_client.send_subscriber_verification_email(address: 1, destination: "/test")
       assert_equal(201, api_response.code)
     end
   end


### PR DESCRIPTION
Relates to: https://trello.com/c/9FmE3rPn/281-double-opt-in-create-api-adapter-to-send-double-opt-in-email

---

Hold until https://trello.com/c/Dte8k1Aa/280-double-opt-in-create-an-internal-api-to-send-double-opt-in-emails is merged or API is confirmed

---

Deprecates the existing create_auth_token and replaces it with send_subscriber_verification_email.
Also adds a new adapter for sending an email to verify a subscription.