### PR TITLE
Suppress and check for deprecated warning

### DIFF
--- a/test/rummager_test.rb
+++ b/test/rummager_test.rb
@@ -7,6 +7,10 @@ describe GdsApi::Rummager do
     stub_request(:get, /example.com\/batch_search/).to_return(body: "[]")
   end
 
+  around(:each) do |example|
+    assert_output(nil, /deprecated/, &example)
+  end
+
   # tests for search
 
   it "#search should raise an exception if the service at the search URI returns a 500" do


### PR DESCRIPTION
https://trello.com/c/9FmE3rPn/281-double-opt-in-create-api-adapter-to-send-double-opt-in-email

This stops the many 'deprecated' warnings for Rummager cluttering the
test output when running 'rake'.