### PR TITLE
Switch the Worldwide API endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+* Change Worldwide API requests to be routed to whitehall-frontend by
+  default, rather than whitehall-admin. Update the test helpers
+  accordingly.
+
 # 63.2.0
 
 * Issue a warning when deprecated stub methods are called. `stub_*` methods

--- a/lib/gds_api.rb
+++ b/lib/gds_api.rb
@@ -117,8 +117,9 @@ module GdsApi
     GdsApi::Maslow.new(Plek.new.external_url_for("maslow"), options)
   end
 
-  # Creates a GdsApi::Organisations adapter for accessing Whitehall APIs on a
-  # whitehall-admin host
+  # Creates a GdsApi::Organisations adapter for accessing Whitehall
+  # APIs through the origin, where the requests will be handled by
+  # Collections frontend.
   #
   # @return [GdsApi::Organisations]
   def self.organisations(options = {})

--- a/lib/gds_api.rb
+++ b/lib/gds_api.rb
@@ -192,10 +192,10 @@ module GdsApi
   end
 
   # Creates a GdsApi::Worldwide adapter for accessing Whitehall APIs on a
-  # whitehall-admin host
+  # whitehall-frontend host
   #
   # @return [GdsApi::Worldwide]
   def self.worldwide(options = {})
-    GdsApi::Worldwide.new(Plek.find("whitehall-admin"), options)
+    GdsApi::Worldwide.new(Plek.find("whitehall-frontend"), options)
   end
 end

--- a/lib/gds_api/test_helpers/worldwide.rb
+++ b/lib/gds_api/test_helpers/worldwide.rb
@@ -8,7 +8,7 @@ module GdsApi
       extend AliasDeprecated
       include GdsApi::TestHelpers::CommonResponses
 
-      WORLDWIDE_API_ENDPOINT = Plek.current.find("whitehall-admin")
+      WORLDWIDE_API_ENDPOINT = Plek.current.find("whitehall-frontend")
 
       # Sets up the index endpoints for the given country slugs
       # The stubs are setup to paginate in chunks of 20


### PR DESCRIPTION
The whitehall-frontend and whitehall-admin hosts should provide
identical responses, as they're the same code. The whitehall-frontend
hosts are setup for handling frontend requests, and have a read-only
database connection. The whitehall-admin hosts are setup for handling
the admin interface.

As the Worldwide API doesn't do any writing, it's suitable to be
handled by the whitehall-frontend hosts. This change is motivated by
the migration to AWS, as it'll be easier to keep whitehall-frontend up
during the migration (compared to whitehall-admin).