### PR TITLE
Update Worldwide test helpers endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Update Worldwide test helpers to use the website root
+
 # 63.5.0
 
 * Change Worldwide API requests to use the website root rather than whitehall-frontend

--- a/lib/gds_api/test_helpers/worldwide.rb
+++ b/lib/gds_api/test_helpers/worldwide.rb
@@ -8,7 +8,7 @@ module GdsApi
       extend AliasDeprecated
       include GdsApi::TestHelpers::CommonResponses
 
-      WORLDWIDE_API_ENDPOINT = Plek.current.find("whitehall-frontend")
+      WORLDWIDE_API_ENDPOINT = Plek.new.website_root
 
       # Sets up the index endpoints for the given country slugs
       # The stubs are setup to paginate in chunks of 20


### PR DESCRIPTION
This was updated for the API itself already; we also needed to update the test
helpers.