### PR TITLE
Add new method to get live content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   should be used instead.
 * Remove methods incorrectly marked as being stubs, I don't expect any are used
   externally so shouldn't be a breaking change.
+* Add `get_live_content` method to `GdsApi::PublishingApi`
 
 # 63.1.1
 

--- a/test/publishing_api_test.rb
+++ b/test/publishing_api_test.rb
@@ -514,6 +514,195 @@ describe GdsApi::PublishingApi do
     end
   end
 
+  describe "#get_live_content" do
+    describe "when the latest version of the content item is published" do
+      before do
+        publishing_api
+          .given("a published content item exists with content_id: #{@content_id}")
+          .upon_receiving("a request to return the live content item")
+          .with(
+            method: :get,
+            path: "/v2/content/#{@content_id}",
+            headers: GdsApi::JsonClient.default_request_headers.merge(
+              "Authorization" => "Bearer #{@bearer_token}",
+            ),
+          )
+          .will_respond_with(
+            status: 200,
+            body: {
+              "content_id" => @content_id,
+              "document_type" => Pact.like("special_route"),
+              "schema_name" => Pact.like("special_route"),
+              "publishing_app" => Pact.like("publisher"),
+              "rendering_app" => Pact.like("frontend"),
+              "locale" => Pact.like("en"),
+              "routes" => Pact.like([{}]),
+              "public_updated_at" => Pact.like("2015-07-30T13:58:11.000Z"),
+              "details" => Pact.like({}),
+              "state_history" => { "1" => "published" },
+              "publication_state" => "published",
+            },
+            headers: {
+              "Content-Type" => "application/json; charset=utf-8",
+            },
+          )
+      end
+
+      it "returns the published content item" do
+        response = @api_client.get_live_content(@content_id)
+        assert_equal 200, response.code
+        assert_equal response["publication_state"], "published"
+      end
+    end
+
+    describe "when the content item has never been live" do
+      before do
+        publishing_api
+          .given("a draft content item exists with content_id: #{@content_id}")
+          .upon_receiving("a request to return the live content item")
+          .with(
+            method: :get,
+            path: "/v2/content/#{@content_id}",
+            headers: GdsApi::JsonClient.default_request_headers.merge(
+              "Authorization" => "Bearer #{@bearer_token}",
+            ),
+          )
+          .will_respond_with(
+            status: 200,
+            body: {
+              "content_id" => @content_id,
+              "document_type" => Pact.like("special_route"),
+              "schema_name" => Pact.like("special_route"),
+              "publishing_app" => Pact.like("publisher"),
+              "rendering_app" => Pact.like("frontend"),
+              "locale" => Pact.like("en"),
+              "routes" => Pact.like([{}]),
+              "details" => Pact.like({}),
+              "state_history" => { "1" => "draft" },
+              "publication_state" => "draft",
+            },
+            headers: {
+              "Content-Type" => "application/json; charset=utf-8",
+            },
+          )
+      end
+
+      it "responds with NoLiveVersion" do
+        assert_raises(GdsApi::PublishingApi::NoLiveVersion) do
+          @api_client.get_live_content(@content_id)
+        end
+      end
+    end
+
+    describe "when there is a draft version of live content" do
+      before do
+        publishing_api
+          .given("a published content item exists with a draft edition for content_id: #{@content_id}")
+          .upon_receiving("a request to return the content item")
+          .with(
+            method: :get,
+            path: "/v2/content/#{@content_id}",
+            query: "locale=en",
+            headers: GdsApi::JsonClient.default_request_headers.merge(
+              "Authorization" => "Bearer #{@bearer_token}",
+            ),
+          )
+          .will_respond_with(
+            status: 200,
+            body: {
+              "content_id" => @content_id,
+              "document_type" => Pact.like("special_route"),
+              "schema_name" => Pact.like("special_route"),
+              "publishing_app" => Pact.like("publisher"),
+              "rendering_app" => Pact.like("frontend"),
+              "locale" => Pact.like("en"),
+              "routes" => Pact.like([{}]),
+              "details" => Pact.like({}),
+              "state_history" => { "1" => "published", "2" => "draft" },
+              "publication_state" => "draft",
+            },
+            headers: {
+              "Content-Type" => "application/json; charset=utf-8",
+            },
+          )
+          .upon_receiving("a request to return the live content item")
+          .with(
+            method: :get,
+            path: "/v2/content/#{@content_id}",
+            query: "locale=en&version=1",
+            headers: GdsApi::JsonClient.default_request_headers.merge(
+              "Authorization" => "Bearer #{@bearer_token}",
+            ),
+          )
+          .will_respond_with(
+            status: 200,
+            body: {
+              "content_id" => @content_id,
+              "document_type" => Pact.like("special_route"),
+              "schema_name" => Pact.like("special_route"),
+              "publishing_app" => Pact.like("publisher"),
+              "rendering_app" => Pact.like("frontend"),
+              "locale" => Pact.like("en"),
+              "routes" => Pact.like([{}]),
+              "public_updated_at" => Pact.like("2015-07-30T13:58:11.000Z"),
+              "details" => Pact.like({}),
+              "state_history" => { "1" => "published", "2" => "draft" },
+              "publication_state" => "published",
+            },
+            headers: {
+              "Content-Type" => "application/json; charset=utf-8",
+            },
+          )
+      end
+
+      it "returns the live content item" do
+        response = @api_client.get_live_content(@content_id)
+        assert_equal 200, response.code
+        assert_equal response["publication_state"], "published"
+      end
+    end
+
+    describe "when the latest version of the content item is unpublished" do
+      before do
+        publishing_api
+          .given("an unpublished content item exists with content_id: #{@content_id}")
+          .upon_receiving("a request to return the content item")
+          .with(
+            method: :get,
+            path: "/v2/content/#{@content_id}",
+            headers: GdsApi::JsonClient.default_request_headers.merge(
+              "Authorization" => "Bearer #{@bearer_token}",
+            ),
+          )
+          .will_respond_with(
+            status: 200,
+            body: {
+              "content_id" => @content_id,
+              "document_type" => Pact.like("special_route"),
+              "schema_name" => Pact.like("special_route"),
+              "publishing_app" => Pact.like("publisher"),
+              "rendering_app" => Pact.like("frontend"),
+              "locale" => Pact.like("en"),
+              "routes" => Pact.like([{}]),
+              "public_updated_at" => Pact.like("2015-07-30T13:58:11.000Z"),
+              "details" => Pact.like({}),
+              "state_history" => { "1" => "unpublished" },
+              "publication_state" => "unpublished",
+            },
+            headers: {
+              "Content-Type" => "application/json; charset=utf-8",
+            },
+          )
+      end
+
+      it "returns the unpublished content item" do
+        response = @api_client.get_live_content(@content_id)
+        assert_equal 200, response.code
+        assert_equal response["publication_state"], "unpublished"
+      end
+    end
+  end
+
   describe "#republish" do
     describe "if the republish command succeeds" do
       before do


### PR DESCRIPTION
Trello: https://trello.com/c/JHMoTkfA
Depends on: https://github.com/alphagov/publishing-api/pull/1679

## What's changed and why?
By default, `get_content` gets the latest version of the content item regardless of the publication state. Sometimes, it is useful to be able to get the "live" version of the content.

This code has already been implemented in [collections-publisher](https://github.com/alphagov/collections-publisher/blob/f04fdc32409165f238b32245d8189faa5ac216a3/app/helpers/publishing_api_helper.rb) to discard drafts, but now something similar needs to be added to content-publisher to allow content items migrated from Whitehall to be compared with the information publishing-api already has about them, so it seemed like a good time to add this functionality somewhere common.