### PR TITLE
Remove params from error reporting

### DIFF
--- a/lib/gds_api/exceptions.rb
+++ b/lib/gds_api/exceptions.rb
@@ -22,11 +22,10 @@ module GdsApi
   class HTTPErrorResponse < BaseError
     attr_accessor :code, :error_details
 
-    def initialize(code, message = nil, error_details = nil, request_body = nil)
+    def initialize(code, message = nil, error_details = nil)
       super(message)
       @code = code
       @error_details = error_details
-      @request_body = request_body
     end
   end
 
@@ -53,8 +52,8 @@ module GdsApi
   class HTTPGatewayTimeout < HTTPIntermittentServerError; end
 
   module ExceptionHandling
-    def build_specific_http_error(error, url, details = nil, request_body = nil)
-      message = "URL: #{url}\nResponse body:\n#{error.http_body}\n\nRequest body:\n#{request_body}"
+    def build_specific_http_error(error, url, details = nil)
+      message = "URL: #{url}\nResponse body:\n#{error.http_body}"
       code = error.http_code
       error_class_for_code(code).new(code, message, details)
     end

--- a/lib/gds_api/json_client.rb
+++ b/lib/gds_api/json_client.rb
@@ -83,7 +83,7 @@ module GdsApi
     def do_raw_request(method, url, params = nil)
       do_request(method, url, params)
     rescue RestClient::Exception => e
-      raise build_specific_http_error(e, url, nil, params)
+      raise build_specific_http_error(e, url, nil)
     end
 
     # method: the symbolic name of the method to use, e.g. :get, :post
@@ -105,7 +105,7 @@ module GdsApi
                         rescue JSON::ParserError
                           nil
                         end
-        raise build_specific_http_error(e, url, error_details, params)
+        raise build_specific_http_error(e, url, error_details)
       end
 
       # If no custom response is given, just instantiate Response

--- a/test/router_test.rb
+++ b/test/router_test.rb
@@ -451,7 +451,7 @@ describe GdsApi::Router do
         end
 
         assert_equal 500, e.code
-        assert_equal "URL: #{@base_api_url}/routes/commit\nResponse body:\nFailed to update all routers\n\nRequest body:\n{}", e.message
+        assert_equal "URL: #{@base_api_url}/routes/commit\nResponse body:\nFailed to update all routers", e.message
       end
     end
   end


### PR DESCRIPTION
The request body can contain personally identifiable information, like email addresses, so I suggest we remove the params from the reporting.

This will probably cause pain for certain debugging scenarios, but trying to filter out all PII is a very hard challenge and will never be perfect for all future scenarios.

We would probably do well to use Sentry's `context` object in each application, where we can configure which fields should be redacted for that application: https://docs.sentry.io/clients/ruby/context/#additional-context.

---

https://trello.com/c/bfmbw28t/89-remove-pii-data-on-email-subscriptions-from-sentry

