### PR TITLE
Add `stub_publishing_api_path_reservation` test helper method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Add `stub_publishing_api_path_reservation` test helper method.
 * Combine `GdsApi::PublishingAPI` and `GdsApi::PublishingApiV2`
 
 # 63.0.0

--- a/lib/gds_api/test_helpers/publishing_api.rb
+++ b/lib/gds_api/test_helpers/publishing_api.rb
@@ -689,6 +689,28 @@ module GdsApi
         end
       end
 
+      # Stub a PUT /v2/paths/:base_path request with the given content id and request body.
+      #
+      # @example
+      #   stub_publishing_api_path_reservation(
+      #     my_content_id,
+      #     publishing_app: "content-publisher",
+      #     override_existing: true,
+      #   )
+      #
+      # @param base_path [String]
+      # @param params [Hash]
+      def stub_publishing_api_path_reservation(base_path, params = {})
+        url = PUBLISHING_API_ENDPOINT + "/paths#{base_path}"
+        response = {
+          status: 200,
+          headers: { content_type: "application/json" },
+          body: params.merge(base_path: base_path).to_json,
+        }
+
+        stub_request(:put, url).with(body: params).to_return(response)
+      end
+
       def stub_default_publishing_api_path_reservation
         stub_request(:put, %r[\A#{PUBLISHING_API_ENDPOINT}/paths/]).to_return { |request|
           base_path = request.uri.path.sub(%r{\A/paths/}, "")


### PR DESCRIPTION
Trello: https://trello.com/c/NC10wudi/1250-add-a-test-helper-to-stub-the-putpath-method-in-gds-api-adapters

Follows on from: https://github.com/alphagov/content-publisher/commit/5e58e4cf242d0549546e675f3143b69c1b472880

## What's changed?

Allow the path reservation for a specific base path to be stubbed.