### PR TITLE
Raise warnings when deprecated methods are used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Unreleased
+
+* Issue a warning when deprecated stub methods are called. `stub_*` methods
+  should be used instead.
+* Remove methods incorrectly marked as being stubs, I don't expect any are used
+  externally so shouldn't be a breaking change.
+
 # 63.1.1
 
 * Fix `GdsApi::TestHelpers::PublishingApiV2` not requiring Publishing API test helpers.

--- a/lib/gds_api/test_helpers/alias_deprecated.rb
+++ b/lib/gds_api/test_helpers/alias_deprecated.rb
@@ -1,0 +1,13 @@
+module GdsApi
+  module TestHelpers
+    module AliasDeprecated
+      def alias_deprecated(deprecated_method, replacement_method)
+        class_name = self.name
+        define_method(deprecated_method) do |*args, &block|
+          warn "##{deprecated_method} is deprecated on #{class_name} and will be removed in a future version. Use ##{replacement_method} instead"
+          public_send(replacement_method, *args, &block)
+        end
+      end
+    end
+  end
+end

--- a/lib/gds_api/test_helpers/asset_manager.rb
+++ b/lib/gds_api/test_helpers/asset_manager.rb
@@ -1,6 +1,10 @@
+require "gds_api/test_helpers/alias_deprecated"
+
 module GdsApi
   module TestHelpers
     module AssetManager
+      extend AliasDeprecated
+
       ASSET_MANAGER_ENDPOINT = Plek.current.find("asset-manager")
 
       def stub_any_asset_manager_call
@@ -104,19 +108,18 @@ module GdsApi
         stub_request(:delete, "#{ASSET_MANAGER_ENDPOINT}/assets/#{asset_id}").to_return(status: 500)
       end
 
-      # Aliases for DEPRECATED methods
-      alias_method :asset_manager_updates_any_asset, :stub_asset_manager_updates_any_asset
-      alias_method :asset_manager_deletes_any_asset, :stub_asset_manager_deletes_any_asset
-      alias_method :asset_manager_has_an_asset, :stub_asset_manager_has_an_asset
-      alias_method :asset_manager_has_a_whitehall_asset, :stub_asset_manager_has_a_whitehall_asset
-      alias_method :asset_manager_does_not_have_an_asset, :stub_asset_manager_does_not_have_an_asset
-      alias_method :asset_manager_does_not_have_a_whitehall_asset, :stub_asset_manager_does_not_have_a_whitehall_asset
-      alias_method :asset_manager_receives_an_asset, :stub_asset_manager_receives_an_asset
-      alias_method :asset_manager_upload_failure, :stub_asset_manager_upload_failure
-      alias_method :asset_manager_update_asset, :stub_asset_manager_update_asset
-      alias_method :asset_manager_update_failure, :stub_asset_manager_update_asset_failure
-      alias_method :asset_manager_delete_asset, :stub_asset_manager_delete_asset
-      alias_method :asset_manager_delete_failure, :stub_asset_manager_delete_asset_failure
+      alias_deprecated :asset_manager_updates_any_asset, :stub_asset_manager_updates_any_asset
+      alias_deprecated :asset_manager_deletes_any_asset, :stub_asset_manager_deletes_any_asset
+      alias_deprecated :asset_manager_has_an_asset, :stub_asset_manager_has_an_asset
+      alias_deprecated :asset_manager_has_a_whitehall_asset, :stub_asset_manager_has_a_whitehall_asset
+      alias_deprecated :asset_manager_does_not_have_an_asset, :stub_asset_manager_does_not_have_an_asset
+      alias_deprecated :asset_manager_does_not_have_a_whitehall_asset, :stub_asset_manager_does_not_have_a_whitehall_asset
+      alias_deprecated :asset_manager_receives_an_asset, :stub_asset_manager_receives_an_asset
+      alias_deprecated :asset_manager_upload_failure, :stub_asset_manager_upload_failure
+      alias_deprecated :asset_manager_update_asset, :stub_asset_manager_update_asset
+      alias_deprecated :asset_manager_update_failure, :stub_asset_manager_update_asset_failure
+      alias_deprecated :asset_manager_delete_asset, :stub_asset_manager_delete_asset
+      alias_deprecated :asset_manager_delete_failure, :stub_asset_manager_delete_asset_failure
     end
   end
 end

--- a/lib/gds_api/test_helpers/calendars.rb
+++ b/lib/gds_api/test_helpers/calendars.rb
@@ -1,6 +1,10 @@
+require "gds_api/test_helpers/alias_deprecated"
+
 module GdsApi
   module TestHelpers
     module Calendars
+      extend AliasDeprecated
+
       def calendars_endpoint(in_division: nil)
         endpoint = "#{Plek.new.website_root}/bank-holidays"
         endpoint += "/#{in_division}" unless in_division.nil?
@@ -53,9 +57,9 @@ module GdsApi
       end
 
       # Aliases for DEPRECATED methods
-      alias_method :calendars_has_no_bank_holidays, :stub_calendars_has_no_bank_holidays
-      alias_method :calendars_has_bank_holidays_on, :stub_calendars_has_bank_holidays_on
-      alias_method :calendars_has_a_bank_holiday_on, :stub_calendars_has_a_bank_holiday_on
+      alias_deprecated :calendars_has_no_bank_holidays, :stub_calendars_has_no_bank_holidays
+      alias_deprecated :calendars_has_bank_holidays_on, :stub_calendars_has_bank_holidays_on
+      alias_deprecated :calendars_has_a_bank_holiday_on, :stub_calendars_has_a_bank_holiday_on
     end
   end
 end

--- a/lib/gds_api/test_helpers/calendars.rb
+++ b/lib/gds_api/test_helpers/calendars.rb
@@ -12,7 +12,7 @@ module GdsApi
       end
 
       def stub_calendars_has_no_bank_holidays(in_division: nil)
-        calendars_has_bank_holidays_on([], in_division: in_division)
+        stub_calendars_has_bank_holidays_on([], in_division: in_division)
       end
 
       def stub_calendars_has_bank_holidays_on(dates, in_division: nil)
@@ -53,7 +53,7 @@ module GdsApi
       end
 
       def stub_calendars_has_a_bank_holiday_on(date, in_division: nil)
-        calendars_has_bank_holidays_on([date], in_division: in_division)
+        stub_calendars_has_bank_holidays_on([date], in_division: in_division)
       end
 
       # Aliases for DEPRECATED methods

--- a/lib/gds_api/test_helpers/calendars.rb
+++ b/lib/gds_api/test_helpers/calendars.rb
@@ -1,7 +1,7 @@
 module GdsApi
   module TestHelpers
     module Calendars
-      def stub_calendars_endpoint(in_division: nil)
+      def calendars_endpoint(in_division: nil)
         endpoint = "#{Plek.new.website_root}/bank-holidays"
         endpoint += "/#{in_division}" unless in_division.nil?
         endpoint + ".json"
@@ -53,7 +53,6 @@ module GdsApi
       end
 
       # Aliases for DEPRECATED methods
-      alias_method :calendars_endpoint, :stub_calendars_endpoint
       alias_method :calendars_has_no_bank_holidays, :stub_calendars_has_no_bank_holidays
       alias_method :calendars_has_bank_holidays_on, :stub_calendars_has_bank_holidays_on
       alias_method :calendars_has_a_bank_holiday_on, :stub_calendars_has_a_bank_holiday_on

--- a/lib/gds_api/test_helpers/content_store.rb
+++ b/lib/gds_api/test_helpers/content_store.rb
@@ -1,3 +1,4 @@
+require "gds_api/test_helpers/alias_deprecated"
 require "gds_api/test_helpers/json_client_helper"
 require "gds_api/test_helpers/content_item_helpers"
 require "json"
@@ -5,6 +6,7 @@ require "json"
 module GdsApi
   module TestHelpers
     module ContentStore
+      extend AliasDeprecated
       include ContentItemHelpers
 
       def content_store_endpoint(draft = false)
@@ -93,11 +95,11 @@ module GdsApi
       end
 
       # Aliases for DEPRECATED methods
-      alias_method :content_store_has_item, :stub_content_store_has_item
-      alias_method :content_store_does_not_have_item, :stub_content_store_does_not_have_item
-      alias_method :content_store_has_gone_item, :stub_content_store_has_gone_item
-      alias_method :content_store_isnt_available, :stub_content_store_isnt_available
-      alias_method :content_store_has_incoming_links, :stub_content_store_has_incoming_links
+      alias_deprecated :content_store_has_item, :stub_content_store_has_item
+      alias_deprecated :content_store_does_not_have_item, :stub_content_store_does_not_have_item
+      alias_deprecated :content_store_has_gone_item, :stub_content_store_has_gone_item
+      alias_deprecated :content_store_isnt_available, :stub_content_store_isnt_available
+      alias_deprecated :content_store_has_incoming_links, :stub_content_store_has_incoming_links
     end
   end
 end

--- a/lib/gds_api/test_helpers/content_store.rb
+++ b/lib/gds_api/test_helpers/content_store.rb
@@ -7,6 +7,10 @@ module GdsApi
     module ContentStore
       include ContentItemHelpers
 
+      def content_store_endpoint(draft = false)
+        draft ? Plek.current.find("draft-content-store") : Plek.current.find("content-store")
+      end
+
       # Stubs a content item in the content store.
       # The following options can be passed in:
       #
@@ -14,14 +18,10 @@ module GdsApi
       #   :private  if true, the Cache-Control header will include the "private" directive. By default it
       #             will include "public"
       #   :draft    will point to the draft content store if set to true
-      def stub_content_store_endpoint(draft = false)
-        draft ? Plek.current.find("draft-content-store") : Plek.current.find("content-store")
-      end
-
       def stub_content_store_has_item(base_path, body = content_item_for_base_path(base_path), options = {})
         max_age = options.fetch(:max_age, 900)
         visibility = options[:private] ? "private" : "public"
-        url = stub_content_store_endpoint(options[:draft]) + "/content" + base_path
+        url = content_store_endpoint(options[:draft]) + "/content" + base_path
         body = body.to_json unless body.is_a?(String)
 
         stub_request(:get, url).to_return(
@@ -35,10 +35,10 @@ module GdsApi
       end
 
       def stub_content_store_does_not_have_item(base_path, options = {})
-        url = stub_content_store_endpoint(options[:draft]) + "/content" + base_path
+        url = content_store_endpoint(options[:draft]) + "/content" + base_path
         stub_request(:get, url).to_return(status: 404, headers: {})
 
-        url = stub_content_store_endpoint(options[:draft]) + "/incoming-links" + base_path
+        url = content_store_endpoint(options[:draft]) + "/incoming-links" + base_path
         stub_request(:get, url).to_return(status: 404, headers: {})
       end
 
@@ -67,7 +67,7 @@ module GdsApi
       #     "details" => {}
       #   }
       def stub_content_store_has_gone_item(base_path, body = gone_content_item_for_base_path(base_path), options = {})
-        url = stub_content_store_endpoint(options[:draft]) + "/content" + base_path
+        url = content_store_endpoint(options[:draft]) + "/content" + base_path
         body = body.to_json unless body.is_a?(String)
 
         stub_request(:get, url).to_return(
@@ -78,7 +78,7 @@ module GdsApi
       end
 
       def stub_content_store_isnt_available
-        stub_request(:any, /#{stub_content_store_endpoint}\/.*/).to_return(status: 503)
+        stub_request(:any, /#{content_store_endpoint}\/.*/).to_return(status: 503)
       end
 
       def content_item_for_base_path(base_path)
@@ -86,14 +86,13 @@ module GdsApi
       end
 
       def stub_content_store_has_incoming_links(base_path, links)
-        url = stub_content_store_endpoint + "/incoming-links" + base_path
+        url = content_store_endpoint + "/incoming-links" + base_path
         body = links.to_json
 
         stub_request(:get, url).to_return(body: body)
       end
 
       # Aliases for DEPRECATED methods
-      alias_method :content_store_endpoint, :stub_content_store_endpoint
       alias_method :content_store_has_item, :stub_content_store_has_item
       alias_method :content_store_does_not_have_item, :stub_content_store_does_not_have_item
       alias_method :content_store_has_gone_item, :stub_content_store_has_gone_item

--- a/lib/gds_api/test_helpers/imminence.rb
+++ b/lib/gds_api/test_helpers/imminence.rb
@@ -1,8 +1,11 @@
+require "gds_api/test_helpers/alias_deprecated"
 require "gds_api/test_helpers/json_client_helper"
 
 module GdsApi
   module TestHelpers
     module Imminence
+      extend AliasDeprecated
+
       # Generally true. If you are initializing the client differently,
       # you could redefine/override the constant or stub directly.
       IMMINENCE_API_ENDPOINT = Plek.current.find("imminence")
@@ -34,10 +37,9 @@ module GdsApi
         to_return(status: status_code, body: return_data.to_json, headers: {})
       end
 
-      # Aliases for DEPRECATED methods
-      alias_method :imminence_has_places, :stub_imminence_has_places
-      alias_method :imminence_has_areas_for_postcode, :stub_imminence_has_areas_for_postcode
-      alias_method :imminence_has_places_for_postcode, :stub_imminence_has_places_for_postcode
+      alias_deprecated :imminence_has_places, :stub_imminence_has_places
+      alias_deprecated :imminence_has_areas_for_postcode, :stub_imminence_has_areas_for_postcode
+      alias_deprecated :imminence_has_places_for_postcode, :stub_imminence_has_places_for_postcode
     end
   end
 end

--- a/lib/gds_api/test_helpers/licence_application.rb
+++ b/lib/gds_api/test_helpers/licence_application.rb
@@ -1,8 +1,11 @@
+require "gds_api/test_helpers/alias_deprecated"
 require "gds_api/test_helpers/json_client_helper"
 
 module GdsApi
   module TestHelpers
     module LicenceApplication
+      extend AliasDeprecated
+
       # Generally true. If you are initializing the client differently,
       # you could redefine/override the constant or stub directly.
       LICENCE_APPLICATION_ENDPOINT = Plek.current.find("licensify")
@@ -30,11 +33,10 @@ module GdsApi
         stub_request(:get, "#{LICENCE_APPLICATION_ENDPOINT}/api/licence/#{identifier}").to_return(status: 500)
       end
 
-      # Aliases for DEPRECATED methods
-      alias_method :licence_exists, :stub_licence_exists
-      alias_method :licence_does_not_exist, :stub_licence_does_not_exist
-      alias_method :licence_times_out, :stub_licence_times_out
-      alias_method :licence_returns_error, :stub_licence_returns_error
+      alias_deprecated :licence_exists, :stub_licence_exists
+      alias_deprecated :licence_does_not_exist, :stub_licence_does_not_exist
+      alias_deprecated :licence_times_out, :stub_licence_times_out
+      alias_deprecated :licence_returns_error, :stub_licence_returns_error
     end
   end
 end

--- a/lib/gds_api/test_helpers/link_checker_api.rb
+++ b/lib/gds_api/test_helpers/link_checker_api.rb
@@ -5,7 +5,7 @@ module GdsApi
     module LinkCheckerApi
       LINK_CHECKER_API_ENDPOINT = Plek.current.find("link-checker-api")
 
-      def stub_link_checker_api_link_report_hash(uri:, status: :ok, checked: nil, errors: [], warnings: [], problem_summary: nil, suggested_fix: nil)
+      def link_checker_api_link_report_hash(uri:, status: :ok, checked: nil, errors: [], warnings: [], problem_summary: nil, suggested_fix: nil)
         {
           uri: uri,
           status: status,
@@ -17,18 +17,18 @@ module GdsApi
         }
       end
 
-      def stub_link_checker_api_batch_report_hash(id:, status: :completed, links: [], totals: {}, completed_at: nil)
+      def link_checker_api_batch_report_hash(id:, status: :completed, links: [], totals: {}, completed_at: nil)
         {
           id: id,
           status: status,
-          links: links.map { |hash| stub_link_checker_api_link_report_hash(**hash) },
+          links: links.map { |hash| link_checker_api_link_report_hash(**hash) },
           totals: totals,
           completed_at: completed_at || Time.now.iso8601,
         }
       end
 
       def stub_link_checker_api_check(uri:, status: :ok, checked: nil, errors: [], warnings: [], problem_summary: nil, suggested_fix: nil)
-        body = stub_link_checker_api_link_report_hash(
+        body = link_checker_api_link_report_hash(
           uri: uri, status: status, checked: checked, errors: errors, warnings: warnings, problem_summary: problem_summary, suggested_fix: suggested_fix,
         ).to_json
 
@@ -38,7 +38,7 @@ module GdsApi
       end
 
       def stub_link_checker_api_get_batch(id:, status: :completed, links: [], totals: {}, completed_at: nil)
-        body = stub_link_checker_api_batch_report_hash(
+        body = link_checker_api_batch_report_hash(
           id: id, status: status, links: links, totals: totals, completed_at: completed_at,
         ).to_json
 
@@ -49,7 +49,7 @@ module GdsApi
       def stub_link_checker_api_create_batch(uris:, checked_within: nil, webhook_uri: nil, webhook_secret_token: nil, id: 0, status: :in_progress, links: nil, totals: {}, completed_at: nil)
         links = uris.map { |uri| { uri: uri } } if links.nil?
 
-        response_body = stub_link_checker_api_batch_report_hash(
+        response_body = link_checker_api_batch_report_hash(
           id: id,
           status: status,
           links: links,
@@ -91,8 +91,6 @@ module GdsApi
       end
 
       # Aliases for DEPRECATED methods
-      alias_method :link_checker_api_link_report_hash, :stub_link_checker_api_link_report_hash
-      alias_method :link_checker_api_batch_report_hash, :stub_link_checker_api_batch_report_hash
       alias_method :link_checker_api_check, :stub_link_checker_api_check
       alias_method :link_checker_api_get_batch, :stub_link_checker_api_get_batch
       alias_method :link_checker_api_create_batch, :stub_link_checker_api_create_batch

--- a/lib/gds_api/test_helpers/link_checker_api.rb
+++ b/lib/gds_api/test_helpers/link_checker_api.rb
@@ -1,8 +1,10 @@
+require "gds_api/test_helpers/alias_deprecated"
 require "gds_api/test_helpers/json_client_helper"
 
 module GdsApi
   module TestHelpers
     module LinkCheckerApi
+      extend AliasDeprecated
       LINK_CHECKER_API_ENDPOINT = Plek.current.find("link-checker-api")
 
       def link_checker_api_link_report_hash(uri:, status: :ok, checked: nil, errors: [], warnings: [], problem_summary: nil, suggested_fix: nil)
@@ -91,10 +93,10 @@ module GdsApi
       end
 
       # Aliases for DEPRECATED methods
-      alias_method :link_checker_api_check, :stub_link_checker_api_check
-      alias_method :link_checker_api_get_batch, :stub_link_checker_api_get_batch
-      alias_method :link_checker_api_create_batch, :stub_link_checker_api_create_batch
-      alias_method :link_checker_api_upsert_resource_monitor, :stub_link_checker_api_upsert_resource_monitor
+      alias_deprecated :link_checker_api_check, :stub_link_checker_api_check
+      alias_deprecated :link_checker_api_get_batch, :stub_link_checker_api_get_batch
+      alias_deprecated :link_checker_api_create_batch, :stub_link_checker_api_create_batch
+      alias_deprecated :link_checker_api_upsert_resource_monitor, :stub_link_checker_api_upsert_resource_monitor
     end
   end
 end

--- a/lib/gds_api/test_helpers/local_links_manager.rb
+++ b/lib/gds_api/test_helpers/local_links_manager.rb
@@ -1,8 +1,10 @@
+require "gds_api/test_helpers/alias_deprecated"
 require "gds_api/test_helpers/json_client_helper"
 
 module GdsApi
   module TestHelpers
     module LocalLinksManager
+      extend AliasDeprecated
       LOCAL_LINKS_MANAGER_ENDPOINT = Plek.current.find("local-links-manager")
 
       def stub_local_links_manager_has_a_link(authority_slug:, lgsl:, lgil:, url:)
@@ -141,17 +143,16 @@ module GdsApi
           .to_return(body: response.to_json, status: 200)
       end
 
-      # Aliases for DEPRECATED methods
-      alias_method :local_links_manager_has_a_link, :stub_local_links_manager_has_a_link
-      alias_method :local_links_manager_has_no_link, :stub_local_links_manager_has_no_link
-      alias_method :local_links_manager_has_no_link_and_no_homepage_url, :stub_local_links_manager_has_no_link_and_no_homepage_url
-      alias_method :local_links_manager_request_with_missing_parameters, :stub_local_links_manager_request_with_missing_parameters
-      alias_method :local_links_manager_does_not_have_required_objects, :stub_local_links_manager_does_not_have_required_objects
-      alias_method :local_links_manager_has_a_local_authority, :stub_local_links_manager_has_a_local_authority
-      alias_method :local_links_manager_has_a_district_and_county_local_authority, :stub_local_links_manager_has_a_district_and_county_local_authority
-      alias_method :local_links_manager_request_without_local_authority_slug, :stub_local_links_manager_request_without_local_authority_slug
-      alias_method :local_links_manager_does_not_have_an_authority, :stub_local_links_manager_does_not_have_an_authority
-      alias_method :local_links_manager_has_a_local_authority_without_homepage, :stub_local_links_manager_has_a_local_authority_without_homepage
+      alias_deprecated :local_links_manager_has_a_link, :stub_local_links_manager_has_a_link
+      alias_deprecated :local_links_manager_has_no_link, :stub_local_links_manager_has_no_link
+      alias_deprecated :local_links_manager_has_no_link_and_no_homepage_url, :stub_local_links_manager_has_no_link_and_no_homepage_url
+      alias_deprecated :local_links_manager_request_with_missing_parameters, :stub_local_links_manager_request_with_missing_parameters
+      alias_deprecated :local_links_manager_does_not_have_required_objects, :stub_local_links_manager_does_not_have_required_objects
+      alias_deprecated :local_links_manager_has_a_local_authority, :stub_local_links_manager_has_a_local_authority
+      alias_deprecated :local_links_manager_has_a_district_and_county_local_authority, :stub_local_links_manager_has_a_district_and_county_local_authority
+      alias_deprecated :local_links_manager_request_without_local_authority_slug, :stub_local_links_manager_request_without_local_authority_slug
+      alias_deprecated :local_links_manager_does_not_have_an_authority, :stub_local_links_manager_does_not_have_an_authority
+      alias_deprecated :local_links_manager_has_a_local_authority_without_homepage, :stub_local_links_manager_has_a_local_authority_without_homepage
     end
   end
 end

--- a/lib/gds_api/test_helpers/local_links_manager.rb
+++ b/lib/gds_api/test_helpers/local_links_manager.rb
@@ -115,14 +115,14 @@ module GdsApi
 
       def stub_local_links_manager_request_without_local_authority_slug
         stub_request(:get, "#{LOCAL_LINKS_MANAGER_ENDPOINT}/api/local-authority")
-        .with(query: { authority_slug: "" })
-        .to_return(body: {}.to_json, status: 400)
+          .with(query: { authority_slug: "" })
+          .to_return(body: {}.to_json, status: 400)
       end
 
       def stub_local_links_manager_does_not_have_an_authority(authority_slug)
         stub_request(:get, "#{LOCAL_LINKS_MANAGER_ENDPOINT}/api/local-authority")
-        .with(query: { authority_slug: authority_slug })
-        .to_return(body: {}.to_json, status: 404)
+          .with(query: { authority_slug: authority_slug })
+          .to_return(body: {}.to_json, status: 404)
       end
 
       def stub_local_links_manager_has_a_local_authority_without_homepage(authority_slug)

--- a/lib/gds_api/test_helpers/mapit.rb
+++ b/lib/gds_api/test_helpers/mapit.rb
@@ -1,6 +1,9 @@
+require "gds_api/test_helpers/alias_deprecated"
+
 module GdsApi
   module TestHelpers
     module Mapit
+      extend AliasDeprecated
       MAPIT_ENDPOINT = Plek.current.find("mapit")
 
       def stub_mapit_has_a_postcode(postcode, coords)
@@ -72,15 +75,14 @@ module GdsApi
         .to_return(body: { "code" => 404, "error" => "No areas were found that matched code #{code_type} = #{code}." }.to_json, status: 404)
       end
 
-      # Aliases for DEPRECATED methods
-      alias_method :mapit_has_a_postcode, :stub_mapit_has_a_postcode
-      alias_method :mapit_has_a_postcode_and_areas, :stub_mapit_has_a_postcode_and_areas
-      alias_method :mapit_does_not_have_a_postcode, :stub_mapit_does_not_have_a_postcode
-      alias_method :mapit_does_not_have_a_bad_postcode, :stub_mapit_does_not_have_a_bad_postcode
-      alias_method :mapit_has_areas, :stub_mapit_has_areas
-      alias_method :mapit_does_not_have_areas, :stub_mapit_does_not_have_areas
-      alias_method :mapit_has_area_for_code, :stub_mapit_has_area_for_code
-      alias_method :mapit_does_not_have_area_for_code, :stub_mapit_does_not_have_area_for_code
+      alias_deprecated :mapit_has_a_postcode, :stub_mapit_has_a_postcode
+      alias_deprecated :mapit_has_a_postcode_and_areas, :stub_mapit_has_a_postcode_and_areas
+      alias_deprecated :mapit_does_not_have_a_postcode, :stub_mapit_does_not_have_a_postcode
+      alias_deprecated :mapit_does_not_have_a_bad_postcode, :stub_mapit_does_not_have_a_bad_postcode
+      alias_deprecated :mapit_has_areas, :stub_mapit_has_areas
+      alias_deprecated :mapit_does_not_have_areas, :stub_mapit_does_not_have_areas
+      alias_deprecated :mapit_has_area_for_code, :stub_mapit_has_area_for_code
+      alias_deprecated :mapit_does_not_have_area_for_code, :stub_mapit_does_not_have_area_for_code
     end
   end
 end

--- a/lib/gds_api/test_helpers/organisations.rb
+++ b/lib/gds_api/test_helpers/organisations.rb
@@ -1,3 +1,4 @@
+require "gds_api/test_helpers/alias_deprecated"
 require "gds_api/test_helpers/json_client_helper"
 require "gds_api/test_helpers/common_responses"
 require "plek"
@@ -6,6 +7,7 @@ require "securerandom"
 module GdsApi
   module TestHelpers
     module Organisations
+      extend AliasDeprecated
       include GdsApi::TestHelpers::CommonResponses
 
       WEBSITE_ROOT = Plek.new.website_root
@@ -116,11 +118,10 @@ module GdsApi
         }
       end
 
-      # Aliases for DEPRECATED methods
-      alias_method :organisations_api_has_organisations, :stub_organisations_api_has_organisations
-      alias_method :organisations_api_has_organisations_with_bodies, :stub_organisations_api_has_organisations_with_bodies
-      alias_method :organisations_api_has_organisation, :stub_organisations_api_has_organisation
-      alias_method :organisations_api_does_not_have_organisation, :stub_organisations_api_does_not_have_organisation
+      alias_deprecated :organisations_api_has_organisations, :stub_organisations_api_has_organisations
+      alias_deprecated :organisations_api_has_organisations_with_bodies, :stub_organisations_api_has_organisations_with_bodies
+      alias_deprecated :organisations_api_has_organisation, :stub_organisations_api_has_organisation
+      alias_deprecated :organisations_api_does_not_have_organisation, :stub_organisations_api_does_not_have_organisation
     end
   end
 end

--- a/lib/gds_api/test_helpers/organisations.rb
+++ b/lib/gds_api/test_helpers/organisations.rb
@@ -14,7 +14,7 @@ module GdsApi
 
       def stub_organisations_api_has_organisations(organisation_slugs)
         bodies = organisation_slugs.map { |slug| organisation_for_slug(slug) }
-        organisations_api_has_organisations_with_bodies(bodies)
+        stub_organisations_api_has_organisations_with_bodies(bodies)
       end
 
       # Sets up the index endpoints for the given organisation slugs
@@ -26,7 +26,7 @@ module GdsApi
         # Stub API call to the endpoint for an individual organisation
         organisation_bodies.each do |body|
           slug = body["details"]["slug"]
-          organisations_api_has_organisation(slug, body)
+          stub_organisations_api_has_organisation(slug, body)
         end
 
         pages = []

--- a/lib/gds_api/test_helpers/publishing_api.rb
+++ b/lib/gds_api/test_helpers/publishing_api.rb
@@ -1,3 +1,4 @@
+require "gds_api/test_helpers/alias_deprecated"
 require "gds_api/test_helpers/json_client_helper"
 require "gds_api/test_helpers/content_item_helpers"
 require "gds_api/test_helpers/intent_helpers"
@@ -7,6 +8,7 @@ module GdsApi
   module TestHelpers
     # @api documented
     module PublishingApi
+      extend AliasDeprecated
       include ContentItemHelpers
       include IntentHelpers
 
@@ -780,25 +782,24 @@ module GdsApi
                     body: { error: error }.to_json)
       end
 
-      # Aliases for DEPRECATED methods
-      alias_method :publishing_api_isnt_available, :stub_publishing_api_isnt_available
-      alias_method :publishing_api_has_content, :stub_publishing_api_has_content
-      alias_method :publishing_api_has_fields_for_document, :stub_publishing_api_has_fields_for_document
-      alias_method :publishing_api_has_linkables, :stub_publishing_api_has_linkables
-      alias_method :publishing_api_has_item, :stub_publishing_api_has_item
-      alias_method :publishing_api_has_item_in_sequence, :stub_publishing_api_has_item_in_sequence
-      alias_method :publishing_api_does_not_have_item, :stub_publishing_api_does_not_have_item
-      alias_method :publishing_api_has_links, :stub_publishing_api_has_links
-      alias_method :publishing_api_has_expanded_links, :stub_publishing_api_has_expanded_links
-      alias_method :publishing_api_has_links_for_content_ids, :stub_publishing_api_has_links_for_content_ids
-      alias_method :publishing_api_does_not_have_links, :stub_publishing_api_does_not_have_links
-      alias_method :publishing_api_has_lookups, :stub_publishing_api_has_lookups
-      alias_method :publishing_api_has_linked_items, :stub_publishing_api_has_linked_items
-      alias_method :publishing_api_get_editions, :stub_publishing_api_get_editions
-      alias_method :publishing_api_has_path_reservation_for, :stub_publishing_api_has_path_reservation_for
-      alias_method :publishing_api_returns_path_reservation_validation_error_for, :stub_publishing_api_returns_path_reservation_validation_error_for
-      alias_method :stub_default_publishing_api_path_reservation, :stub_any_publishing_api_path_reservation
-      alias_method :stub_default_publishing_api_put_intent, :stub_any_publishing_api_put_intent
+      alias_deprecated :publishing_api_isnt_available, :stub_publishing_api_isnt_available
+      alias_deprecated :publishing_api_has_content, :stub_publishing_api_has_content
+      alias_deprecated :publishing_api_has_fields_for_document, :stub_publishing_api_has_fields_for_document
+      alias_deprecated :publishing_api_has_linkables, :stub_publishing_api_has_linkables
+      alias_deprecated :publishing_api_has_item, :stub_publishing_api_has_item
+      alias_deprecated :publishing_api_has_item_in_sequence, :stub_publishing_api_has_item_in_sequence
+      alias_deprecated :publishing_api_does_not_have_item, :stub_publishing_api_does_not_have_item
+      alias_deprecated :publishing_api_has_links, :stub_publishing_api_has_links
+      alias_deprecated :publishing_api_has_expanded_links, :stub_publishing_api_has_expanded_links
+      alias_deprecated :publishing_api_has_links_for_content_ids, :stub_publishing_api_has_links_for_content_ids
+      alias_deprecated :publishing_api_does_not_have_links, :stub_publishing_api_does_not_have_links
+      alias_deprecated :publishing_api_has_lookups, :stub_publishing_api_has_lookups
+      alias_deprecated :publishing_api_has_linked_items, :stub_publishing_api_has_linked_items
+      alias_deprecated :publishing_api_get_editions, :stub_publishing_api_get_editions
+      alias_deprecated :publishing_api_has_path_reservation_for, :stub_publishing_api_has_path_reservation_for
+      alias_deprecated :publishing_api_returns_path_reservation_validation_error_for, :stub_publishing_api_returns_path_reservation_validation_error_for
+      alias_deprecated :stub_default_publishing_api_path_reservation, :stub_any_publishing_api_path_reservation
+      alias_deprecated :stub_default_publishing_api_put_intent, :stub_any_publishing_api_put_intent
 
     private
 

--- a/lib/gds_api/test_helpers/support.rb
+++ b/lib/gds_api/test_helpers/support.rb
@@ -1,6 +1,9 @@
+require "gds_api/test_helpers/alias_deprecated"
+
 module GdsApi
   module TestHelpers
     module Support
+      extend AliasDeprecated
       SUPPORT_ENDPOINT = Plek.current.find("support")
 
       def stub_support_foi_request_creation(request_details = nil)
@@ -19,8 +22,7 @@ module GdsApi
         stub_request(:post, /#{SUPPORT_ENDPOINT}\/.*/).to_return(status: 503)
       end
 
-      # Aliases for DEPRECATED methods
-      alias_method :support_isnt_available, :stub_support_isnt_available
+      alias_deprecated :support_isnt_available, :stub_support_isnt_available
     end
   end
 end

--- a/lib/gds_api/test_helpers/support_api.rb
+++ b/lib/gds_api/test_helpers/support_api.rb
@@ -1,9 +1,11 @@
+require "gds_api/test_helpers/alias_deprecated"
 require "cgi"
 require "plek"
 
 module GdsApi
   module TestHelpers
     module SupportApi
+      extend AliasDeprecated
       SUPPORT_API_ENDPOINT = Plek.current.find("support-api")
 
       def stub_support_api_problem_report_creation(request_details = nil)
@@ -154,8 +156,7 @@ module GdsApi
         stub_request(:any, %r{\A#{SUPPORT_API_ENDPOINT}})
       end
 
-      # Aliases for DEPRECATED methods
-      alias_method :support_api_isnt_available, :stub_support_api_isnt_available
+      alias_deprecated :support_api_isnt_available, :stub_support_api_isnt_available
     end
   end
 end

--- a/lib/gds_api/test_helpers/worldwide.rb
+++ b/lib/gds_api/test_helpers/worldwide.rb
@@ -1,9 +1,11 @@
+require "gds_api/test_helpers/alias_deprecated"
 require "gds_api/test_helpers/json_client_helper"
 require "gds_api/test_helpers/common_responses"
 
 module GdsApi
   module TestHelpers
     module Worldwide
+      extend AliasDeprecated
       include GdsApi::TestHelpers::CommonResponses
 
       WORLDWIDE_API_ENDPOINT = Plek.current.find("whitehall-admin")
@@ -111,13 +113,12 @@ module GdsApi
         }
       end
 
-      # Aliases for DEPRECATED methods
-      alias_method :worldwide_api_has_locations, :stub_worldwide_api_has_locations
-      alias_method :worldwide_api_has_selection_of_locations, :stub_worldwide_api_has_selection_of_locations
-      alias_method :worldwide_api_has_location, :stub_worldwide_api_has_location
-      alias_method :worldwide_api_has_does_not_have_location, :stub_worldwide_api_does_not_have_location
-      alias_method :worldwide_api_has_organisations_for_location, :stub_worldwide_api_has_organisations_for_location
-      alias_method :worldwide_api_has_no_organisations_for_location, :stub_worldwide_api_has_no_organisations_for_location
+      alias_deprecated :worldwide_api_has_locations, :stub_worldwide_api_has_locations
+      alias_deprecated :worldwide_api_has_selection_of_locations, :stub_worldwide_api_has_selection_of_locations
+      alias_deprecated :worldwide_api_has_location, :stub_worldwide_api_has_location
+      alias_deprecated :worldwide_api_has_does_not_have_location, :stub_worldwide_api_does_not_have_location
+      alias_deprecated :worldwide_api_has_organisations_for_location, :stub_worldwide_api_has_organisations_for_location
+      alias_deprecated :worldwide_api_has_no_organisations_for_location, :stub_worldwide_api_has_no_organisations_for_location
     end
   end
 end

--- a/test/licence_application_api_test.rb
+++ b/test/licence_application_api_test.rb
@@ -73,7 +73,7 @@ class LicenceApplicationApiTest < Minitest::Test
   end
 
   def test_should_raise_if_licence_is_unrecognised
-    licence_does_not_exist("bloop")
+    stub_licence_does_not_exist("bloop")
 
     assert_raises(GdsApi::HTTPNotFound) do
       api.details_for_licence("bloop")
@@ -81,7 +81,7 @@ class LicenceApplicationApiTest < Minitest::Test
   end
 
   def test_should_provide_full_licence_details_for_canonical_id
-    licence_exists("590001", "isLocationSpecific" => true, "geographicalAvailability" => %w(England Wales), "issuingAuthorities" => [])
+    stub_licence_exists("590001", "isLocationSpecific" => true, "geographicalAvailability" => %w(England Wales), "issuingAuthorities" => [])
 
     expected = {
       "isLocationSpecific" => true,
@@ -93,7 +93,7 @@ class LicenceApplicationApiTest < Minitest::Test
   end
 
   def test_should_raise_for_bad_snac_code_entry
-    licence_does_not_exist("590001/bleep")
+    stub_licence_does_not_exist("590001/bleep")
 
     assert_raises(GdsApi::HTTPNotFound) do
       api.details_for_licence("590001", "bleep")
@@ -101,7 +101,7 @@ class LicenceApplicationApiTest < Minitest::Test
   end
 
   def test_should_raise_for_bad_licence_id_and_snac_code
-    licence_does_not_exist("bloop/bleep")
+    stub_licence_does_not_exist("bloop/bleep")
 
     assert_raises(GdsApi::HTTPNotFound) do
       api.details_for_licence("bloop", "bleep")
@@ -120,7 +120,7 @@ class LicenceApplicationApiTest < Minitest::Test
   end
 
   def test_should_return_full_licence_details_with_location_specific_information
-    licence_exists("866-5-1/00AA", <<~JSON
+    stub_licence_exists("866-5-1/00AA", <<~JSON
       {
          "isLocationSpecific":true,
          "geographicalAvailability":[
@@ -179,7 +179,7 @@ class LicenceApplicationApiTest < Minitest::Test
   end
 
   def test_should_raise_exception_on_timeout
-    licence_times_out("866-5-1")
+    stub_licence_times_out("866-5-1")
 
     assert_raises GdsApi::TimedOutException do
       api.details_for_licence("866-5-1")
@@ -187,7 +187,7 @@ class LicenceApplicationApiTest < Minitest::Test
   end
 
   def test_should_raise_exception_on_api_error
-    licence_returns_error("866-5-1")
+    stub_licence_returns_error("866-5-1")
 
     assert_raises GdsApi::HTTPServerError do
       api.details_for_licence("866-5-1")


### PR DESCRIPTION
To help get us to a point where we can eventually remove the various deprecated test helper methods I've set it up so calling any of these methods will result in a warning. Hopefully this will allow people to change them so it's not too big a pain point when the methods are eventually removed.

I also removed some incorrect aliasing of methods prefixed with a stub. I very much doubt they're used outside the app so I think it's reasonable to not consider that a breaking change.