### PR TITLE
Make entire repository pass Rubocop linting

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 
 require "rdoc/task"
-require 'rake/testtask'
+require "rake/testtask"
 
 RDoc::Task.new do |rd|
   rd.rdoc_files.include("lib/**/*.rb")
@@ -15,12 +15,12 @@ Rake::TestTask.new("test") do |t|
 end
 task default: :test
 
-require 'pact_broker/client/tasks'
+require "pact_broker/client/tasks"
 
 def configure_pact_broker_location(task)
   task.pact_broker_base_url = ENV.fetch("PACT_BROKER_BASE_URL")
-  if ENV['PACT_BROKER_USERNAME']
-    task.pact_broker_basic_auth = { username: ENV['PACT_BROKER_USERNAME'], password: ENV['PACT_BROKER_PASSWORD'] }
+  if ENV["PACT_BROKER_USERNAME"]
+    task.pact_broker_basic_auth = { username: ENV["PACT_BROKER_USERNAME"], password: ENV["PACT_BROKER_PASSWORD"] }
   end
 end
 

--- a/gds-api-adapters.gemspec
+++ b/gds-api-adapters.gemspec
@@ -5,6 +5,7 @@ $:.unshift lib unless $:.include?(lib)
 
 require "gds_api/version"
 
+# rubocop:disable Metrics/BlockLength
 Gem::Specification.new do |s|
   s.name         = "gds-api-adapters"
   s.version      = GdsApi::VERSION
@@ -46,3 +47,4 @@ Gem::Specification.new do |s|
   s.add_development_dependency "webrick", "~> 1.4"
   s.add_development_dependency "yard", "~> 0.9"
 end
+# rubocop:enable Metrics/BlockLength

--- a/gds-api-adapters.gemspec
+++ b/gds-api-adapters.gemspec
@@ -3,7 +3,7 @@
 lib = File.expand_path("lib", __dir__)
 $:.unshift lib unless $:.include?(lib)
 
-require 'gds_api/version'
+require "gds_api/version"
 
 Gem::Specification.new do |s|
   s.name         = "gds-api-adapters"
@@ -15,34 +15,34 @@ Gem::Specification.new do |s|
   s.homepage     = "http://github.com/alphagov/gds-api-adapters"
   s.description  = "A set of adapters providing easy access to the GDS GOV.UK APIs"
 
-  s.required_ruby_version = '>= 2.3.0'
+  s.required_ruby_version = ">= 2.3.0"
   s.files        = Dir.glob("lib/**/*") + Dir.glob("test/fixtures/**/*") + %w(README.md Rakefile)
-  s.require_path = 'lib'
-  s.add_dependency 'addressable'
-  s.add_dependency 'link_header'
-  s.add_dependency 'null_logger'
-  s.add_dependency 'plek', '>= 1.9.0'
-  s.add_dependency 'rack-cache'
-  s.add_dependency 'rest-client', '~> 2.0'
+  s.require_path = "lib"
+  s.add_dependency "addressable"
+  s.add_dependency "link_header"
+  s.add_dependency "null_logger"
+  s.add_dependency "plek", ">= 1.9.0"
+  s.add_dependency "rack-cache"
+  s.add_dependency "rest-client", "~> 2.0"
 
-  s.add_development_dependency 'climate_control', '~> 0.2'
-  s.add_development_dependency 'govuk-content-schema-test-helpers', '~> 1.6'
-  s.add_development_dependency 'minitest', '~> 5.11'
-  s.add_development_dependency 'minitest-around', '~> 0.5'
-  s.add_development_dependency 'mocha', '~> 1.3'
-  s.add_development_dependency 'pact', '~> 1.20'
-  s.add_development_dependency 'pact-consumer-minitest', '~> 1.0'
-  s.add_development_dependency 'pact-mock_service', '~> 2.6'
-  s.add_development_dependency 'pact_broker-client', '~> 1.14'
-  s.add_development_dependency 'pry'
-  s.add_development_dependency 'rack', '~> 2.0'
-  s.add_development_dependency 'rack-test'
-  s.add_development_dependency 'rake', '~> 12.3'
-  s.add_development_dependency 'rubocop-govuk'
-  s.add_development_dependency 'simplecov', '~> 0.16'
-  s.add_development_dependency 'simplecov-rcov'
-  s.add_development_dependency 'timecop', '~> 0.9'
-  s.add_development_dependency 'webmock', '~> 3.5'
-  s.add_development_dependency 'webrick', '~> 1.4'
-  s.add_development_dependency 'yard', '~> 0.9'
+  s.add_development_dependency "climate_control", "~> 0.2"
+  s.add_development_dependency "govuk-content-schema-test-helpers", "~> 1.6"
+  s.add_development_dependency "minitest", "~> 5.11"
+  s.add_development_dependency "minitest-around", "~> 0.5"
+  s.add_development_dependency "mocha", "~> 1.3"
+  s.add_development_dependency "pact", "~> 1.20"
+  s.add_development_dependency "pact-consumer-minitest", "~> 1.0"
+  s.add_development_dependency "pact-mock_service", "~> 2.6"
+  s.add_development_dependency "pact_broker-client", "~> 1.14"
+  s.add_development_dependency "pry"
+  s.add_development_dependency "rack", "~> 2.0"
+  s.add_development_dependency "rack-test"
+  s.add_development_dependency "rake", "~> 12.3"
+  s.add_development_dependency "rubocop-govuk"
+  s.add_development_dependency "simplecov", "~> 0.16"
+  s.add_development_dependency "simplecov-rcov"
+  s.add_development_dependency "timecop", "~> 0.9"
+  s.add_development_dependency "webmock", "~> 3.5"
+  s.add_development_dependency "webrick", "~> 1.4"
+  s.add_development_dependency "yard", "~> 0.9"
 end


### PR DESCRIPTION
This is depended on by https://github.com/alphagov/govuk-jenkinslib/pull/66.