### PR TITLE
Update changelog to explain that I'm stupid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 67.0.0
 
+* Note: this release was misnumbered and should have been version 64 - there
+  are no versions 64, 65, 66 of this gem.
 * BREAKING: Remove deprecated test helper methods that weren't prefixed with `stub_`
 * BREAKING: Remove `GdsApi::PublishingApiV2` use `GdsApi::PublishingApi`
 


### PR DESCRIPTION
Oh dear, I can't seem to increment numbers properly. This tries to
explain why we've skipped 3 major versions in one release.

Leaving an embarrassing note here seems preferable to yanking the
release as that will mean we can never release version 67.0.0.