### PR TITLE
Require PublishingApi test helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Fix `GdsApi::TestHelpers::PublishingApiV2` not requiring Publishing API test helpers.
+
 # 63.1.0
 
 * Make success and error responses on Publishing API path methods accurate.

--- a/lib/gds_api/test_helpers/publishing_api_v2.rb
+++ b/lib/gds_api/test_helpers/publishing_api_v2.rb
@@ -1,7 +1,4 @@
-require "gds_api/test_helpers/json_client_helper"
-require "gds_api/test_helpers/content_item_helpers"
-require "gds_api/test_helpers/intent_helpers"
-require "json"
+require "gds_api/test_helpers/publishing_api"
 
 module GdsApi
   module TestHelpers


### PR DESCRIPTION
Test helpers are normally required explicitly as
GdsApi::TestHelpers::PublishingApiV2 requires
GdsApi::TestHelpers::PublishingApi we need to make sure that this file
is already loaded.

This was causing errors for collections-publisher see: https://ci.integration.publishing.service.gov.uk/job/collections-publisher/job/dependabot%252Fbundler%252Fgds-api-adapters-63.1.0/3/console and can be resolved by running this branch against collections-publisher https://ci.integration.publishing.service.gov.uk/job/collections-publisher/job/gds-api-test/2/console