### PR TITLE
Fix various put path related issues for Publishing API helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Make success and error responses on Publishing API path methods accurate.
+* Deprecate `stub_default_*` Publishing API test helpers in favour of the `stub_any_*` convention.
 * Add `stub_publishing_api_path_reservation` test helper method.
 * Combine `GdsApi::PublishingAPI` and `GdsApi::PublishingApiV2`
 

--- a/lib/gds_api/test_helpers/publishing_api.rb
+++ b/lib/gds_api/test_helpers/publishing_api.rb
@@ -652,7 +652,7 @@ module GdsApi
         stub_request(:delete, url).to_return(status: 200, body: "{}", headers: { "Content-Type" => "application/json; charset=utf-8" })
       end
 
-      def stub_default_publishing_api_put_intent
+      def stub_any_publishing_api_put_intent
         stub_request(:put, %r{\A#{PUBLISHING_API_ENDPOINT}/publish-intent})
       end
 
@@ -711,7 +711,7 @@ module GdsApi
         stub_request(:put, url).with(body: params).to_return(response)
       end
 
-      def stub_default_publishing_api_path_reservation
+      def stub_any_publishing_api_path_reservation
         stub_request(:put, %r[\A#{PUBLISHING_API_ENDPOINT}/paths/]).to_return { |request|
           base_path = request.uri.path.sub(%r{\A/paths/}, "")
           { status: 200, headers: { content_type: "application/json" },
@@ -759,6 +759,8 @@ module GdsApi
       alias_method :publishing_api_get_editions, :stub_publishing_api_get_editions
       alias_method :publishing_api_has_path_reservation_for, :stub_publishing_api_has_path_reservation_for
       alias_method :publishing_api_returns_path_reservation_validation_error_for, :stub_publishing_api_returns_path_reservation_validation_error_for
+      alias_method :stub_default_publishing_api_path_reservation, :stub_any_publishing_api_path_reservation
+      alias_method :stub_default_publishing_api_put_intent, :stub_any_publishing_api_put_intent
 
     private
 

--- a/lib/gds_api/test_helpers/publishing_api.rb
+++ b/lib/gds_api/test_helpers/publishing_api.rb
@@ -689,7 +689,7 @@ module GdsApi
         end
       end
 
-      # Stub a PUT /v2/paths/:base_path request with the given content id and request body.
+      # Stub a PUT /paths/:base_path request with the given content id and request body.
       #
       # @example
       #   stub_publishing_api_path_reservation(

--- a/lib/gds_api/test_helpers/publishing_api.rb
+++ b/lib/gds_api/test_helpers/publishing_api.rb
@@ -711,12 +711,20 @@ module GdsApi
         stub_request(:put, url).with(body: params).to_return(response)
       end
 
+      # Stub all PUT /paths/:base_path requests
+      #
+      # @example
+      #   stub_any_publishing_api_path_reservation
       def stub_any_publishing_api_path_reservation
-        stub_request(:put, %r[\A#{PUBLISHING_API_ENDPOINT}/paths/]).to_return { |request|
-          base_path = request.uri.path.sub(%r{\A/paths/}, "")
-          { status: 200, headers: { content_type: "application/json" },
-            body: publishing_api_path_data_for(base_path).to_json }
-        }
+        stub_request(:put, %r[\A#{PUBLISHING_API_ENDPOINT}/paths/]).to_return do |request|
+          base_path = request.uri.path.sub(%r{\A/paths}, "")
+          body = JSON.parse(request.body).merge(base_path: base_path)
+          {
+            status: 200,
+            headers: { content_type: "application/json" },
+            body: body.to_json,
+          }
+        end
       end
 
       def stub_publishing_api_has_path_reservation_for(path, publishing_app)

--- a/lib/gds_api/test_helpers/publishing_api.rb
+++ b/lib/gds_api/test_helpers/publishing_api.rb
@@ -888,16 +888,6 @@ module GdsApi
       def intent_for_publishing_api(base_path, publishing_app = "publisher")
         intent_for_base_path(base_path).merge("publishing_app" => publishing_app)
       end
-
-      def publishing_api_path_data_for(path, override_attributes = {})
-        now = Time.zone.now.utc.iso8601
-        {
-          "path" => path,
-          "publishing_app" => "foo-publisher",
-          "created_at" => now,
-          "updated_at" => now,
-        }.merge(override_attributes)
-      end
     end
   end
 end

--- a/test/test_helpers/publishing_api_test.rb
+++ b/test/test_helpers/publishing_api_test.rb
@@ -443,6 +443,43 @@ describe GdsApi::TestHelpers::PublishingApi do
     end
   end
 
+  describe "#stub_publishing_api_returns_path_reservation_validation_error_for" do
+    it "returns a validation error for a particular path" do
+      stub_publishing_api_returns_path_reservation_validation_error_for("/foo")
+
+      error = assert_raises GdsApi::HTTPUnprocessableEntity do
+        publishing_api.put_path("/foo", {})
+      end
+
+      assert error.message.include?({
+        error: {
+          code: 422,
+          message: "Base path Computer says no",
+          fields: { base_path: ["Computer says no"] },
+        },
+      }.to_json)
+    end
+
+    it "can accept user provided errors" do
+      stub_publishing_api_returns_path_reservation_validation_error_for(
+        "/foo",
+        field: ["error 1", "error 2"],
+      )
+
+      error = assert_raises GdsApi::HTTPUnprocessableEntity do
+        publishing_api.put_path("/foo", {})
+      end
+
+      assert error.message.include?({
+        error: {
+          code: 422,
+          message: "Field error 1",
+          fields: { field: ["error 1", "error 2"] },
+        },
+      }.to_json)
+    end
+  end
+
   describe "#request_json_matching predicate" do
     describe "nested required attribute" do
       let(:matcher) { request_json_matching("a" => { "b" => 1 }) }

--- a/test/test_helpers/publishing_api_test.rb
+++ b/test/test_helpers/publishing_api_test.rb
@@ -395,6 +395,25 @@ describe GdsApi::TestHelpers::PublishingApi do
     end
   end
 
+  describe "#stub_any_publishing_api_path_reservation" do
+    it "stubs a request to reserve a path" do
+      stub_any_publishing_api_path_reservation
+
+      api_response = publishing_api.put_path("/foo", {})
+      assert_equal(api_response.code, 200)
+    end
+
+    it "returns the payload with the base_path merged in" do
+      stub_any_publishing_api_path_reservation
+
+      api_response = publishing_api.put_path("/foo", publishing_app: "foo-publisher")
+      assert_equal({
+        "publishing_app" => "foo-publisher",
+        "base_path" => "/foo",
+      }, api_response.to_h)
+    end
+  end
+
   describe "#request_json_matching predicate" do
     describe "nested required attribute" do
       let(:matcher) { request_json_matching("a" => { "b" => 1 }) }

--- a/test/test_helpers/publishing_api_test.rb
+++ b/test/test_helpers/publishing_api_test.rb
@@ -6,7 +6,7 @@ describe GdsApi::TestHelpers::PublishingApi do
   include GdsApi::TestHelpers::PublishingApi
   let(:publishing_api) { GdsApi::PublishingApi.new(Plek.current.find("publishing-api")) }
 
-  describe "#publishing_api_has_linked_items" do
+  describe "#stub_publishing_api_has_linked_items" do
     it "stubs the get linked items api call" do
       links = [
         { "content_id" => "id-1", "title" => "title 1", "link_type" => "taxons" },
@@ -32,7 +32,7 @@ describe GdsApi::TestHelpers::PublishingApi do
     end
   end
 
-  describe "#publish_api_has_links_for_content_ids" do
+  describe "#stub_publish_api_has_links_for_content_ids" do
     it "stubs the call to get links for content ids" do
       links = {
                 "2878337b-bed9-4e7f-85b6-10ed2cbcd504" => {
@@ -49,7 +49,7 @@ describe GdsApi::TestHelpers::PublishingApi do
     end
   end
 
-  describe "#publishing_api_has_lookups" do
+  describe "#stub_publishing_api_has_lookups" do
     it "stubs the lookup for content items" do
       lookup_hash = { "/foo" => "2878337b-bed9-4e7f-85b6-10ed2cbcd504" }
 
@@ -60,7 +60,7 @@ describe GdsApi::TestHelpers::PublishingApi do
     end
   end
 
-  describe "#publishing_api_has_content" do
+  describe "#stub_publishing_api_has_content" do
     it "stubs the call to get content items" do
       stub_publishing_api_has_content([{ "content_id" => "2878337b-bed9-4e7f-85b6-10ed2cbcd504" }])
 
@@ -136,7 +136,7 @@ describe GdsApi::TestHelpers::PublishingApi do
     end
   end
 
-  describe "#publishing_api_has_item" do
+  describe "#stub_publishing_api_has_item" do
     it "stubs the call to get content items" do
       stub_publishing_api_has_item("content_id" => "2878337b-bed9-4e7f-85b6-10ed2cbcd504")
       response = publishing_api.get_content("2878337b-bed9-4e7f-85b6-10ed2cbcd504").parsed_content
@@ -165,7 +165,7 @@ describe GdsApi::TestHelpers::PublishingApi do
     end
   end
 
-  describe "#publishing_api_has_expanded_links" do
+  describe "#stub_publishing_api_has_expanded_links" do
     it "stubs the call to get expanded links when content_id is a symbol" do
       payload = {
         content_id: "2e20294a-d694-4083-985e-d8bedefc2354",
@@ -306,7 +306,7 @@ describe GdsApi::TestHelpers::PublishingApi do
     end
   end
 
-  describe "#publishing_api_get_editions" do
+  describe "#stub_publishing_api_get_editions" do
     it "stubs the get editions api call" do
       editions = [
         { "content_id" => "id-1", "title" => "title 1" },
@@ -327,7 +327,7 @@ describe GdsApi::TestHelpers::PublishingApi do
     end
   end
 
-  describe "#publishing_api_isnt_available" do
+  describe "#stub_publishing_api_isnt_available" do
     it "returns a 503 for V2 requests" do
       stub_publishing_api_isnt_available
 


### PR DESCRIPTION
In https://github.com/alphagov/gds-api-adapters/pull/968 we discovered that the stub methods for the Publishing API's PUT /path method were returning strange custom errors and responses that weren't representative of what the Publishing API actually did.

I've sorted those out and fixed various other issues in the immediate vicinity.