### PR TITLE
Resolve some Publishing API test helper inconsistencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+* Fix Publishing API `stub_any_publishing_api_call` methods only operating on
+  the V2 endpoint.
+
 # 63.3.0
 
 * Change Worldwide API requests to be routed to whitehall-frontend by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Add `stub_any_publishing_api_unreserve_path` test helper.
 * Fix Publishing API `stub_any_publishing_api_call` methods only operating on
   the V2 endpoint.
 

--- a/lib/gds_api/test_helpers/publishing_api.rb
+++ b/lib/gds_api/test_helpers/publishing_api.rb
@@ -174,20 +174,19 @@ module GdsApi
         stub_request(:post, %r{\A#{PUBLISHING_API_V2_ENDPOINT}/content/.*/discard-draft})
       end
 
-      # Stub any version 2 request to the publishing API
+      # Stub any request to the publishing API
       def stub_any_publishing_api_call
-        stub_request(:any, %r{\A#{PUBLISHING_API_V2_ENDPOINT}})
+        stub_request(:any, %r{\A#{PUBLISHING_API_ENDPOINT}})
       end
 
-      # Stub any version 2 request to the publishing API to return a 404 response
+      # Stub any request to the publishing API to return a 404 response
       def stub_any_publishing_api_call_to_return_not_found
-        stub_request(:any, %r{\A#{PUBLISHING_API_V2_ENDPOINT}})
+        stub_request(:any, %r{\A#{PUBLISHING_API_ENDPOINT}})
           .to_return(status: 404, headers: { "Content-Type" => "application/json; charset=utf-8" })
       end
 
-      # Stub any version 2 request to the publishing API to return a 503 response
+      # Stub any request to the publishing API to return a 503 response
       def stub_publishing_api_isnt_available
-        stub_request(:any, /#{PUBLISHING_API_V2_ENDPOINT}\/.*/).to_return(status: 503)
         stub_request(:any, /#{PUBLISHING_API_ENDPOINT}\/.*/).to_return(status: 503)
       end
 

--- a/lib/gds_api/test_helpers/publishing_api.rb
+++ b/lib/gds_api/test_helpers/publishing_api.rb
@@ -640,6 +640,10 @@ module GdsApi
         stub_publishing_api_unreserve_path_with_code(base_path, publishing_app, 422)
       end
 
+      def stub_any_publishing_api_unreserve_path
+        stub_request(:delete, %r{\A#{PUBLISHING_API_ENDPOINT}/paths/})
+      end
+
       # Stub a PUT /publish-intent/:base_path request with the given base_path
       # and request body.
       #

--- a/test/test_helpers/publishing_api_test.rb
+++ b/test/test_helpers/publishing_api_test.rb
@@ -427,6 +427,15 @@ describe GdsApi::TestHelpers::PublishingApi do
     end
   end
 
+  describe "#stub_any_publishing_api_unreserve_path" do
+    it "stubs a request to unreserve a path" do
+      stub_any_publishing_api_unreserve_path
+
+      api_response = publishing_api.unreserve_path("/foo", "myapp")
+      assert_equal(api_response.code, 200)
+    end
+  end
+
   describe "#stub_any_publishing_api_path_reservation" do
     it "stubs a request to reserve a path" do
       stub_any_publishing_api_path_reservation

--- a/test/test_helpers/publishing_api_test.rb
+++ b/test/test_helpers/publishing_api_test.rb
@@ -328,15 +328,28 @@ describe GdsApi::TestHelpers::PublishingApi do
   end
 
   describe "#stub_publishing_api_isnt_available" do
-    it "returns a 503 for any request" do
+    it "raises a GdsApi::HTTPUnavailable for any request" do
       stub_publishing_api_isnt_available
 
-      assert_raises GdsApi::BaseError do
+      assert_raises GdsApi::HTTPUnavailable do
         publishing_api.get_content_items({})
       end
+    end
+  end
 
-      assert_raises GdsApi::BaseError do
-        publishing_api.lookup_content_id(base_path: "")
+  describe "#stub_any_publishing_api_call" do
+    it "returns a 200 response for any request" do
+      stub_any_publishing_api_call
+      response = publishing_api.get_editions
+      assert_equal(response.code, 200)
+    end
+  end
+
+  describe "#stub_any_publishing_api_call_to_return_not_found" do
+    it "returns a GdsApi::HTTPNotFound for any request" do
+      stub_any_publishing_api_call_to_return_not_found
+      assert_raises GdsApi::HTTPNotFound do
+        publishing_api.get_editions
       end
     end
   end


### PR DESCRIPTION
Trello: https://trello.com/c/yqXt0RGc/1417-remove-documents-at-dwps-request

This resolves a couple issues with test helpers for Publishing API: 

- The stub any methods were applying only to the V2 endpoint so not covering those without a version namespace.
- Adds a `stub_any_publishing_api_unreserve_path` to match the variety of other `stub_any` methods from Publishing API.