### PR TITLE
Bump to 63.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 63.6.0
+
+* Remove request body parameters from error reporting payload.
+
 # 63.5.1
 
 * Update Worldwide test helpers to use the website root

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = "63.5.1".freeze
+  VERSION = "63.6.0".freeze
 end


### PR DESCRIPTION
Removes request body parameters from error reporting payload.

See https://github.com/alphagov/gds-api-adapters/pull/992.