### PR TITLE
Change Worldwide API to use root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Change Worldwide API requests to use the website root rather than whitehall-frontend
+
 # 63.4.0
 
 * Add `stub_any_publishing_api_unreserve_path` test helper.

--- a/lib/gds_api.rb
+++ b/lib/gds_api.rb
@@ -197,6 +197,6 @@ module GdsApi
   #
   # @return [GdsApi::Worldwide]
   def self.worldwide(options = {})
-    GdsApi::Worldwide.new(Plek.find("whitehall-frontend"), options)
+    GdsApi::Worldwide.new(Plek.new.website_root, options)
   end
 end


### PR DESCRIPTION
The Worldwide API was changed to use `whitehall-frontend` in order to avoid
breaking things if `whitehall-admin` was shut down during its migration to AWS.
Now that it has migrated and we're not planning on making `whitehall-frontend`
accessible to Carrenza, we change Worldwide API to use the public version of
the API.