### PR TITLE
Run RuboCop as part of `bundle exec rake` defaults

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,3 +4,7 @@ inherit_gem:
 
 AllCops:
   TargetRubyVersion: 2.4
+
+Naming/FileName:
+  Exclude:
+    - lib/gds-api-adapters.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,4 +7,7 @@ AllCops:
 
 Naming/FileName:
   Exclude:
+    # RuboCop wants this to be renamed to `lib/gds_api_adapters.rb`. But I don't
+    # know what effect that'll have on the rest of this gem and don't particularly
+    # have the brain to find out. So I'm ignoring it for now. -- Issy, 2020-05.
     - lib/gds-api-adapters.rb

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 require "rdoc/task"
 require "rake/testtask"
 

--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,8 @@ Rake::TestTask.new("test") do |t|
   t.test_files = FileList["test/**/*_test.rb"]
   t.warning = false
 end
-task default: :test
+
+task default: %i[lint test]
 
 require "pact_broker/client/tasks"
 
@@ -31,5 +32,5 @@ end
 
 desc "Run the linter against changed files"
 task :lint do
-  sh "bundle exec rubocop --format clang lib test"
+  sh "bundle exec rubocop --format clang"
 end

--- a/gds-api-adapters.gemspec
+++ b/gds-api-adapters.gemspec
@@ -1,11 +1,7 @@
-# -*- encoding: utf-8 -*-
-
 lib = File.expand_path("lib", __dir__)
-$:.unshift lib unless $:.include?(lib)
+$LOAD_PATH.unshift lib unless $LOAD_PATH.include?(lib)
 
 require "gds_api/version"
-
-# rubocop:disable Metrics/BlockLength
 Gem::Specification.new do |s|
   s.name         = "gds-api-adapters"
   s.version      = GdsApi::VERSION
@@ -17,7 +13,7 @@ Gem::Specification.new do |s|
   s.description  = "A set of adapters providing easy access to the GDS GOV.UK APIs"
 
   s.required_ruby_version = ">= 2.4.0"
-  s.files        = Dir.glob("lib/**/*") + Dir.glob("test/fixtures/**/*") + %w(README.md Rakefile)
+  s.files        = Dir.glob("lib/**/*") + Dir.glob("test/fixtures/**/*") + %w[README.md Rakefile]
   s.require_path = "lib"
   s.add_dependency "addressable"
   s.add_dependency "link_header"
@@ -47,4 +43,3 @@ Gem::Specification.new do |s|
   s.add_development_dependency "webrick", "~> 1.4"
   s.add_development_dependency "yard", "~> 0.9"
 end
-# rubocop:enable Metrics/BlockLength

--- a/lib/gds_api/base.rb
+++ b/lib/gds_api/base.rb
@@ -24,7 +24,8 @@ class GdsApi::Base
                  :put_json,
                  :patch_json,
                  :delete_json,
-                 :get_raw, :get_raw!,
+                 :get_raw,
+                 :get_raw!,
                  :put_multipart,
                  :post_multipart
 
@@ -69,9 +70,9 @@ private
     param_pairs = params.sort.map { |key, value|
       case value
       when Array
-        value.map { |v|
+        value.map do |v|
           "#{CGI.escape(key.to_s + '[]')}=#{CGI.escape(v.to_s)}"
-        }
+        end
       else
         "#{CGI.escape(key.to_s)}=#{CGI.escape(value.to_s)}"
       end

--- a/lib/gds_api/imminence.rb
+++ b/lib/gds_api/imminence.rb
@@ -20,8 +20,8 @@ class GdsApi::Imminence < GdsApi::Base
   end
 
   def self.parse_place_hash(place_hash)
-    location = self.extract_location_hash(place_hash["location"])
-    address = self.extract_address_hash(place_hash)
+    location = extract_location_hash(place_hash["location"])
+    address = extract_address_hash(place_hash)
 
     place_hash.merge(location).merge(address)
   end

--- a/lib/gds_api/json_client.rb
+++ b/lib/gds_api/json_client.rb
@@ -29,7 +29,7 @@ module GdsApi
     end
 
     def self.default_request_with_json_body_headers
-      self.default_request_headers.merge(self.json_body_headers)
+      default_request_headers.merge(json_body_headers)
     end
 
     def self.json_body_headers
@@ -109,7 +109,7 @@ module GdsApi
       end
 
       # If no custom response is given, just instantiate Response
-      create_response ||= Proc.new { |r| Response.new(r) }
+      create_response ||= proc { |r| Response.new(r) }
       create_response.call(response)
     end
 
@@ -177,10 +177,10 @@ module GdsApi
       ::RestClient::Request.execute(method_params)
     rescue Errno::ECONNREFUSED => e
       logger.error loggable.merge(status: "refused", error_message: e.message, error_class: e.class.name, end_time: Time.now.to_f).to_json
-      raise GdsApi::EndpointNotFound.new("Could not connect to #{url}")
+      raise GdsApi::EndpointNotFound, "Could not connect to #{url}"
     rescue RestClient::Exceptions::Timeout => e
       logger.error loggable.merge(status: "timeout", error_message: e.message, error_class: e.class.name, end_time: Time.now.to_f).to_json
-      raise GdsApi::TimedOutException.new
+      raise GdsApi::TimedOutException
     rescue URI::InvalidURIError => e
       logger.error loggable.merge(status: "invalid_uri", error_message: e.message, error_class: e.class.name, end_time: Time.now.to_f).to_json
       raise GdsApi::InvalidUrl
@@ -192,10 +192,10 @@ module GdsApi
       raise
     rescue Errno::ECONNRESET => e
       logger.error loggable.merge(status: "connection_reset", error_message: e.message, error_class: e.class.name, end_time: Time.now.to_f).to_json
-      raise GdsApi::TimedOutException.new
+      raise GdsApi::TimedOutException
     rescue SocketError => e
       logger.error loggable.merge(status: "socket_error", error_message: e.message, error_class: e.class.name, end_time: Time.now.to_f).to_json
-      raise GdsApi::SocketErrorException.new
+      raise GdsApi::SocketErrorException
     end
   end
 end

--- a/lib/gds_api/list_response.rb
+++ b/lib/gds_api/list_response.rb
@@ -25,7 +25,7 @@ module GdsApi
     end
 
     def has_next_page?
-      ! page_link("next").nil?
+      !page_link("next").nil?
     end
 
     def next_page
@@ -39,7 +39,7 @@ module GdsApi
     end
 
     def has_previous_page?
-      ! page_link("previous").nil?
+      !page_link("previous").nil?
     end
 
     def previous_page
@@ -70,12 +70,12 @@ module GdsApi
     # point. Note that the responses are stored so subsequent pages will not be
     # loaded multiple times.
     def with_subsequent_pages
-      Enumerator.new { |yielder|
-        self.each do |i| yielder << i end
+      Enumerator.new do |yielder|
+        each { |i| yielder << i }
         if has_next_page?
-          next_page.with_subsequent_pages.each do |i| yielder << i end
+          next_page.with_subsequent_pages.each { |i| yielder << i }
         end
-      }
+      end
     end
 
   private

--- a/lib/gds_api/performance_platform/data_out.rb
+++ b/lib/gds_api/performance_platform/data_out.rb
@@ -70,40 +70,40 @@ module GdsApi
 
       def search_terms(slug)
         options = {
-            slug: slug,
-            transaction: "search-terms",
-            group_by: "searchKeyword",
-            collect: "searchUniques:sum",
+          slug: slug,
+          transaction: "search-terms",
+          group_by: "searchKeyword",
+          collect: "searchUniques:sum",
         }
         statistics(options)
       end
 
       def searches(slug, is_multipart)
         options = {
-            slug: slug,
-            transaction: "search-terms",
-            group_by: "pagePath",
-            collect: "searchUniques:sum",
+          slug: slug,
+          transaction: "search-terms",
+          group_by: "pagePath",
+          collect: "searchUniques:sum",
         }
         statistics(options, is_multipart)
       end
 
       def page_views(slug, is_multipart)
         options = {
-            slug: slug,
-            transaction: "page-statistics",
-            group_by: "pagePath",
-            collect: "uniquePageviews:sum",
+          slug: slug,
+          transaction: "page-statistics",
+          group_by: "pagePath",
+          collect: "uniquePageviews:sum",
         }
         statistics(options, is_multipart)
       end
 
       def problem_reports(slug, is_multipart)
         options = {
-            slug: slug,
-            transaction: "page-contacts",
-            group_by: "pagePath",
-            collect: "total:sum",
+          slug: slug,
+          transaction: "page-contacts",
+          group_by: "pagePath",
+          collect: "total:sum",
         }
         statistics(options, is_multipart)
       end
@@ -114,11 +114,11 @@ module GdsApi
       # Backdrop can be found here: https://github.com/alphagov/backdrop
       def statistics(options, is_multipart = false)
         params = {
-            group_by: options[:group_by],
-            collect: options[:collect],
-            duration: 42,
-            period: "day",
-            end_at: Date.today.to_time.getutc.iso8601,
+          group_by: options[:group_by],
+          collect: options[:collect],
+          duration: 42,
+          period: "day",
+          end_at: Date.today.to_time.getutc.iso8601,
         }
 
         filter_param = is_multipart ? :filter_by_prefix : :filter_by

--- a/lib/gds_api/publishing_api.rb
+++ b/lib/gds_api/publishing_api.rb
@@ -381,7 +381,7 @@ class GdsApi::PublishingApi < GdsApi::Base
   # @see https://github.com/alphagov/publishing-api/blob/master/doc/api.md#get-v2linkables
   def get_linkables(document_type: nil)
     if document_type.nil?
-      raise ArgumentError.new("Please provide a `document_type`")
+      raise ArgumentError, "Please provide a `document_type`"
     end
 
     get_json("#{endpoint}/v2/linkables?document_type=#{document_type}")
@@ -486,7 +486,7 @@ class GdsApi::PublishingApi < GdsApi::Base
   #     publishing_app: 'content-publisher',
   #     rendering_app: 'government-frontend',
   #   }
-  #)
+  # )
   #
   # @see https://github.com/alphagov/publishing-api/blob/master/doc/api.md#put-publish-intentbase_path
   def put_intent(base_path, payload)

--- a/lib/gds_api/response.rb
+++ b/lib/gds_api/response.rb
@@ -74,9 +74,13 @@ module GdsApi
       @parsed_content ||= transform_parsed(JSON.parse(@http_response.body))
     end
 
-    def present?; true; end
+    def present?
+      true
+    end
 
-    def blank?; false; end
+    def blank?
+      false
+    end
 
   private
 
@@ -85,7 +89,7 @@ module GdsApi
 
       case value
       when Hash
-        Hash[value.map { |k, v|
+        Hash[value.map do |k, v|
           # NOTE: Don't bother transforming if the value is nil
           if k == "web_url" && v
             # Use relative URLs to route when the web_url value is on the
@@ -98,7 +102,7 @@ module GdsApi
           else
             [k, transform_parsed(v)]
           end
-        }]
+        end]
       when Array
         value.map { |v| transform_parsed(v) }
       else

--- a/lib/gds_api/test_helpers/alias_deprecated.rb
+++ b/lib/gds_api/test_helpers/alias_deprecated.rb
@@ -2,7 +2,7 @@ module GdsApi
   module TestHelpers
     module AliasDeprecated
       def alias_deprecated(deprecated_method, replacement_method)
-        class_name = self.name
+        class_name = name
         define_method(deprecated_method) do |*args, &block|
           warn "##{deprecated_method} is deprecated on #{class_name} and will be removed in a future version. Use ##{replacement_method} instead"
           public_send(replacement_method, *args, &block)

--- a/lib/gds_api/test_helpers/email_alert_api.rb
+++ b/lib/gds_api/test_helpers/email_alert_api.rb
@@ -83,12 +83,12 @@ module GdsApi
       #  stub_email_alert_api_has_subscriptions([
       #    {
       #      id: 'id-of-my-subscriber-list',
-      #      frequency: 'weekly',
+      #      frequency: 'weekly',
       #      ended: true,
       #    },
       #    {
       #      id: 'id-of-my-subscriber-list',
-      #      frequency: 'daily',
+      #      frequency: 'daily',
       #    },
       #  ])
       #
@@ -176,7 +176,7 @@ module GdsApi
 
       def assert_email_alert_api_content_change_created(attributes = nil)
         if attributes
-          matcher = ->(request) do
+          matcher = lambda do |request|
             payload = JSON.parse(request.body)
             payload.select { |k, _| attributes.key?(k) } == attributes
           end
@@ -187,7 +187,7 @@ module GdsApi
 
       def assert_email_alert_api_message_created(attributes = nil)
         if attributes
-          matcher = ->(request) do
+          matcher = lambda do |request|
             payload = JSON.parse(request.body)
             payload.select { |k, _| attributes.key?(k) } == attributes
           end
@@ -222,21 +222,21 @@ module GdsApi
         stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscriptions")
           .with(
             body: { subscriber_list_id: subscriber_list_id, address: address, frequency: frequency }.to_json,
-        ).to_return(status: 201, body: { subscription_id: returned_subscription_id }.to_json)
+          ).to_return(status: 201, body: { subscription_id: returned_subscription_id }.to_json)
       end
 
       def stub_email_alert_api_creates_an_existing_subscription(subscriber_list_id, address, frequency, returned_subscription_id)
         stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscriptions")
           .with(
             body: { subscriber_list_id: subscriber_list_id, address: address, frequency: frequency }.to_json,
-        ).to_return(status: 200, body: { subscription_id: returned_subscription_id }.to_json)
+          ).to_return(status: 200, body: { subscription_id: returned_subscription_id }.to_json)
       end
 
       def stub_email_alert_api_refuses_to_create_subscription(subscriber_list_id, address, frequency)
         stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscriptions")
           .with(
             body: { subscriber_list_id: subscriber_list_id, address: address, frequency: frequency }.to_json,
-        ).to_return(status: 422)
+          ).to_return(status: 422)
       end
 
       def stub_email_alert_api_sends_subscription_verification_email(address, frequency, topic_id)
@@ -292,7 +292,7 @@ module GdsApi
             body: {
               subscriber_list: returned_attributes,
             }.to_json,
-        )
+          )
       end
 
       def stub_email_alert_api_does_not_have_subscriber_list_by_slug(slug:)

--- a/lib/gds_api/test_helpers/imminence.rb
+++ b/lib/gds_api/test_helpers/imminence.rb
@@ -18,12 +18,16 @@ module GdsApi
       def stub_imminence_has_areas_for_postcode(postcode, areas)
         results = {
           "_response_info" => { "status" => "ok" },
-          "total" => areas.size, "startIndex" => 1, "pageSize" => areas.size,
-          "currentPage" => 1, "pages" => 1, "results" => areas
+          "total" => areas.size,
+          "startIndex" => 1,
+          "pageSize" => areas.size,
+          "currentPage" => 1,
+          "pages" => 1,
+          "results" => areas,
         }
 
-        stub_request(:get, %r{\A#{IMMINENCE_API_ENDPOINT}/areas/#{postcode}\.json}).
-          to_return(body: results.to_json)
+        stub_request(:get, %r{\A#{IMMINENCE_API_ENDPOINT}/areas/#{postcode}\.json})
+          .to_return(body: results.to_json)
       end
 
       def stub_imminence_has_places_for_postcode(places, slug, postcode, limit)
@@ -32,9 +36,9 @@ module GdsApi
       end
 
       def stub_imminence_places_request(slug, query_hash, return_data, status_code = 200)
-        stub_request(:get, "#{IMMINENCE_API_ENDPOINT}/places/#{slug}.json").
-        with(query: query_hash).
-        to_return(status: status_code, body: return_data.to_json, headers: {})
+        stub_request(:get, "#{IMMINENCE_API_ENDPOINT}/places/#{slug}.json")
+        .with(query: query_hash)
+        .to_return(status: status_code, body: return_data.to_json, headers: {})
       end
 
       alias_deprecated :imminence_has_places, :stub_imminence_has_places

--- a/lib/gds_api/test_helpers/licence_application.rb
+++ b/lib/gds_api/test_helpers/licence_application.rb
@@ -12,17 +12,17 @@ module GdsApi
 
       def stub_licence_exists(identifier, licence)
         licence = licence.to_json unless licence.is_a?(String)
-        stub_request(:get, "#{LICENCE_APPLICATION_ENDPOINT}/api/licence/#{identifier}").
-          with(headers: GdsApi::JsonClient.default_request_headers).
-          to_return(status: 200,
-            body: licence)
+        stub_request(:get, "#{LICENCE_APPLICATION_ENDPOINT}/api/licence/#{identifier}")
+          .with(headers: GdsApi::JsonClient.default_request_headers)
+          .to_return(status: 200,
+                     body: licence)
       end
 
       def stub_licence_does_not_exist(identifier)
-        stub_request(:get, "#{LICENCE_APPLICATION_ENDPOINT}/api/licence/#{identifier}").
-          with(headers: GdsApi::JsonClient.default_request_headers).
-          to_return(status: 404,
-            body: "{\"error\": [\"Unrecognised Licence Id: #{identifier}\"]}")
+        stub_request(:get, "#{LICENCE_APPLICATION_ENDPOINT}/api/licence/#{identifier}")
+          .with(headers: GdsApi::JsonClient.default_request_headers)
+          .to_return(status: 404,
+                     body: "{\"error\": [\"Unrecognised Licence Id: #{identifier}\"]}")
       end
 
       def stub_licence_times_out(identifier)

--- a/lib/gds_api/test_helpers/mapit.rb
+++ b/lib/gds_api/test_helpers/mapit.rb
@@ -10,7 +10,7 @@ module GdsApi
         response = {
           "wgs84_lat" => coords.first,
           "wgs84_lon" => coords.last,
-          "postcode"  => postcode,
+          "postcode" => postcode,
         }
 
         stub_request(:get, "#{MAPIT_ENDPOINT}/postcode/" + postcode.tr(" ", "+") + ".json")
@@ -23,21 +23,22 @@ module GdsApi
         response = {
           "wgs84_lat" => coords.first,
           "wgs84_lon" => coords.last,
-          "postcode"  => postcode,
+          "postcode" => postcode,
         }
 
-        area_response = Hash[areas.map.with_index { |area, i|
-          [i, {
-            "codes" => {
-              "ons" => area["ons"],
-              "gss" => area["gss"],
-              "govuk_slug" => area["govuk_slug"],
-            },
-            "name" => area["name"],
-            "type" => area["type"],
-            "country_name" => area["country_name"],
-          }]
-        }]
+        area_response = Hash[areas.map.with_index do |area, i|
+          [i,
+           {
+             "codes" => {
+               "ons" => area["ons"],
+               "gss" => area["gss"],
+               "govuk_slug" => area["govuk_slug"],
+             },
+             "name" => area["name"],
+             "type" => area["type"],
+             "country_name" => area["country_name"],
+           }]
+        end]
 
         stub_request(:get, "#{MAPIT_ENDPOINT}/postcode/" + postcode.tr(" ", "+") + ".json")
           .to_return(body: response.merge("areas" => area_response).to_json, status: 200)

--- a/lib/gds_api/test_helpers/organisations.rb
+++ b/lib/gds_api/test_helpers/organisations.rb
@@ -35,12 +35,14 @@ module GdsApi
         end
 
         pages.each_with_index do |page, i|
-          page_details = plural_response_base.merge("results" => page,
+          page_details = plural_response_base.merge(
+            "results" => page,
             "total" => organisation_bodies.size,
             "pages" => pages.size,
             "current_page" => i + 1,
             "page_size" => 20,
-            "start_index" => i * 20 + 1)
+            "start_index" => i * 20 + 1,
+          )
 
           links = { self: "#{WEBSITE_ROOT}/api/organisations?page=#{i + 1}" }
           links[:next] = "#{WEBSITE_ROOT}/api/organisations?page=#{i + 2}" if pages[i + 1]
@@ -52,13 +54,13 @@ module GdsApi
             link_headers << "<#{href}>; rel=\"#{rel}\""
           end
 
-          stub_request(:get, links[:self]).
-            to_return(status: 200, body: page_details.to_json, headers: { "Link" => link_headers.join(", ") })
+          stub_request(:get, links[:self])
+            .to_return(status: 200, body: page_details.to_json, headers: { "Link" => link_headers.join(", ") })
 
           if i.zero?
             # First page exists at URL with and without page param
-            stub_request(:get, links[:self].sub(/\?page=1/, "")).
-              to_return(status: 200, body: page_details.to_json, headers: { "Link" => link_headers.join(", ") })
+            stub_request(:get, links[:self].sub(/\?page=1/, ""))
+              .to_return(status: 200, body: page_details.to_json, headers: { "Link" => link_headers.join(", ") })
           end
         end
 
@@ -70,8 +72,8 @@ module GdsApi
 
       def stub_organisations_api_has_organisation(organisation_slug, details = nil)
         details ||= organisation_for_slug(organisation_slug)
-        stub_request(:get, "#{WEBSITE_ROOT}/api/organisations/#{organisation_slug}").
-          to_return(status: 200, body: details.to_json)
+        stub_request(:get, "#{WEBSITE_ROOT}/api/organisations/#{organisation_slug}")
+          .to_return(status: 200, body: details.to_json)
       end
 
       def stub_organisations_api_does_not_have_organisation(organisation_slug)

--- a/lib/gds_api/test_helpers/performance_platform/data_out.rb
+++ b/lib/gds_api/test_helpers/performance_platform/data_out.rb
@@ -5,13 +5,13 @@ module GdsApi
         PP_DATA_OUT_ENDPOINT = "https://www.performance.service.gov.uk".freeze
 
         def stub_service_feedback(slug, response_body = {})
-          stub_http_request(:get, "#{PP_DATA_OUT_ENDPOINT}/data/#{slug}/customer-satisfaction").
-            to_return(status: 200, body: response_body.to_json)
+          stub_http_request(:get, "#{PP_DATA_OUT_ENDPOINT}/data/#{slug}/customer-satisfaction")
+            .to_return(status: 200, body: response_body.to_json)
         end
 
         def stub_data_set_not_available(slug)
-          stub_http_request(:get, "#{PP_DATA_OUT_ENDPOINT}/data/#{slug}/customer-satisfaction").
-            to_return(status: 404)
+          stub_http_request(:get, "#{PP_DATA_OUT_ENDPOINT}/data/#{slug}/customer-satisfaction")
+            .to_return(status: 404)
         end
 
         def stub_service_not_available
@@ -20,51 +20,51 @@ module GdsApi
 
         def stub_search_terms(slug, response_body = {})
           options = {
-              slug: slug,
-              transaction: "search-terms",
-              group_by: "searchKeyword",
-              collect: "searchUniques:sum",
+            slug: slug,
+            transaction: "search-terms",
+            group_by: "searchKeyword",
+            collect: "searchUniques:sum",
           }
           stub_statistics(options, false, response_body)
         end
 
         def stub_searches(slug, is_multipart, response_body = {})
           options = {
-              slug: slug,
-              transaction: "search-terms",
-              group_by: "pagePath",
-              collect: "searchUniques:sum",
+            slug: slug,
+            transaction: "search-terms",
+            group_by: "pagePath",
+            collect: "searchUniques:sum",
           }
           stub_statistics(options, is_multipart, response_body)
         end
 
         def stub_page_views(slug, is_multipart, response_body = {})
           options = {
-              slug: slug,
-              transaction: "page-statistics",
-              group_by: "pagePath",
-              collect: "uniquePageviews:sum",
+            slug: slug,
+            transaction: "page-statistics",
+            group_by: "pagePath",
+            collect: "uniquePageviews:sum",
           }
           stub_statistics(options, is_multipart, response_body)
         end
 
         def stub_problem_reports(slug, is_multipart, response_body = {})
           options = {
-              slug: slug,
-              transaction: "page-contacts",
-              group_by: "pagePath",
-              collect: "total:sum",
+            slug: slug,
+            transaction: "page-contacts",
+            group_by: "pagePath",
+            collect: "total:sum",
           }
           stub_statistics(options, is_multipart, response_body)
         end
 
         def stub_statistics(options, is_multipart, response_body = {})
           params = {
-              group_by: options[:group_by],
-              collect: options[:collect],
-              duration: 42,
-              period: "day",
-              end_at: Date.today.to_time.getutc.iso8601,
+            group_by: options[:group_by],
+            collect: options[:collect],
+            duration: 42,
+            period: "day",
+            end_at: Date.today.to_time.getutc.iso8601,
           }
 
           filter_param = is_multipart ? :filter_by_prefix : :filter_by
@@ -76,21 +76,21 @@ module GdsApi
         end
 
         def stub_search_404(slug)
-          stub_request(:get, "#{PP_DATA_OUT_ENDPOINT}/data/govuk-info/search-terms").
-              with(query: hash_including(filter_by: slug)).
-              to_return(status: 404, headers: { content_type: "application/json" })
+          stub_request(:get, "#{PP_DATA_OUT_ENDPOINT}/data/govuk-info/search-terms")
+              .with(query: hash_including(filter_by: slug))
+              .to_return(status: 404, headers: { content_type: "application/json" })
         end
 
         def stub_page_views_404(slug)
-          stub_request(:get, "#{PP_DATA_OUT_ENDPOINT}/data/govuk-info/page-statistics").
-              with(query: hash_including(filter_by: slug)).
-              to_return(status: 404, headers: { content_type: "application/json" })
+          stub_request(:get, "#{PP_DATA_OUT_ENDPOINT}/data/govuk-info/page-statistics")
+              .with(query: hash_including(filter_by: slug))
+              .to_return(status: 404, headers: { content_type: "application/json" })
         end
 
         def stub_problem_reports_404(slug)
-          stub_request(:get, "#{PP_DATA_OUT_ENDPOINT}/data/govuk-info/page-contacts").
-              with(query: hash_including(filter_by: slug)).
-              to_return(status: 404, headers: { content_type: "application/json" })
+          stub_request(:get, "#{PP_DATA_OUT_ENDPOINT}/data/govuk-info/page-contacts")
+              .with(query: hash_including(filter_by: slug))
+              .to_return(status: 404, headers: { content_type: "application/json" })
         end
       end
     end

--- a/lib/gds_api/test_helpers/support_api.rb
+++ b/lib/gds_api/test_helpers/support_api.rb
@@ -65,9 +65,9 @@ module GdsApi
       end
 
       def stub_support_api_problem_reports(params, response_body = {})
-        stub_http_request(:get, "#{SUPPORT_API_ENDPOINT}/anonymous-feedback/problem-reports").
-          with(query: params).
-          to_return(status: 200, body: response_body.to_json)
+        stub_http_request(:get, "#{SUPPORT_API_ENDPOINT}/anonymous-feedback/problem-reports")
+          .with(query: params)
+          .to_return(status: 200, body: response_body.to_json)
       end
 
       def stub_support_api_mark_reviewed_for_spam(request_details = nil, response_body = {})
@@ -89,8 +89,8 @@ module GdsApi
       def stub_support_api_anonymous_feedback_organisation_summary(slug, ordering = nil, response_body = {})
         uri = "#{SUPPORT_API_ENDPOINT}/anonymous-feedback/organisations/#{slug}"
         uri << "?ordering=#{ordering}" if ordering
-        stub_http_request(:get, uri).
-          to_return(status: 200, body: response_body.to_json)
+        stub_http_request(:get, uri)
+          .to_return(status: 200, body: response_body.to_json)
       end
 
       def stub_support_api_organisations_list(response_body = nil)
@@ -111,8 +111,8 @@ module GdsApi
           },
         ]
 
-        stub_http_request(:get, "#{SUPPORT_API_ENDPOINT}/organisations").
-          to_return(status: 200, body: response_body.to_json)
+        stub_http_request(:get, "#{SUPPORT_API_ENDPOINT}/organisations")
+          .to_return(status: 200, body: response_body.to_json)
       end
 
       def stub_support_api_organisation(slug = "cabinet-office", response_body = nil)
@@ -124,22 +124,22 @@ module GdsApi
           govuk_status: "live",
         }
 
-        stub_http_request(:get, "#{SUPPORT_API_ENDPOINT}/organisations/#{slug}").
-          to_return(status: 200, body: response_body.to_json)
+        stub_http_request(:get, "#{SUPPORT_API_ENDPOINT}/organisations/#{slug}")
+          .to_return(status: 200, body: response_body.to_json)
       end
 
       def stub_support_api_document_type_list(response_body = nil)
-        response_body ||= %w(case_study detailed_guide smart_answer)
+        response_body ||= %w[case_study detailed_guide smart_answer]
 
-        stub_http_request(:get, "#{SUPPORT_API_ENDPOINT}/anonymous-feedback/document-types").
-            to_return(status: 200, body: response_body.to_json)
+        stub_http_request(:get, "#{SUPPORT_API_ENDPOINT}/anonymous-feedback/document-types")
+            .to_return(status: 200, body: response_body.to_json)
       end
 
       def stub_support_api_anonymous_feedback_doc_type_summary(document_type, ordering = nil, response_body = nil)
         uri = "#{SUPPORT_API_ENDPOINT}/anonymous-feedback/document-types/#{document_type}"
         uri << "?ordering=#{ordering}" if ordering
-        stub_http_request(:get, uri).
-            to_return(status: 200, body: response_body.to_json)
+        stub_http_request(:get, uri)
+            .to_return(status: 200, body: response_body.to_json)
       end
 
       def stub_support_api_feedback_export_request(id, response_body = nil)
@@ -148,8 +148,8 @@ module GdsApi
           ready: true,
         }
 
-        stub_http_request(:get, "#{SUPPORT_API_ENDPOINT}/anonymous-feedback/export-requests/#{id}").
-          to_return(status: 200, body: response_body.to_json)
+        stub_http_request(:get, "#{SUPPORT_API_ENDPOINT}/anonymous-feedback/export-requests/#{id}")
+          .to_return(status: 200, body: response_body.to_json)
       end
 
       def stub_any_support_api_call

--- a/lib/gds_api/test_helpers/worldwide.rb
+++ b/lib/gds_api/test_helpers/worldwide.rb
@@ -23,12 +23,14 @@ module GdsApi
         end
 
         pages.each_with_index do |page, i|
-          page_details = plural_response_base.merge("results" => page,
+          page_details = plural_response_base.merge(
+            "results" => page,
             "total" => location_slugs.size,
             "pages" => pages.size,
             "current_page" => i + 1,
             "page_size" => 20,
-            "start_index" => i * 20 + 1)
+            "start_index" => i * 20 + 1,
+          )
 
           links = { self: "#{WORLDWIDE_API_ENDPOINT}/api/world-locations?page=#{i + 1}" }
           links[:next] = "#{WORLDWIDE_API_ENDPOINT}/api/world-locations?page=#{i + 2}" if pages[i + 1]
@@ -40,32 +42,59 @@ module GdsApi
             link_headers << "<#{href}>; rel=\"#{rel}\""
           end
 
-          stub_request(:get, links[:self]).
-            to_return(status: 200, body: page_details.to_json, headers: { "Link" => link_headers.join(", ") })
+          stub_request(:get, links[:self])
+            .to_return(status: 200, body: page_details.to_json, headers: { "Link" => link_headers.join(", ") })
 
           if i.zero?
             # First page exists at URL with and without page param
-            stub_request(:get, links[:self].sub(/\?page=1/, "")).
-              to_return(status: 200, body: page_details.to_json, headers: { "Link" => link_headers.join(", ") })
+            stub_request(:get, links[:self].sub(/\?page=1/, ""))
+              .to_return(status: 200, body: page_details.to_json, headers: { "Link" => link_headers.join(", ") })
           end
         end
       end
 
       def stub_worldwide_api_has_selection_of_locations
-        stub_worldwide_api_has_locations %w(
-          afghanistan angola australia bahamas belarus brazil brunei cambodia chad
-          croatia denmark eritrea france ghana iceland japan laos luxembourg malta
-          micronesia mozambique nicaragua panama portugal sao-tome-and-principe singapore
-          south-korea sri-lanka uk-delegation-to-council-of-europe
+        stub_worldwide_api_has_locations %w[
+          afghanistan
+          angola
+          australia
+          bahamas
+          belarus
+          brazil
+          brunei
+          cambodia
+          chad
+          croatia
+          denmark
+          eritrea
+          france
+          ghana
+          iceland
+          japan
+          laos
+          luxembourg
+          malta
+          micronesia
+          mozambique
+          nicaragua
+          panama
+          portugal
+          sao-tome-and-principe
+          singapore
+          south-korea
+          sri-lanka
+          uk-delegation-to-council-of-europe
           uk-delegation-to-organization-for-security-and-co-operation-in-europe
-          united-kingdom venezuela vietnam
-        )
+          united-kingdom
+          venezuela
+          vietnam
+        ]
       end
 
       def stub_worldwide_api_has_location(location_slug, details = nil)
         details ||= world_location_for_slug(location_slug)
-        stub_request(:get, "#{WORLDWIDE_API_ENDPOINT}/api/world-locations/#{location_slug}").
-          to_return(status: 200, body: details.to_json)
+        stub_request(:get, "#{WORLDWIDE_API_ENDPOINT}/api/world-locations/#{location_slug}")
+          .to_return(status: 200, body: details.to_json)
       end
 
       def stub_worldwide_api_does_not_have_location(location_slug)
@@ -75,15 +104,15 @@ module GdsApi
       def stub_worldwide_api_has_organisations_for_location(location_slug, json_or_hash)
         json = json_or_hash.is_a?(Hash) ? json_or_hash.to_json : json_or_hash
         url = "#{WORLDWIDE_API_ENDPOINT}/api/world-locations/#{location_slug}/organisations"
-        stub_request(:get, url).
-          to_return(status: 200, body: json, headers: { "Link" => "<#{url}; rel\"self\"" })
+        stub_request(:get, url)
+          .to_return(status: 200, body: json, headers: { "Link" => "<#{url}; rel\"self\"" })
       end
 
       def stub_worldwide_api_has_no_organisations_for_location(location_slug)
         details = { "results" => [], "total" => 0, "_response_info" => { "status" => "ok" } }
         url = "#{WORLDWIDE_API_ENDPOINT}/api/world-locations/#{location_slug}/organisations"
-        stub_request(:get, url).
-          to_return(status: 200, body: details.to_json, headers: { "Link" => "<#{url}; rel\"self\"" })
+        stub_request(:get, url)
+          .to_return(status: 200, body: details.to_json, headers: { "Link" => "<#{url}; rel\"self\"" })
       end
 
       def world_location_for_slug(slug)

--- a/test/asset_manager_test.rb
+++ b/test/asset_manager_test.rb
@@ -14,17 +14,17 @@ describe GdsApi::AssetManager do
   let(:asset_url) { [base_api_url, "assets", asset_id].join("/") }
   let(:asset_id) { "new-asset-id" }
 
-  let(:stub_asset_manager_response) {
+  let(:stub_asset_manager_response) do
     {
       asset: {
         id: asset_url,
       },
     }
-  }
+  end
 
   it "creates an asset with a file" do
-    req = stub_request(:post, "#{base_api_url}/assets").
-      with { |request|
+    req = stub_request(:post, "#{base_api_url}/assets")
+      .with { |request|
         request.body =~ %r{Content\-Disposition: form\-data; name="asset\[file\]"; filename="hello\.txt"\r\nContent\-Type: text/plain}
       }.to_return(body: JSON.dump(stub_asset_manager_response), status: 201)
 
@@ -35,8 +35,8 @@ describe GdsApi::AssetManager do
   end
 
   it "creates a Whitehall asset with a file" do
-    req = stub_request(:post, "#{base_api_url}/whitehall_assets").
-      with { |request|
+    req = stub_request(:post, "#{base_api_url}/whitehall_assets")
+      .with { |request|
         request.body =~ %r{Content\-Disposition: form\-data; name="asset\[file\]"; filename="hello\.txt"\r\nContent\-Type: text/plain}
       }.to_return(body: JSON.dump(stub_asset_manager_response), status: 201)
 
@@ -79,8 +79,8 @@ describe GdsApi::AssetManager do
     let(:asset_id) { "test-id" }
 
     it "updates an asset with a file" do
-      req = stub_request(:put, "#{base_api_url}/assets/test-id").
-        to_return(body: JSON.dump(stub_asset_manager_response), status: 200)
+      req = stub_request(:put, "#{base_api_url}/assets/test-id")
+        .to_return(body: JSON.dump(stub_asset_manager_response), status: 200)
 
       response = api.update_asset(asset_id, file: file_fixture)
 
@@ -128,8 +128,8 @@ describe GdsApi::AssetManager do
   end
 
   it "deletes an asset for the given id" do
-    req = stub_request(:delete, "#{base_api_url}/assets/#{asset_id}").
-      to_return(body: JSON.dump(stub_asset_manager_response), status: 200)
+    req = stub_request(:delete, "#{base_api_url}/assets/#{asset_id}")
+      .to_return(body: JSON.dump(stub_asset_manager_response), status: 200)
 
     response = api.delete_asset(asset_id)
 
@@ -138,8 +138,8 @@ describe GdsApi::AssetManager do
   end
 
   it "restores an asset for the given id" do
-    req = stub_request(:post, "#{base_api_url}/assets/#{asset_id}/restore").
-      to_return(body: JSON.dump(stub_asset_manager_response), status: 200)
+    req = stub_request(:post, "#{base_api_url}/assets/#{asset_id}/restore")
+      .to_return(body: JSON.dump(stub_asset_manager_response), status: 200)
 
     response = api.restore_asset(asset_id)
 

--- a/test/email_alert_api_test.rb
+++ b/test/email_alert_api_test.rb
@@ -9,21 +9,21 @@ describe GdsApi::EmailAlertApi do
   let(:api_client)    { GdsApi::EmailAlertApi.new(base_url) }
 
   let(:title) { "Some Title" }
-  let(:tags) {
+  let(:tags) do
     {
       "format" => %w[some-document-format],
     }
-  }
+  end
 
   describe "content changes" do
     let(:subject) { "Email subject" }
-    let(:publication_params) {
+    let(:publication_params) do
       {
         "title" => title,
         "subject" => subject,
         "tags" => tags,
       }
-    }
+    end
 
     before do
       stub_email_alert_api_accepts_content_change
@@ -50,13 +50,13 @@ describe GdsApi::EmailAlertApi do
 
   describe "messages" do
     let(:subject) { "Email subject" }
-    let(:message_params) {
+    let(:message_params) do
       {
         "subject" => subject,
         "body" => "Body",
         "tags" => tags,
       }
-    }
+    end
 
     before do
       stub_email_alert_api_accepts_message
@@ -82,11 +82,11 @@ describe GdsApi::EmailAlertApi do
     assert_requested(:post, "#{base_url}/emails", body: email_params.to_json)
   end
 
-  let(:unpublish_message) {
+  let(:unpublish_message) do
     {
       "content_id" => "content-id",
     }
-  }
+  end
 
   describe "unpublishing messages" do
     before do
@@ -206,12 +206,12 @@ describe GdsApi::EmailAlertApi do
     let(:expected_subscription_url) { "a subscription url" }
 
     describe "#find_or_create_subscriber_list_by_tags" do
-      let(:params) {
+      let(:params) do
         {
           "title" => title,
           "tags" => tags,
         }
-      }
+      end
 
       describe "a subscriber list with that tag set does not yet exist" do
         before do
@@ -265,13 +265,13 @@ describe GdsApi::EmailAlertApi do
       end
 
       describe "when the optional 'document_type' is provided" do
-        let(:params) {
+        let(:params) do
           {
             "title" => title,
             "tags" => tags,
             "document_type" => "travel_advice",
           }
-        }
+        end
 
         before do
           stub_email_alert_api_has_subscriber_list(
@@ -295,14 +295,14 @@ describe GdsApi::EmailAlertApi do
       end
 
       describe "when the optional 'email_document_supertype' and 'government_document_supertype' are provided" do
-        let(:params) {
+        let(:params) do
           {
             "title" => title,
             "tags" => tags,
             "email_document_supertype" => "publications",
             "government_document_supertype" => "travel_advice",
           }
-        }
+        end
 
         before do
           stub_email_alert_api_has_subscriber_list(
@@ -331,13 +331,13 @@ describe GdsApi::EmailAlertApi do
       end
 
       describe "when the optional 'gov_delivery_id' is provided" do
-        let(:params) {
+        let(:params) do
           {
             "title" => title,
             "tags" => tags,
             "gov_delivery_id" => "TOPIC-A",
           }
-        }
+        end
 
         before do
           stub_email_alert_api_has_subscriber_list(
@@ -361,19 +361,19 @@ describe GdsApi::EmailAlertApi do
       end
 
       describe "when both tags and links are provided" do
-        let(:links) {
+        let(:links) do
           {
             "format" => %w[some-document-format],
           }
-        }
+        end
 
-        let(:params) {
+        let(:params) do
           {
             "title" => title,
             "tags" => tags,
             "links" => links,
           }
-        }
+        end
 
         before do
           stub_email_alert_api_has_subscriber_list(

--- a/test/gds_api_base_test.rb
+++ b/test/gds_api_base_test.rb
@@ -23,11 +23,11 @@ class GdsApiBaseTest < Minitest::Test
   def test_should_construct_escaped_query_string_for_rails
     api = ConcreteApi.new("http://foo")
 
-    url = api.url_for_slug("slug", "b" => %w(123))
+    url = api.url_for_slug("slug", "b" => %w[123])
     u = URI.parse(url)
     assert_equal "b%5B%5D=123", u.query
 
-    url = api.url_for_slug("slug", "b" => %w(123 456))
+    url = api.url_for_slug("slug", "b" => %w[123 456])
     u = URI.parse(url)
     assert_equal "b%5B%5D=123&b%5B%5D=456", u.query
   end

--- a/test/govuk_headers_test.rb
+++ b/test/govuk_headers_test.rb
@@ -14,10 +14,13 @@ describe GdsApi::GovukHeaders do
     GdsApi::GovukHeaders.set_header("GDS-Request-Id", "123-456")
     GdsApi::GovukHeaders.set_header("Content-Type", "application/pdf")
 
-    assert_equal({
-      "GDS-Request-Id" => "123-456",
-      "Content-Type" => "application/pdf",
-    }, GdsApi::GovukHeaders.headers)
+    assert_equal(
+      {
+        "GDS-Request-Id" => "123-456",
+        "Content-Type" => "application/pdf",
+      },
+      GdsApi::GovukHeaders.headers,
+    )
   end
 
   it "supports clearing of headers" do

--- a/test/imminence_api_test.rb
+++ b/test/imminence_api_test.rb
@@ -136,9 +136,9 @@ class ImminenceApiTest < Minitest::Test
       </kml>
     KML
 
-    stub_request(:get, "#{ROOT}/places/test.kml").
-      with(headers: GdsApi::JsonClient.default_request_headers).
-      to_return(status: 200, body: kml_body)
+    stub_request(:get, "#{ROOT}/places/test.kml")
+      .with(headers: GdsApi::JsonClient.default_request_headers)
+      .to_return(status: 200, body: kml_body)
 
     response_body = api_client.places_kml("test")
     assert_equal kml_body, response_body
@@ -151,13 +151,17 @@ class ImminenceApiTest < Minitest::Test
     ]
     results = {
       "_response_info" => { "status" => "ok" },
-      "total" => areas.size, "startIndex" => 1, "pageSize" => areas.size,
-      "currentPage" => 1, "pages" => 1, "results" => areas
+      "total" => areas.size,
+      "startIndex" => 1,
+      "pageSize" => areas.size,
+      "currentPage" => 1,
+      "pages" => 1,
+      "results" => areas,
     }
 
-    stub_request(:get, "#{ROOT}/areas/WC2B%206SE.json").
-      with(headers: GdsApi::JsonClient.default_request_headers).
-      to_return(status: 200, body: results.to_json)
+    stub_request(:get, "#{ROOT}/areas/WC2B%206SE.json")
+      .with(headers: GdsApi::JsonClient.default_request_headers)
+      .to_return(status: 200, body: results.to_json)
 
     response = api_client.areas_for_postcode("WC2B 6SE")
 
@@ -175,13 +179,17 @@ class ImminenceApiTest < Minitest::Test
     ]
     results = {
       "_response_info" => { "status" => "ok" },
-      "total" => areas.size, "startIndex" => 1, "pageSize" => areas.size,
-      "currentPage" => 1, "pages" => 1, "results" => areas
+      "total" => areas.size,
+      "startIndex" => 1,
+      "pageSize" => areas.size,
+      "currentPage" => 1,
+      "pages" => 1,
+      "results" => areas,
     }
 
-    stub_request(:get, "#{ROOT}/areas/EUR.json").
-      with(headers: GdsApi::JsonClient.default_request_headers).
-      to_return(status: 200, body: results.to_json)
+    stub_request(:get, "#{ROOT}/areas/EUR.json")
+      .with(headers: GdsApi::JsonClient.default_request_headers)
+      .to_return(status: 200, body: results.to_json)
 
     response = api_client.areas_for_type("EUR")
 

--- a/test/json_client_test.rb
+++ b/test/json_client_test.rb
@@ -11,7 +11,7 @@ class JsonClientTest < MiniTest::Spec
     WebMock.disable_net_connect!
   end
 
-  def options;
+  def options
     {}
   end
 
@@ -221,7 +221,7 @@ class JsonClientTest < MiniTest::Spec
     # with a redirect to the same URL, but we'd risk getting the test code into
     # an infinite loop if the code didn't do what it was supposed to. The
     # failure response block aborts the test if we have too many requests.
-    failure = lambda { |_request| flunk("Request called too many times") }
+    failure = ->(_request) { flunk("Request called too many times") }
     stub_request(:get, url).to_return(redirect).times(11).then.to_return(failure)
 
     assert_raises GdsApi::HTTPErrorResponse do
@@ -245,7 +245,7 @@ class JsonClientTest < MiniTest::Spec
     }
 
     # See the comment in the above test for an explanation of this
-    failure = lambda { |_request| flunk("Request called too many times") }
+    failure = ->(_request) { flunk("Request called too many times") }
     stub_request(:get, first_url).to_return(first_redirect).times(6).then.to_return(failure)
     stub_request(:get, second_url).to_return(second_redirect).times(6).then.to_return(failure)
 
@@ -357,16 +357,16 @@ class JsonClientTest < MiniTest::Spec
     url = "http://some.endpoint/some.json"
     stub_request(:put, url).to_return(body: '{"a":1}', status: 200)
     response = @client.put_json(url, {})
-    assert ! response.blank?
+    assert !response.blank?
     assert response.present?
   end
 
   def test_client_can_use_basic_auth
     client = GdsApi::JsonClient.new(basic_auth: { user: "user", password: "password" })
 
-    stub_request(:put, "http://some.endpoint/some.json").
-      with(basic_auth: %w{user password}).
-      to_return(body: '{"a":1}', status: 200)
+    stub_request(:put, "http://some.endpoint/some.json")
+      .with(basic_auth: %w[user password])
+      .to_return(body: '{"a":1}', status: 200)
 
     response = client.put_json("http://some.endpoint/some.json", {})
     assert_equal 1, response["a"]
@@ -374,12 +374,12 @@ class JsonClientTest < MiniTest::Spec
 
   def test_client_can_use_bearer_token
     client = GdsApi::JsonClient.new(bearer_token: "SOME_BEARER_TOKEN")
-    expected_headers = GdsApi::JsonClient.default_request_with_json_body_headers.
-      merge("Authorization" => "Bearer SOME_BEARER_TOKEN")
+    expected_headers = GdsApi::JsonClient.default_request_with_json_body_headers
+      .merge("Authorization" => "Bearer SOME_BEARER_TOKEN")
 
-    stub_request(:put, "http://some.other.endpoint/some.json").
-      with(headers: expected_headers).
-      to_return(body: '{"a":2}', status: 200)
+    stub_request(:put, "http://some.other.endpoint/some.json")
+      .with(headers: expected_headers)
+      .to_return(body: '{"a":2}', status: 200)
 
     response = client.put_json("http://some.other.endpoint/some.json", {})
     assert_equal 2, response["a"]
@@ -388,9 +388,11 @@ class JsonClientTest < MiniTest::Spec
   def test_client_can_set_custom_headers_on_gets
     stub_request(:get, "http://some.other.endpoint/some.json").to_return(status: 200)
 
-    GdsApi::JsonClient.new.get_json("http://some.other.endpoint/some.json",
-                                    "HEADER-A" => "B",
-                                    "HEADER-C" => "D")
+    GdsApi::JsonClient.new.get_json(
+      "http://some.other.endpoint/some.json",
+      "HEADER-A" => "B",
+      "HEADER-C" => "D",
+    )
 
     assert_requested(:get, %r{/some.json}) do |request|
       headers_with_uppercase_names = Hash[request.headers.collect { |key, value| [key.upcase, value] }]
@@ -401,10 +403,12 @@ class JsonClientTest < MiniTest::Spec
   def test_client_can_set_custom_headers_on_posts
     stub_request(:post, "http://some.other.endpoint/some.json").to_return(status: 200)
 
-    GdsApi::JsonClient.new.post_json("http://some.other.endpoint/some.json",
-                                     {},
-                                     "HEADER-A" => "B",
-                                     "HEADER-C" => "D")
+    GdsApi::JsonClient.new.post_json(
+      "http://some.other.endpoint/some.json",
+      {},
+      "HEADER-A" => "B",
+      "HEADER-C" => "D",
+    )
 
     assert_requested(:post, %r{/some.json}) do |request|
       headers_with_uppercase_names = Hash[request.headers.collect { |key, value| [key.upcase, value] }]
@@ -415,10 +419,12 @@ class JsonClientTest < MiniTest::Spec
   def test_client_can_set_custom_headers_on_puts
     stub_request(:put, "http://some.other.endpoint/some.json").to_return(status: 200)
 
-    GdsApi::JsonClient.new.put_json("http://some.other.endpoint/some.json",
-                                    {},
-                                    "HEADER-A" => "B",
-                                    "HEADER-C" => "D")
+    GdsApi::JsonClient.new.put_json(
+      "http://some.other.endpoint/some.json",
+      {},
+      "HEADER-A" => "B",
+      "HEADER-C" => "D",
+    )
 
     assert_requested(:put, %r{/some.json}) do |request|
       headers_with_uppercase_names = Hash[request.headers.collect { |key, value| [key.upcase, value] }]
@@ -429,9 +435,12 @@ class JsonClientTest < MiniTest::Spec
   def test_client_can_set_custom_headers_on_deletes
     stub_request(:delete, "http://some.other.endpoint/some.json").to_return(status: 200)
 
-    GdsApi::JsonClient.new.delete_json("http://some.other.endpoint/some.json",
-                                       {},
-                                       "HEADER-A" => "B", "HEADER-C" => "D")
+    GdsApi::JsonClient.new.delete_json(
+      "http://some.other.endpoint/some.json",
+      {},
+      "HEADER-A" => "B",
+      "HEADER-C" => "D",
+    )
 
     assert_requested(:delete, %r{/some.json}) do |request|
       headers_with_uppercase_names = Hash[request.headers.collect { |key, value| [key.upcase, value] }]
@@ -461,7 +470,7 @@ class JsonClientTest < MiniTest::Spec
     GdsApi::JsonClient.new.get_json("http://some.other.endpoint/some.json")
 
     assert_requested(:get, %r{/some.json}) do |request|
-      !request.headers.has_key?("X-Govuk-Authenticated-User")
+      !request.headers.key?("X-Govuk-Authenticated-User")
     end
   end
 
@@ -505,8 +514,8 @@ class JsonClientTest < MiniTest::Spec
 
   def test_client_can_post_multipart_responses
     url = "http://some.endpoint/some.json"
-    stub_request(:post, url).
-      with(headers: { "Content-Type" => %r{multipart/form-data; boundary=----RubyFormBoundary\w+} }) { |request|
+    stub_request(:post, url)
+      .with(headers: { "Content-Type" => %r{multipart/form-data; boundary=----RubyFormBoundary\w+} }) { |request|
         request.body =~ %r{------RubyFormBoundary\w+\r\nContent-Disposition: form-data; name="a"\r\n\r\n123\r\n------RubyFormBoundary\w+--\r\n}
       }.to_return(body: '{"b": "1"}', status: 200)
 
@@ -535,8 +544,8 @@ class JsonClientTest < MiniTest::Spec
   # EXACTLY the same as the post_multipart tests
   def test_client_can_put_multipart_responses
     url = "http://some.endpoint/some.json"
-    stub_request(:put, url).
-      with(headers: { "Content-Type" => %r{multipart/form-data; boundary=----RubyFormBoundary\w+} }) { |request|
+    stub_request(:put, url)
+      .with(headers: { "Content-Type" => %r{multipart/form-data; boundary=----RubyFormBoundary\w+} }) { |request|
         request.body =~ %r{------RubyFormBoundary\w+\r\nContent-Disposition: form-data; name="a"\r\n\r\n123\r\n------RubyFormBoundary\w+--\r\n}
       }.to_return(body: '{"b": "1"}', status: 200)
 

--- a/test/licence_application_api_test.rb
+++ b/test/licence_application_api_test.rb
@@ -18,35 +18,35 @@ class LicenceApplicationApiTest < Minitest::Test
   end
 
   def test_should_return_list_of_licences
-    stub_request(:get, "#{@core_url}/api/licences").
-      with(headers: GdsApi::JsonClient.default_request_headers).
-      to_return(status: 200,
-                body: <<~JSON,
-                  [
-                     {
-                        "code":"1324-5-1",
-                        "name":"Land drainage consents",
-                        "legislation":[
-                           "Land Drainage Act 1991"
-                        ]
-                     },
-                     {
-                        "code":"695-5-1",
-                        "name":"Skip operator licence",
-                        "legislation":[
-                           "Highways Act 1980, Section 139"
-                        ]
-                     },
-                     {
-                        "code":"1251-4-1",
-                        "name":"Residential care homes",
-                        "legislation":[
-                           "Health and Personal Social Services (Quality, Improvement and Regulation) (Northern Ireland) Order 2003"
-                        ]
-                     }
-                  ]
-                JSON
-              )
+    stub_request(:get, "#{@core_url}/api/licences")
+      .with(headers: GdsApi::JsonClient.default_request_headers)
+      .to_return(status: 200,
+                 body: <<~JSON,
+                   [
+                      {
+                         "code":"1324-5-1",
+                         "name":"Land drainage consents",
+                         "legislation":[
+                            "Land Drainage Act 1991"
+                         ]
+                      },
+                      {
+                         "code":"695-5-1",
+                         "name":"Skip operator licence",
+                         "legislation":[
+                            "Highways Act 1980, Section 139"
+                         ]
+                      },
+                      {
+                         "code":"1251-4-1",
+                         "name":"Residential care homes",
+                         "legislation":[
+                            "Health and Personal Social Services (Quality, Improvement and Regulation) (Northern Ireland) Order 2003"
+                         ]
+                      }
+                   ]
+                 JSON
+                )
 
     land_drainage = {
       "code" => "1324-5-1",
@@ -58,10 +58,10 @@ class LicenceApplicationApiTest < Minitest::Test
   end
 
   def test_should_return_error_message_if_licences_collection_not_found
-    stub_request(:get, "#{@core_url}/api/licences").
-      with(headers: GdsApi::JsonClient.default_request_headers).
-      to_return(status: 404,
-        body: "{\"error\": \"Error\"}")
+    stub_request(:get, "#{@core_url}/api/licences")
+      .with(headers: GdsApi::JsonClient.default_request_headers)
+      .to_return(status: 404,
+                 body: "{\"error\": \"Error\"}")
 
     assert_raises GdsApi::HTTPNotFound do
       api.all_licences
@@ -81,11 +81,11 @@ class LicenceApplicationApiTest < Minitest::Test
   end
 
   def test_should_provide_full_licence_details_for_canonical_id
-    stub_licence_exists("590001", "isLocationSpecific" => true, "geographicalAvailability" => %w(England Wales), "issuingAuthorities" => [])
+    stub_licence_exists("590001", "isLocationSpecific" => true, "geographicalAvailability" => %w[England Wales], "issuingAuthorities" => [])
 
     expected = {
       "isLocationSpecific" => true,
-      "geographicalAvailability" => %w(England Wales),
+      "geographicalAvailability" => %w[England Wales],
       "issuingAuthorities" => [],
     }
 
@@ -109,10 +109,10 @@ class LicenceApplicationApiTest < Minitest::Test
   end
 
   def test_should_return_error_message_to_pick_a_relevant_snac_code_for_the_provided_licence_id
-    stub_request(:get, "#{@core_url}/api/licence/590001/sw10").
-      with(headers: GdsApi::JsonClient.default_request_headers).
-      to_return(status: 404,
-                body: "{\"error\": \"No authorities found for the licence 590001 and for the snacCode sw10\"}")
+    stub_request(:get, "#{@core_url}/api/licence/590001/sw10")
+      .with(headers: GdsApi::JsonClient.default_request_headers)
+      .to_return(status: 404,
+                 body: "{\"error\": \"No authorities found for the licence 590001 and for the snacCode sw10\"}")
 
     assert_raises(GdsApi::HTTPNotFound) do
       api.details_for_licence("590001", "sw10")
@@ -172,10 +172,11 @@ class LicenceApplicationApiTest < Minitest::Test
 
     assert_equal true, response["isLocationSpecific"]
 
-    assert_includes response["issuingAuthorities"][0]["authorityInteractions"]["apply"], "url" => "https://www.gov.uk/motor-salvage-operator-registration/city-of-london/apply-1",
-      "usesLicensify" => true,
-      "description" => "Application to register as a motor salvage operator",
-      "payment" => "none"
+    assert_includes response["issuingAuthorities"][0]["authorityInteractions"]["apply"],
+                    "url" => "https://www.gov.uk/motor-salvage-operator-registration/city-of-london/apply-1",
+                    "usesLicensify" => true,
+                    "description" => "Application to register as a motor salvage operator",
+                    "payment" => "none"
   end
 
   def test_should_raise_exception_on_timeout

--- a/test/link_checker_api_test.rb
+++ b/test/link_checker_api_test.rb
@@ -56,7 +56,7 @@ describe GdsApi::LinkCheckerApi do
         "Test:10",
       )
 
-      assert resource_monitor.has_key?("id")
+      assert resource_monitor.key?("id")
     end
   end
 end

--- a/test/list_response_test.rb
+++ b/test/list_response_test.rb
@@ -8,7 +8,7 @@ describe GdsApi::ListResponse do
 
     it "should allow Enumerable access to the results array" do
       data = {
-        "results" => %w(foo bar baz),
+        "results" => %w[foo bar baz],
         "total" => 3,
         "_response_info" => {
           "status" => "ok",
@@ -17,7 +17,7 @@ describe GdsApi::ListResponse do
       response = GdsApi::ListResponse.new(stub(body: data.to_json), nil)
 
       assert_equal "foo", response.first
-      assert_equal %w(foo bar baz), response.to_a
+      assert_equal %w[foo bar baz], response.to_a
       assert response.any?
     end
 
@@ -39,21 +39,25 @@ describe GdsApi::ListResponse do
   describe "handling pagination" do
     before :each do
       page1 = {
-        "results" => %w(foo1 bar1),
+        "results" => %w[foo1 bar1],
         "total" => 6,
-        "current_page" => 1, "pages" => 3, "page_size" => 2,
+        "current_page" => 1,
+        "pages" => 3,
+        "page_size" => 2,
         "_response_info" => {
           "status" => "ok",
           "links" => [
             { "href" => "http://www.example.com/2", "rel" => "next" },
             { "href" => "http://www.example.com/1", "rel" => "self" },
           ],
-        }
+        },
       }
       page2 = {
-        "results" => %w(foo2 bar2),
+        "results" => %w[foo2 bar2],
         "total" => 6,
-        "current_page" => 2, "pages" => 3, "page_size" => 2,
+        "current_page" => 2,
+        "pages" => 3,
+        "page_size" => 2,
         "_response_info" => {
           "status" => "ok",
           "links" => [
@@ -61,19 +65,21 @@ describe GdsApi::ListResponse do
             { "href" => "http://www.example.com/3", "rel" => "next" },
             { "href" => "http://www.example.com/2", "rel" => "self" },
           ],
-        }
+        },
       }
       page3 = {
-        "results" => %w(foo3 bar3),
+        "results" => %w[foo3 bar3],
         "total" => 6,
-        "current_page" => 3, "pages" => 3, "page_size" => 2,
+        "current_page" => 3,
+        "pages" => 3,
+        "page_size" => 2,
         "_response_info" => {
           "status" => "ok",
           "links" => [
             { "href" => "http://www.example.com/2", "rel" => "previous" },
             { "href" => "http://www.example.com/3", "rel" => "self" },
           ],
-        }
+        },
       }
       @p1_response = stub(
         body: page1.to_json,
@@ -107,12 +113,12 @@ describe GdsApi::ListResponse do
       it "should allow accessing the next page" do
         resp = GdsApi::ListResponse.new(@p1_response, @client)
         assert resp.has_next_page?
-        assert_equal %w(foo2 bar2), resp.next_page["results"]
+        assert_equal %w[foo2 bar2], resp.next_page["results"]
       end
 
       it "should return nil with no next page" do
         resp = GdsApi::ListResponse.new(@p3_response, @client)
-        assert ! resp.has_next_page?
+        assert !resp.has_next_page?
         assert_nil resp.next_page
       end
 
@@ -131,12 +137,12 @@ describe GdsApi::ListResponse do
       it "should allow accessing the previous page" do
         resp = GdsApi::ListResponse.new(@p2_response, @client)
         assert resp.has_previous_page?
-        assert_equal %w(foo1 bar1), resp.previous_page["results"]
+        assert_equal %w[foo1 bar1], resp.previous_page["results"]
       end
 
       it "should return nil with no previous page" do
         resp = GdsApi::ListResponse.new(@p1_response, @client)
-        assert ! resp.has_previous_page?
+        assert !resp.has_previous_page?
         assert_nil resp.previous_page
       end
 
@@ -158,8 +164,8 @@ describe GdsApi::ListResponse do
 
       it "should allow iteration across multiple pages" do
         assert_equal 6, @response.with_subsequent_pages.count
-        assert_equal %w(foo1 bar1 foo2 bar2 foo3 bar3), @response.with_subsequent_pages.to_a
-        assert_equal(%w(foo1 foo2 foo3), @response.with_subsequent_pages.select { |s| s =~ /foo/ })
+        assert_equal %w[foo1 bar1 foo2 bar2 foo3 bar3], @response.with_subsequent_pages.to_a
+        assert_equal(%w[foo1 foo2 foo3], @response.with_subsequent_pages.select { |s| s =~ /foo/ })
       end
 
       it "should not load a page multiple times" do
@@ -174,7 +180,7 @@ describe GdsApi::ListResponse do
 
       it "should work with a non-paginated response" do
         data = {
-          "results" => %w(foo1 bar1),
+          "results" => %w[foo1 bar1],
           "total" => 2,
           "_response_info" => {
             "status" => "ok",
@@ -182,7 +188,7 @@ describe GdsApi::ListResponse do
         }
         response = GdsApi::ListResponse.new(stub(body: data.to_json, status: 200, headers: {}), nil)
 
-        assert_equal %w(foo1 bar1), response.with_subsequent_pages.to_a
+        assert_equal %w[foo1 bar1], response.with_subsequent_pages.to_a
       end
     end
   end

--- a/test/local_links_manager_api_test.rb
+++ b/test/local_links_manager_api_test.rb
@@ -23,9 +23,9 @@ describe GdsApi::LocalLinksManager do
         expected_response = {
           "local_authority" => {
             "name" => "Blackburn",
-              "snac" => "00AG",
-              "tier" => "unitary",
-              "homepage_url" => "http://blackburn.example.com",
+            "snac" => "00AG",
+            "tier" => "unitary",
+            "homepage_url" => "http://blackburn.example.com",
           },
           "local_interaction" => {
             "lgsl_code" => 2,
@@ -48,9 +48,9 @@ describe GdsApi::LocalLinksManager do
         expected_response = {
           "local_authority" => {
             "name" => "Blackburn",
-              "snac" => "00AG",
-              "tier" => "unitary",
-              "homepage_url" => "http://blackburn.example.com",
+            "snac" => "00AG",
+            "tier" => "unitary",
+            "homepage_url" => "http://blackburn.example.com",
           },
         }
 
@@ -68,9 +68,9 @@ describe GdsApi::LocalLinksManager do
         expected_response = {
           "local_authority" => {
             "name" => "Blackburn",
-              "snac" => "00AG",
-              "tier" => "unitary",
-              "homepage_url" => nil,
+            "snac" => "00AG",
+            "tier" => "unitary",
+            "homepage_url" => nil,
           },
         }
 

--- a/test/mapit_test.rb
+++ b/test/mapit_test.rb
@@ -27,10 +27,14 @@ describe GdsApi::Mapit do
     end
 
     it "should return areas" do
-      stub_mapit_has_a_postcode_and_areas("SW1A 1AA", [51.5010096, -0.1415870], [
-        { "name" => "Lancashire County Council", "type" => "CTY", "ons" => "30", "gss" => "E10000017" },
-        { "name" => "South Ribble Borough Council", "type" => "DIS", "ons" => "30UN", "gss" => "E07000126" },
-      ])
+      stub_mapit_has_a_postcode_and_areas(
+        "SW1A 1AA",
+        [51.5010096, -0.1415870],
+        [
+          { "name" => "Lancashire County Council", "type" => "CTY", "ons" => "30", "gss" => "E10000017" },
+          { "name" => "South Ribble Borough Council", "type" => "DIS", "ons" => "30UN", "gss" => "E07000126" },
+        ],
+      )
 
       response = @api.location_for_postcode("SW1A 1AA")
       assert_equal 2, response.areas.length
@@ -64,9 +68,12 @@ describe GdsApi::Mapit do
 
   describe "areas_for_type" do
     before do
-      stub_mapit_has_areas("EUR", "123" => { "name" => "Eastern", "id" => "123", "country_name" => "England" },
-       "234" => { "name" => "North West", "id" => "234", "country_name" => "England" },
-       "345" => { "name" => "Scotland", "id" => "345", "country_name" => "Scotland" })
+      stub_mapit_has_areas(
+        "EUR",
+        "123" => { "name" => "Eastern", "id" => "123", "country_name" => "England" },
+        "234" => { "name" => "North West", "id" => "234", "country_name" => "England" },
+        "345" => { "name" => "Scotland", "id" => "345", "country_name" => "Scotland" },
+      )
       stub_mapit_does_not_have_areas("FOO")
     end
     it "should return areas of a type" do

--- a/test/maslow_test.rb
+++ b/test/maslow_test.rb
@@ -7,6 +7,6 @@ describe GdsApi::Maslow do
   end
 
   it "should provide a URL to need pages" do
-    assert_equal "http://maslow.dev.gov.uk/needs/12345", @api.need_page_url(12345)
+    assert_equal "http://maslow.dev.gov.uk/needs/12345", @api.need_page_url(12_345)
   end
 end

--- a/test/middleware/govuk_header_sniffer_test.rb
+++ b/test/middleware/govuk_header_sniffer_test.rb
@@ -5,7 +5,7 @@ describe GdsApi::GovukHeaderSniffer do
   include Rack::Test::Methods
 
   let(:inner_app) do
-    lambda { |_env| [200, { "Content-Type" => "text/plain" }, ["All good!"]] }
+    ->(_env) { [200, { "Content-Type" => "text/plain" }, ["All good!"]] }
   end
 
   let(:app) { GdsApi::GovukHeaderSniffer.new(inner_app, "HTTP_GOVUK_REQUEST_ID") }

--- a/test/organisations_api_test.rb
+++ b/test/organisations_api_test.rb
@@ -12,7 +12,7 @@ describe GdsApi::Organisations do
 
   describe "fetching list of organisations" do
     it "should get the organisations" do
-      organisation_slugs = %w(ministry-of-fun tea-agency)
+      organisation_slugs = %w[ministry-of-fun tea-agency]
       stub_organisations_api_has_organisations(organisation_slugs)
 
       response = @api.organisations

--- a/test/pp_data_in_test.rb
+++ b/test/pp_data_in_test.rb
@@ -21,7 +21,7 @@ describe GdsApi::PerformancePlatform::DataIn do
   end
 
   it "can submit entries counts for corporate content problem reports" do
-    entries = %w(some entries)
+    entries = %w[some entries]
 
     stub_post = stub_corporate_content_problem_report_count_submission(entries)
 
@@ -31,7 +31,7 @@ describe GdsApi::PerformancePlatform::DataIn do
   end
 
   it "can submit the corporate content urls with the most problem reports" do
-    entries = %w(some entries)
+    entries = %w[some entries]
 
     stub_post = stub_corporate_content_urls_with_the_most_problem_reports_submission(entries)
 

--- a/test/publishing_api/special_route_publisher_test.rb
+++ b/test/publishing_api/special_route_publisher_test.rb
@@ -7,7 +7,7 @@ describe GdsApi::PublishingApi::SpecialRoutePublisher do
   include ::GdsApi::TestHelpers::PublishingApi
 
   let(:content_id) { "a-content-id-of-sorts" }
-  let(:special_route) {
+  let(:special_route) do
     {
       content_id: content_id,
       title: "A title",
@@ -17,7 +17,7 @@ describe GdsApi::PublishingApi::SpecialRoutePublisher do
       publishing_app: "static",
       rendering_app: "static",
     }
-  }
+  end
 
   let(:publisher) { GdsApi::PublishingApi::SpecialRoutePublisher.new }
   let(:endpoint) { Plek.current.find("publishing-api") }
@@ -87,12 +87,12 @@ describe GdsApi::PublishingApi::SpecialRoutePublisher do
     end
 
     describe "Timezone handling" do
-      let(:publishing_api) {
+      let(:publishing_api) do
         stub(:publishing_api, put_content_item: nil)
-      }
-      let(:publisher) {
+      end
+      let(:publisher) do
         GdsApi::PublishingApi::SpecialRoutePublisher.new(publishing_api: publishing_api)
-      }
+      end
 
       it "is robust to Time.zone returning nil" do
         Timecop.freeze(Time.now) do

--- a/test/publishing_api_test.rb
+++ b/test/publishing_api_test.rb
@@ -1274,9 +1274,12 @@ describe GdsApi::PublishingApi do
       end
 
       it "replaces the links and responds with the new links" do
-        response = @api_client.patch_links(@content_id, links: {
-          organisations: %w[591436ab-c2ae-416f-a3c5-1901d633fbfb],
-        })
+        response = @api_client.patch_links(
+          @content_id,
+          links: {
+            organisations: %w[591436ab-c2ae-416f-a3c5-1901d633fbfb],
+          },
+        )
         assert_equal 200, response.code
         assert_equal(
           %w[591436ab-c2ae-416f-a3c5-1901d633fbfb],
@@ -1314,9 +1317,12 @@ describe GdsApi::PublishingApi do
       end
 
       it "adds the new type of links and responds with the whole link set" do
-        response = @api_client.patch_links(@content_id, links: {
-          topics: %w[225df4a8-2945-4e9b-8799-df7424a90b69],
-        })
+        response = @api_client.patch_links(
+          @content_id,
+          links: {
+            topics: %w[225df4a8-2945-4e9b-8799-df7424a90b69],
+          },
+        )
 
         assert_equal 200, response.code
         assert_equal(
@@ -1355,9 +1361,12 @@ describe GdsApi::PublishingApi do
       end
 
       it "responds with the links" do
-        response = @api_client.patch_links(@content_id, links: {
-          organisations: [],
-        })
+        response = @api_client.patch_links(
+          @content_id,
+          links: {
+            organisations: [],
+          },
+        )
 
         assert_equal 200, response.code
         assert_equal({}, response["links"])
@@ -1392,9 +1401,12 @@ describe GdsApi::PublishingApi do
       end
 
       it "responds with the links" do
-        response = @api_client.patch_links(@content_id, links: {
-          organisations: %w[591436ab-c2ae-416f-a3c5-1901d633fbfb],
-        })
+        response = @api_client.patch_links(
+          @content_id,
+          links: {
+            organisations: %w[591436ab-c2ae-416f-a3c5-1901d633fbfb],
+          },
+        )
 
         assert_equal 200, response.code
         assert_equal(
@@ -1497,7 +1509,7 @@ describe GdsApi::PublishingApi do
   end
 
   describe "#get_linkables" do
-    let(:linkables) {
+    let(:linkables) do
       [
         {
           "title" => "Content Item A",
@@ -1514,7 +1526,7 @@ describe GdsApi::PublishingApi do
           "base_path" => "/another-base-path",
         },
       ]
-    }
+    end
 
     it "returns the content items of a given document_type" do
       publishing_api
@@ -1540,7 +1552,7 @@ describe GdsApi::PublishingApi do
   end
 
   describe "#get_links_changes" do
-    let(:link_changes) {
+    let(:link_changes) do
       { "link_changes" => [
         {
           "source" => { "title" => "Edition Title A1",
@@ -1567,7 +1579,7 @@ describe GdsApi::PublishingApi do
           "created_at" => "2017-01-01T09:00:00.100Z",
         },
       ] }
-    }
+    end
 
     it "returns the changes for a single link_type" do
       publishing_api
@@ -1586,7 +1598,7 @@ describe GdsApi::PublishingApi do
           body: link_changes,
         )
 
-      response = @api_client.get_links_changes(link_types: %w(taxons))
+      response = @api_client.get_links_changes(link_types: %w[taxons])
       assert_equal 200, response.code
       assert_equal link_changes, response.to_hash
     end
@@ -1612,7 +1624,7 @@ describe GdsApi::PublishingApi do
             pages: 2,
             current_page: 1,
             links: [{ href: "http://example.org/v2/content?document_type=topic&fields%5B%5D=title&fields%5B%5D=base_path&per_page=2&page=2",
-                     rel: "next" },
+                      rel: "next" },
                     { href: "http://example.org/v2/content?document_type=topic&fields%5B%5D=title&fields%5B%5D=base_path&per_page=2&page=1",
                       rel: "self" }],
             results: [
@@ -1660,7 +1672,6 @@ describe GdsApi::PublishingApi do
     end
   end
 
-
   describe "#get_content_items" do
     it "returns the content items of a certain document_type" do
       publishing_api
@@ -1704,7 +1715,8 @@ describe GdsApi::PublishingApi do
         ["current_page", 1],
         ["links", [{ "href" => "http://example.org/v2/content?document_type=topic&fields%5B%5D=title&fields%5B%5D=base_path&page=1", "rel" => "self" }]],
         ["results", [{ "title" => "Content Item A", "base_path" => "/a-base-path" }, { "title" => "Content Item B", "base_path" => "/another-base-path" }]],
-      ], response.to_a
+      ],
+                   response.to_a
     end
 
     it "returns the content items in english locale by default" do
@@ -1748,7 +1760,8 @@ describe GdsApi::PublishingApi do
         ["current_page", 1],
         ["links", [{ "href" => "http://example.org/v2/content?document_type=topic&fields%5B%5D=content_id&fields%5B%5D=locale&page=1", "rel" => "self" }]],
         ["results", [{ "content_id" => "bed722e6-db68-43e5-9079-063f623335a7", "locale" => "en" }]],
-      ], response.to_a
+      ],
+                   response.to_a
     end
 
     it "returns the content items in a specific locale" do
@@ -1792,7 +1805,8 @@ describe GdsApi::PublishingApi do
         ["current_page", 1],
         ["links", [{ "href" => "http://example.org/v2/content?document_type=topic&fields%5B%5D=content_id&fields%5B%5D=locale&locale=fr&page=1", "rel" => "self" }]],
         ["results", [{ "content_id" => "bed722e6-db68-43e5-9079-063f623335a7", "locale" => "fr" }]],
-      ], response.to_a
+      ],
+                   response.to_a
     end
 
     it "returns the content items in all the available locales" do
@@ -1834,14 +1848,16 @@ describe GdsApi::PublishingApi do
       assert_equal 200, response.code
       assert_equal [
         ["total", 3],
-        ["pages", 1], ["current_page", 1],
+        ["pages", 1],
+        ["current_page", 1],
         ["links",
          [{ "href" => "http://example.org/v2/content?document_type=topic&fields%5B%5D=content_id&fields%5B%5D=locale&locale=all&page=1", "rel" => "self" }]],
         ["results",
          [{ "content_id" => "bed722e6-db68-43e5-9079-063f623335a7", "locale" => "en" },
           { "content_id" => "bed722e6-db68-43e5-9079-063f623335a7", "locale" => "fr" },
-          { "content_id" => "bed722e6-db68-43e5-9079-063f623335a7", "locale" => "ar" }]]
-      ], response.to_a
+          { "content_id" => "bed722e6-db68-43e5-9079-063f623335a7", "locale" => "ar" }]],
+      ],
+                   response.to_a
     end
 
     it "returns details hashes" do
@@ -1885,7 +1901,8 @@ describe GdsApi::PublishingApi do
         ["current_page", 1],
         ["links", [{ "href" => "http://example.org/v2/content?document_type=topic&fields%5B%5D=content_id&fields%5B%5D=details&page=1", "rel" => "self" }]],
         ["results", [{ "content_id" => "bed722e6-db68-43e5-9079-063f623335a7", "details" => { "foo" => "bar" } }]],
-      ], response.to_a
+      ],
+                   response.to_a
     end
 
     it "returns the items matching a query" do
@@ -1931,7 +1948,8 @@ describe GdsApi::PublishingApi do
         ["current_page", 1],
         ["links", [{ "href" => "http://example.org/v2/content?document_type=topic&fields%5B%5D=content_id&q=an+internal+name&search_in%5B%5D=details.internal_name&page=1", "rel" => "self" }]],
         ["results", [{ "content_id" => "aaaaaaaa-aaaa-1aaa-aaaa-aaaaaaaaaaaa" }]],
-      ], response.to_a
+      ],
+                   response.to_a
     end
   end
 
@@ -2088,7 +2106,7 @@ describe GdsApi::PublishingApi do
           @api_client.get_linked_items(
             @content_id,
             link_type: "topic",
-            fields: %w(content_id base_path),
+            fields: %w[content_id base_path],
           )
         end
       end
@@ -2145,7 +2163,7 @@ describe GdsApi::PublishingApi do
         response = @api_client.get_linked_items(
           @linked_content_item["content_id"],
           link_type: "topic",
-          fields: %w(content_id base_path),
+          fields: %w[content_id base_path],
         )
         assert_equal 200, response.code
 
@@ -2190,7 +2208,7 @@ describe GdsApi::PublishingApi do
       end
 
       it "will response correctly" do
-        response = @api_client.get_editions(fields: %w(content_id))
+        response = @api_client.get_editions(fields: %w[content_id])
         assert_equal response["results"].length, 2
       end
     end
@@ -2285,7 +2303,7 @@ describe GdsApi::PublishingApi do
           .with("http://example.org#{second_page_path}")
           .returns(GdsApi::JsonClient.new.get_json("#{publishing_api_host}#{second_page_path}", second_page[:request][:headers]))
 
-        response = @api_client.get_paged_editions(fields: %w(content_id), per_page: 2).to_a
+        response = @api_client.get_paged_editions(fields: %w[content_id], per_page: 2).to_a
 
         response.count.must_equal 2
         first_page_content_ids = response[0]["results"].map { |content_item| content_item["content_id"] }
@@ -2521,7 +2539,7 @@ describe GdsApi::PublishingApi do
           status: 200,
           body: {
             "publishing_app" => "publisher",
-            "rendering_app" =>  "frontend",
+            "rendering_app" => "frontend",
             "publish_time" => "2019-11-11t17:56:17+00:00",
           },
           headers: {

--- a/test/response_test.rb
+++ b/test/response_test.rb
@@ -195,7 +195,7 @@ describe GdsApi::Response do
     before :each do
       @response_data = {
         "_response_info" => {
-            "status" => "ok",
+          "status" => "ok",
         },
         "id" => "https://www.gov.uk/api/vat-rates.json",
         "web_url" => "https://www.gov.uk/vat-rates",
@@ -203,10 +203,10 @@ describe GdsApi::Response do
         "format" => "answer",
         "updated_at" => "2013-04-04T15:51:54+01:00",
         "details" => {
-            "need_id" => "1870",
-            "business_proposition" => false,
-            "description" => "Current VAT rates - standard 20% and rates for reduced rate and zero-rated items",
-            "language" => "en",
+          "need_id" => "1870",
+          "business_proposition" => false,
+          "description" => "Current VAT rates - standard 20% and rates for reduced rate and zero-rated items",
+          "language" => "en",
         },
         "tags" => [
           { "slug" => "foo" },

--- a/test/router_test.rb
+++ b/test/router_test.rb
@@ -19,9 +19,9 @@ describe GdsApi::Router do
   describe "managing backends" do
     describe "fetching details about a backend" do
       it "should return backend details" do
-        req = WebMock.stub_request(:get, "#{@base_api_url}/backends/foo").
-          to_return(body: { "backend_id" => "foo", "backend_url" => "http://foo.example.com/" }.to_json,
-                    headers: { "Content-type" => "application/json" })
+        req = WebMock.stub_request(:get, "#{@base_api_url}/backends/foo")
+          .to_return(body: { "backend_id" => "foo", "backend_url" => "http://foo.example.com/" }.to_json,
+                     headers: { "Content-type" => "application/json" })
 
         response = @api.get_backend("foo")
         assert_equal 200, response.code
@@ -31,8 +31,8 @@ describe GdsApi::Router do
       end
 
       it "raises for a non-existend backend" do
-        req = WebMock.stub_request(:get, "#{@base_api_url}/backends/foo").
-          to_return(status: 404)
+        req = WebMock.stub_request(:get, "#{@base_api_url}/backends/foo")
+          .to_return(status: 404)
 
         assert_raises(GdsApi::HTTPNotFound) do
           @api.get_backend("foo")
@@ -42,8 +42,8 @@ describe GdsApi::Router do
       end
 
       it "should URI escape the given ID" do
-        req = WebMock.stub_request(:get, "#{@base_api_url}/backends/foo+bar").
-          to_return(status: 404)
+        req = WebMock.stub_request(:get, "#{@base_api_url}/backends/foo+bar")
+          .to_return(status: 404)
 
         assert_raises(GdsApi::HTTPNotFound) do
           @api.get_backend("foo bar")
@@ -55,10 +55,11 @@ describe GdsApi::Router do
 
     describe "creating/updating a backend" do
       it "should allow creating/updating a backend" do
-        req = WebMock.stub_request(:put, "#{@base_api_url}/backends/foo").
-          with(body: { "backend" => { "backend_url" => "http://foo.example.com/" } }.to_json).
-          to_return(status: 201, body: { "backend_id" => "foo", "backend_url" => "http://foo.example.com/" }.to_json,
-                    headers: { "Content-type" => "application/json" })
+        req = WebMock.stub_request(:put, "#{@base_api_url}/backends/foo")
+          .with(body: { "backend" => { "backend_url" => "http://foo.example.com/" } }.to_json)
+          .to_return(status: 201,
+                     body: { "backend_id" => "foo", "backend_url" => "http://foo.example.com/" }.to_json,
+                     headers: { "Content-type" => "application/json" })
 
         response = @api.add_backend("foo", "http://foo.example.com/")
         assert_equal 201, response.code
@@ -89,9 +90,9 @@ describe GdsApi::Router do
       end
 
       it "should URI escape the passed id" do
-        req = WebMock.stub_request(:put, "#{@base_api_url}/backends/foo+bar").
-          with(body: { "backend" => { "backend_url" => "http://foo.example.com/" } }.to_json).
-          to_return(status: 404, body: "Not found")
+        req = WebMock.stub_request(:put, "#{@base_api_url}/backends/foo+bar")
+          .with(body: { "backend" => { "backend_url" => "http://foo.example.com/" } }.to_json)
+          .to_return(status: 404, body: "Not found")
 
         # We expect a GdsApi::HTTPErrorResponse, but we want to ensure nothing else is raised
         begin
@@ -106,9 +107,10 @@ describe GdsApi::Router do
 
     describe "deleting a backend" do
       it "allow deleting a backend" do
-        req = WebMock.stub_request(:delete, "#{@base_api_url}/backends/foo").
-          to_return(status: 200, body: { "backend_id" => "foo", "backend_url" => "http://foo.example.com/" }.to_json,
-                    headers: { "Content-type" => "application/json" })
+        req = WebMock.stub_request(:delete, "#{@base_api_url}/backends/foo")
+          .to_return(status: 200,
+                     body: { "backend_id" => "foo", "backend_url" => "http://foo.example.com/" }.to_json,
+                     headers: { "Content-type" => "application/json" })
 
         response = @api.delete_backend("foo")
         assert_equal 200, response.code
@@ -138,8 +140,8 @@ describe GdsApi::Router do
       end
 
       it "should URI escape the passed id" do
-        req = WebMock.stub_request(:delete, "#{@base_api_url}/backends/foo+bar").
-          to_return(status: 404, body: "Not found")
+        req = WebMock.stub_request(:delete, "#{@base_api_url}/backends/foo+bar")
+          .to_return(status: 404, body: "Not found")
 
         assert_raises GdsApi::HTTPErrorResponse do
           @api.delete_backend("foo bar")
@@ -152,8 +154,8 @@ describe GdsApi::Router do
 
   describe "managing routes" do
     before :each do
-      @commit_req = WebMock.stub_request(:post, "#{@base_api_url}/routes/commit").
-        to_return(status: 200, body: "Routers updated")
+      @commit_req = WebMock.stub_request(:post, "#{@base_api_url}/routes/commit")
+        .to_return(status: 200, body: "Routers updated")
     end
 
     describe "fetching a route" do
@@ -199,9 +201,9 @@ describe GdsApi::Router do
       it "should escape the params" do
         # The WebMock query matcher matches unescaped params.  The call blows up if they're not escaped
 
-        req = WebMock.stub_request(:get, "#{@base_api_url}/routes").
-          with(query: { "incoming_path" => "/foo bar" }).
-          to_return(status: 404)
+        req = WebMock.stub_request(:get, "#{@base_api_url}/routes")
+          .with(query: { "incoming_path" => "/foo bar" })
+          .to_return(status: 404)
 
         assert_raises(GdsApi::HTTPNotFound) do
           @api.get_route("/foo bar")
@@ -215,9 +217,9 @@ describe GdsApi::Router do
     describe "creating/updating a route" do
       it "should allow creating/updating a route" do
         route_data = { "incoming_path" => "/foo", "route_type" => "exact", "handler" => "backend", "backend_id" => "foo" }
-        req = WebMock.stub_request(:put, "#{@base_api_url}/routes").
-          with(body: { "route" => route_data }.to_json).
-          to_return(status: 201, body: route_data.to_json, headers: { "Content-type" => "application/json" })
+        req = WebMock.stub_request(:put, "#{@base_api_url}/routes")
+          .with(body: { "route" => route_data }.to_json)
+          .to_return(status: 201, body: route_data.to_json, headers: { "Content-type" => "application/json" })
 
         response = @api.add_route("/foo", "exact", "foo")
         assert_equal 201, response.code
@@ -228,8 +230,8 @@ describe GdsApi::Router do
       end
 
       it "should commit the routes when asked to" do
-        req = WebMock.stub_request(:put, "#{@base_api_url}/routes").
-          to_return(status: 201, body: {}.to_json, headers: { "Content-type" => "application/json" })
+        req = WebMock.stub_request(:put, "#{@base_api_url}/routes")
+          .to_return(status: 201, body: {}.to_json, headers: { "Content-type" => "application/json" })
 
         @api.add_route("/foo", "exact", "foo", commit: true)
 
@@ -259,11 +261,15 @@ describe GdsApi::Router do
 
     describe "creating/updating a redirect route" do
       it "should allow creating/updating a redirect route" do
-        route_data = { "incoming_path" => "/foo", "route_type" => "exact", "handler" => "redirect",
-          "redirect_to" => "/bar", "redirect_type" => "permanent", "segments_mode" => nil }
-        req = WebMock.stub_request(:put, "#{@base_api_url}/routes").
-          with(body: { "route" => route_data }.to_json).
-          to_return(status: 201, body: route_data.to_json, headers: { "Content-type" => "application/json" })
+        route_data = { "incoming_path" => "/foo",
+                       "route_type" => "exact",
+                       "handler" => "redirect",
+                       "redirect_to" => "/bar",
+                       "redirect_type" => "permanent",
+                       "segments_mode" => nil }
+        req = WebMock.stub_request(:put, "#{@base_api_url}/routes")
+          .with(body: { "route" => route_data }.to_json)
+          .to_return(status: 201, body: route_data.to_json, headers: { "Content-type" => "application/json" })
 
         response = @api.add_redirect_route("/foo", "exact", "/bar")
         assert_equal 201, response.code
@@ -274,11 +280,15 @@ describe GdsApi::Router do
       end
 
       it "should allow creating/updating a temporary redirect route" do
-        route_data = { "incoming_path" => "/foo", "route_type" => "exact", "handler" => "redirect",
-          "redirect_to" => "/bar", "redirect_type" => "temporary", "segments_mode" => nil }
-        req = WebMock.stub_request(:put, "#{@base_api_url}/routes").
-          with(body: { "route" => route_data }.to_json).
-          to_return(status: 201, body: route_data.to_json, headers: { "Content-type" => "application/json" })
+        route_data = { "incoming_path" => "/foo",
+                       "route_type" => "exact",
+                       "handler" => "redirect",
+                       "redirect_to" => "/bar",
+                       "redirect_type" => "temporary",
+                       "segments_mode" => nil }
+        req = WebMock.stub_request(:put, "#{@base_api_url}/routes")
+          .with(body: { "route" => route_data }.to_json)
+          .to_return(status: 201, body: route_data.to_json, headers: { "Content-type" => "application/json" })
 
         response = @api.add_redirect_route("/foo", "exact", "/bar", "temporary")
         assert_equal 201, response.code
@@ -289,11 +299,15 @@ describe GdsApi::Router do
       end
 
       it "should allow creating/updating a redirect route which preserves segments" do
-        route_data = { "incoming_path" => "/foo", "route_type" => "exact", "handler" => "redirect",
-          "redirect_to" => "/bar", "redirect_type" => "temporary", "segments_mode" => "preserve" }
-        req = WebMock.stub_request(:put, "#{@base_api_url}/routes").
-          with(body: { "route" => route_data }.to_json).
-          to_return(status: 201, body: route_data.to_json, headers: { "Content-type" => "application/json" })
+        route_data = { "incoming_path" => "/foo",
+                       "route_type" => "exact",
+                       "handler" => "redirect",
+                       "redirect_to" => "/bar",
+                       "redirect_type" => "temporary",
+                       "segments_mode" => "preserve" }
+        req = WebMock.stub_request(:put, "#{@base_api_url}/routes")
+          .with(body: { "route" => route_data }.to_json)
+          .to_return(status: 201, body: route_data.to_json, headers: { "Content-type" => "application/json" })
 
         response = @api.add_redirect_route("/foo", "exact", "/bar", "temporary", segments_mode: "preserve")
         assert_equal 201, response.code
@@ -304,8 +318,8 @@ describe GdsApi::Router do
       end
 
       it "should commit the routes when asked to" do
-        req = WebMock.stub_request(:put, "#{@base_api_url}/routes").
-          to_return(status: 201, body: {}.to_json, headers: { "Content-type" => "application/json" })
+        req = WebMock.stub_request(:put, "#{@base_api_url}/routes")
+          .to_return(status: 201, body: {}.to_json, headers: { "Content-type" => "application/json" })
 
         @api.add_redirect_route("/foo", "exact", "/bar", "temporary", commit: true)
 
@@ -314,8 +328,12 @@ describe GdsApi::Router do
       end
 
       it "should raise an error if creating/updating the redirect route fails" do
-        route_data = { "incoming_path" => "/foo", "route_type" => "exact", "handler" => "redirect",
-          "redirect_to" => "bar", "redirect_type" => "permanent", "segments_mode" => nil }
+        route_data = { "incoming_path" => "/foo",
+                       "route_type" => "exact",
+                       "handler" => "redirect",
+                       "redirect_to" => "bar",
+                       "redirect_type" => "permanent",
+                       "segments_mode" => nil }
         response_data = route_data.merge("errors" => { "redirect_to" => "is not a valid URL path" })
 
         req = WebMock.stub_request(:put, "#{@base_api_url}/routes")
@@ -337,9 +355,9 @@ describe GdsApi::Router do
     describe "#add_gone_route" do
       it "should allow creating/updating a gone route" do
         route_data = { "incoming_path" => "/foo", "route_type" => "exact", "handler" => "gone" }
-        req = WebMock.stub_request(:put, "#{@base_api_url}/routes").
-          with(body: { "route" => route_data }.to_json).
-          to_return(status: 201, body: route_data.to_json, headers: { "Content-type" => "application/json" })
+        req = WebMock.stub_request(:put, "#{@base_api_url}/routes")
+          .with(body: { "route" => route_data }.to_json)
+          .to_return(status: 201, body: route_data.to_json, headers: { "Content-type" => "application/json" })
 
         response = @api.add_gone_route("/foo", "exact")
         assert_equal 201, response.code
@@ -350,8 +368,8 @@ describe GdsApi::Router do
       end
 
       it "should commit the routes when asked to" do
-        req = WebMock.stub_request(:put, "#{@base_api_url}/routes").
-          to_return(status: 201, body: {}.to_json, headers: { "Content-type" => "application/json" })
+        req = WebMock.stub_request(:put, "#{@base_api_url}/routes")
+          .to_return(status: 201, body: {}.to_json, headers: { "Content-type" => "application/json" })
 
         @api.add_gone_route("/foo", "exact", commit: true)
 
@@ -382,9 +400,9 @@ describe GdsApi::Router do
     describe "deleting a route" do
       it "should allow deleting a route" do
         route_data = { "incoming_path" => "/foo", "route_type" => "exact", "handler" => "backend", "backend_id" => "foo" }
-        req = WebMock.stub_request(:delete, "#{@base_api_url}/routes").
-          with(query: { "incoming_path" => "/foo" }).
-          to_return(status: 200, body: route_data.to_json, headers: { "Content-type" => "application/json" })
+        req = WebMock.stub_request(:delete, "#{@base_api_url}/routes")
+          .with(query: { "incoming_path" => "/foo" })
+          .to_return(status: 200, body: route_data.to_json, headers: { "Content-type" => "application/json" })
 
         response = @api.delete_route("/foo")
         assert_equal 200, response.code
@@ -395,9 +413,9 @@ describe GdsApi::Router do
       end
 
       it "should commit the routes when asked to" do
-        req = WebMock.stub_request(:delete, "#{@base_api_url}/routes").
-          with(query: { "incoming_path" => "/foo" }).
-          to_return(status: 200, body: {}.to_json, headers: { "Content-type" => "application/json" })
+        req = WebMock.stub_request(:delete, "#{@base_api_url}/routes")
+          .with(query: { "incoming_path" => "/foo" })
+          .to_return(status: 200, body: {}.to_json, headers: { "Content-type" => "application/json" })
 
         @api.delete_route("/foo", commit: true)
 
@@ -406,9 +424,9 @@ describe GdsApi::Router do
       end
 
       it "should raise HTTPNotFound if nothing found" do
-        req = WebMock.stub_request(:delete, "#{@base_api_url}/routes").
-          with(query: { "incoming_path" => "/foo" }).
-          to_return(status: 404)
+        req = WebMock.stub_request(:delete, "#{@base_api_url}/routes")
+          .with(query: { "incoming_path" => "/foo" })
+          .to_return(status: 404)
 
         e = assert_raises(GdsApi::HTTPNotFound) do
           @api.delete_route("/foo")
@@ -423,9 +441,9 @@ describe GdsApi::Router do
       it "should escape the params" do
         # The WebMock query matcher matches unescaped params.  The call blows up if they're not escaped
 
-        req = WebMock.stub_request(:delete, "#{@base_api_url}/routes").
-          with(query: { "incoming_path" => "/foo bar" }).
-          to_return(status: 404)
+        req = WebMock.stub_request(:delete, "#{@base_api_url}/routes")
+          .with(query: { "incoming_path" => "/foo bar" })
+          .to_return(status: 404)
 
         assert_raises GdsApi::HTTPNotFound do
           @api.delete_route("/foo bar")
@@ -443,8 +461,8 @@ describe GdsApi::Router do
       end
 
       it "should raise an error if committing the routes fails" do
-        WebMock.stub_request(:post, "#{@base_api_url}/routes/commit").
-          to_return(status: 500, body: "Failed to update all routers")
+        WebMock.stub_request(:post, "#{@base_api_url}/routes/commit")
+          .to_return(status: 500, body: "Failed to update all routers")
 
         e = assert_raises(GdsApi::HTTPErrorResponse) do
           @api.commit_routes

--- a/test/search.rb
+++ b/test/search.rb
@@ -66,7 +66,7 @@ describe GdsApi::Search do
   it "#search should issue a request for all the params supplied" do
     GdsApi::Search.new("http://example.com").search(
       q: "query & stuff",
-      filter_topics: %w(1 2),
+      filter_topics: %w[1 2],
       order: "-public_timestamp",
     )
 

--- a/test/support_api_test.rb
+++ b/test/support_api_test.rb
@@ -50,7 +50,7 @@ describe GdsApi::SupportApi do
   end
 
   it "fetches problem report daily totals" do
-    response_body = { "data" => %w(results) }
+    response_body = { "data" => %w[results] }
     request_date = Date.new(2014, 7, 12)
 
     stub_get = stub_support_api_problem_report_daily_totals_for(request_date, response_body.to_json)

--- a/test/support_test.rb
+++ b/test/support_test.rb
@@ -13,9 +13,9 @@ describe GdsApi::Support do
   it "can create an FOI request" do
     request_details = { "foi_request" => { "requester" => { "name" => "A", "email" => "a@b.com" }, "details" => "abc" } }
 
-    stub_post = stub_request(:post, "#{@base_api_url}/foi_requests").
-      with(body: { "foi_request" => request_details }.to_json).
-      to_return(status: 201)
+    stub_post = stub_request(:post, "#{@base_api_url}/foi_requests")
+      .with(body: { "foi_request" => request_details }.to_json)
+      .to_return(status: 201)
 
     @api.create_foi_request(request_details)
 
@@ -31,9 +31,9 @@ describe GdsApi::Support do
   it "can create a named contact" do
     request_details = { certain: "details" }
 
-    stub_post = stub_request(:post, "#{@base_api_url}/named_contacts").
-      with(body: { "named_contact" => request_details }.to_json).
-      to_return(status: 201)
+    stub_post = stub_request(:post, "#{@base_api_url}/named_contacts")
+      .with(body: { "named_contact" => request_details }.to_json)
+      .to_return(status: 201)
 
     @api.create_named_contact(request_details)
 
@@ -47,7 +47,9 @@ describe GdsApi::Support do
   end
 
   it "gets the correct feedback URL" do
-    assert_equal("#{@base_api_url}/anonymous_feedback?path=foo",
-                 @api.feedback_url("foo"))
+    assert_equal(
+      "#{@base_api_url}/anonymous_feedback?path=foo",
+      @api.feedback_url("foo"),
+    )
   end
 end

--- a/test/test_helpers/email_alert_api_test.rb
+++ b/test/test_helpers/email_alert_api_test.rb
@@ -56,7 +56,7 @@ describe GdsApi::TestHelpers::EmailAlertApi do
       stub_email_alert_api_has_subscriber_subscriptions(
         id,
         address,
-        subscriptions: %w(one two),
+        subscriptions: %w[one two],
       )
 
       result = email_alert_api.get_subscriptions(id: id)

--- a/test/test_helpers/publishing_api_test.rb
+++ b/test/test_helpers/publishing_api_test.rb
@@ -35,13 +35,13 @@ describe GdsApi::TestHelpers::PublishingApi do
   describe "#stub_publish_api_has_links_for_content_ids" do
     it "stubs the call to get links for content ids" do
       links = {
-                "2878337b-bed9-4e7f-85b6-10ed2cbcd504" => {
-                  "links" => { "taxons" => %w[eb6965c7-3056-45d0-ae50-2f0a5e2e0854] },
-                },
-                "eec13cea-219d-4896-9c97-60114da23559" => {
-                  "links" => {},
-                },
-              }
+        "2878337b-bed9-4e7f-85b6-10ed2cbcd504" => {
+          "links" => { "taxons" => %w[eb6965c7-3056-45d0-ae50-2f0a5e2e0854] },
+        },
+        "eec13cea-219d-4896-9c97-60114da23559" => {
+          "links" => {},
+        },
+      }
 
       stub_publishing_api_has_links_for_content_ids(links)
 
@@ -179,14 +179,17 @@ describe GdsApi::TestHelpers::PublishingApi do
       stub_publishing_api_has_expanded_links(payload)
       response = publishing_api.get_expanded_links("2e20294a-d694-4083-985e-d8bedefc2354")
 
-      assert_equal({
-        "content_id" => "2e20294a-d694-4083-985e-d8bedefc2354",
-        "organisations" => [
-          {
-            "content_id" => %w[a8a09822-1729-48a7-8a68-d08300de9d1e],
-          },
-        ],
-      }, response.to_h)
+      assert_equal(
+        {
+          "content_id" => "2e20294a-d694-4083-985e-d8bedefc2354",
+          "organisations" => [
+            {
+              "content_id" => %w[a8a09822-1729-48a7-8a68-d08300de9d1e],
+            },
+          ],
+        },
+        response.to_h,
+      )
     end
 
     it "stubs the call to get expanded links when content_id is a string" do
@@ -202,14 +205,17 @@ describe GdsApi::TestHelpers::PublishingApi do
       stub_publishing_api_has_expanded_links(payload)
       response = publishing_api.get_expanded_links("2e20294a-d694-4083-985e-d8bedefc2354")
 
-      assert_equal({
-        "content_id" => "2e20294a-d694-4083-985e-d8bedefc2354",
-        "organisations" => [
-          {
-            "content_id" => %w[a8a09822-1729-48a7-8a68-d08300de9d1e],
-          },
-        ],
-      }, response.to_h)
+      assert_equal(
+        {
+          "content_id" => "2e20294a-d694-4083-985e-d8bedefc2354",
+          "organisations" => [
+            {
+              "content_id" => %w[a8a09822-1729-48a7-8a68-d08300de9d1e],
+            },
+          ],
+        },
+        response.to_h,
+      )
     end
 
     it "stubs with query parameters" do
@@ -225,14 +231,17 @@ describe GdsApi::TestHelpers::PublishingApi do
       stub_publishing_api_has_expanded_links(payload, with_drafts: false, generate: true)
       response = publishing_api.get_expanded_links("2e20294a-d694-4083-985e-d8bedefc2354", with_drafts: false, generate: true)
 
-      assert_equal({
-        "content_id" => "2e20294a-d694-4083-985e-d8bedefc2354",
-        "organisations" => [
-          {
-            "content_id" => %w[a8a09822-1729-48a7-8a68-d08300de9d1e],
-          },
-        ],
-      }, response.to_h)
+      assert_equal(
+        {
+          "content_id" => "2e20294a-d694-4083-985e-d8bedefc2354",
+          "organisations" => [
+            {
+              "content_id" => %w[a8a09822-1729-48a7-8a68-d08300de9d1e],
+            },
+          ],
+        },
+        response.to_h,
+      )
     end
   end
 
@@ -241,7 +250,7 @@ describe GdsApi::TestHelpers::PublishingApi do
       content_id = SecureRandom.uuid
       body = {
         links: {
-          my_linkset: %w(link_1),
+          my_linkset: %w[link_1],
         },
         previous_version: 4,
       }
@@ -261,7 +270,7 @@ describe GdsApi::TestHelpers::PublishingApi do
       content_id = SecureRandom.uuid
       body = {
         links: {
-          my_linkset: %w(link_1),
+          my_linkset: %w[link_1],
         },
         previous_version: 4,
       }
@@ -315,7 +324,7 @@ describe GdsApi::TestHelpers::PublishingApi do
 
       stub_publishing_api_get_editions(
         editions,
-        fields: %w(title),
+        fields: %w[title],
       )
 
       api_response = publishing_api.get_editions(fields: [:title])
@@ -363,11 +372,14 @@ describe GdsApi::TestHelpers::PublishingApi do
       api_response = publishing_api.put_intent("/foo", params)
       assert_equal(api_response.code, 200)
 
-      assert_equal({
-        "publishing_app" => "publisher",
-        "rendering_app" => "frontend",
-        "publish_time" => "2019-11-11t17:56:17+00:00",
-      }, api_response.to_h)
+      assert_equal(
+        {
+          "publishing_app" => "publisher",
+          "rendering_app" => "frontend",
+          "publish_time" => "2019-11-11t17:56:17+00:00",
+        },
+        api_response.to_h,
+      )
     end
 
     it "accepts parameters as a string" do
@@ -448,10 +460,13 @@ describe GdsApi::TestHelpers::PublishingApi do
       stub_any_publishing_api_path_reservation
 
       api_response = publishing_api.put_path("/foo", publishing_app: "foo-publisher")
-      assert_equal({
-        "publishing_app" => "foo-publisher",
-        "base_path" => "/foo",
-      }, api_response.to_h)
+      assert_equal(
+        {
+          "publishing_app" => "foo-publisher",
+          "base_path" => "/foo",
+        },
+        api_response.to_h,
+      )
     end
   end
 
@@ -461,10 +476,13 @@ describe GdsApi::TestHelpers::PublishingApi do
 
       api_response = publishing_api.put_path("/foo", publishing_app: "foo-publisher")
       assert_equal(api_response.code, 200)
-      assert_equal({
-        "publishing_app" => "foo-publisher",
-        "base_path" => "/foo",
-      }, api_response.to_h)
+      assert_equal(
+        {
+          "publishing_app" => "foo-publisher",
+          "base_path" => "/foo",
+        },
+        api_response.to_h,
+      )
     end
 
     it "returns an error response for a request for the path and a different publishing app" do

--- a/test/worldwide_api_test.rb
+++ b/test/worldwide_api_test.rb
@@ -12,7 +12,7 @@ describe GdsApi::Worldwide do
 
   describe "fetching list of world locations" do
     it "should get the world locations" do
-      country_slugs = %w(the-shire rivendel rohan lorien gondor arnor mordor)
+      country_slugs = %w[the-shire rivendel rohan lorien gondor arnor mordor]
       stub_worldwide_api_has_locations(country_slugs)
 
       response = @api.world_locations


### PR DESCRIPTION
- This is a prerequisite for being able to move more of our apps to
  GitHub Actions. We want one single step bundle exec rake that runs
  everything. This ensures parity between local dev and what CI runs
  (something that we don't always have now).

https://trello.com/c/5Gob6WUL/147-for-everyone-ensure-that-rubocop-runs-as-part-of-bundle-exec-rake-as-one-of-the-default-tasks
