### PR TITLE
Remove require from example usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ A set of API adapters to work with the GDS APIs.
 Example usage:
 
 ```ruby
-require 'gds_api/publishing_api'
 GdsApi.publishing_api.get_content("f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a")
 ```
 


### PR DESCRIPTION
The file in question didn't need to be required (it's required automatically with `require "gds-api-adapters"`). I didn't think we needed any require provided though since you'll get that automatically with bundler.