### PR TITLE
Remove dependency on rack-cache gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Remove dependency on rack-cache gem
+
 # 67.0.0
 
 * Note: this release was misnumbered and should have been version 64 - there

--- a/gds-api-adapters.gemspec
+++ b/gds-api-adapters.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |s|
   s.add_dependency "link_header"
   s.add_dependency "null_logger"
   s.add_dependency "plek", ">= 1.9.0"
-  s.add_dependency "rack-cache"
   s.add_dependency "rest-client", "~> 2.0"
 
   s.add_development_dependency "climate_control", "~> 0.2"

--- a/gds-api-adapters.gemspec
+++ b/gds-api-adapters.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "govuk-content-schema-test-helpers", "~> 1.6"
   s.add_development_dependency "minitest", "~> 5.11"
   s.add_development_dependency "minitest-around", "~> 0.5"
-  s.add_development_dependency "mocha", "~> 1.3"
+  s.add_development_dependency "mocha", "~> 1.11"
   s.add_development_dependency "pact", "~> 1.20"
   s.add_development_dependency "pact-consumer-minitest", "~> 1.0"
   s.add_development_dependency "pact-mock_service", "~> 2.6"

--- a/test/cache_control_test.rb
+++ b/test/cache_control_test.rb
@@ -1,0 +1,166 @@
+require_relative "test_helper"
+require "gds_api/response"
+
+describe GdsApi::Response::CacheControl do
+  CacheControl = GdsApi::Response::CacheControl
+
+  it "takes no args and initializes with an empty set of values" do
+    cache_control = CacheControl.new
+
+    assert cache_control.empty?
+    assert_equal "", cache_control.to_s
+  end
+
+  it "takes a String and parses it into a Hash when created" do
+    cache_control = CacheControl.new("max-age=600, foo")
+
+    assert cache_control["foo"]
+    assert_equal "600", cache_control["max-age"]
+  end
+
+  it "takes a String with a single name=value pair" do
+    cache_control = CacheControl.new("max-age=600")
+    assert_equal "600", cache_control["max-age"]
+  end
+
+  it "takes a String with multiple name=value pairs" do
+    cache_control = CacheControl.new("max-age=600, max-stale=300, min-fresh=570")
+
+    assert_equal "600", cache_control["max-age"]
+    assert_equal "300", cache_control["max-stale"]
+    assert_equal "570", cache_control["min-fresh"]
+  end
+
+  it "takes a String with a single flag value" do
+    cache_control = CacheControl.new("no-cache")
+
+    assert cache_control.include?("no-cache")
+    assert_equal true, cache_control["no-cache"]
+  end
+
+  it "takes a String with a bunch of all kinds of stuff" do
+    cache_control = CacheControl.new("max-age=600,must-revalidate,min-fresh=3000,foo=bar,baz")
+
+    assert_equal "600", cache_control["max-age"]
+    assert_equal true, cache_control["must-revalidate"]
+    assert_equal "3000", cache_control["min-fresh"]
+    assert_equal "bar", cache_control["foo"]
+    assert_equal true, cache_control["baz"]
+  end
+
+  it "strips leading and trailing spaces from header value" do
+    cache_control = CacheControl.new("   public,   max-age =   600  ")
+
+    assert cache_control.include?("public")
+    assert cache_control.include?("max-age")
+    assert_equal "600", cache_control["max-age"]
+  end
+
+  it "strips blank segments" do
+    cache_control = CacheControl.new("max-age=600,,max-stale=300")
+
+    assert_equal 2, cache_control.size
+    assert_equal "600", cache_control["max-age"]
+    assert_equal "300", cache_control["max-stale"]
+  end
+
+  it "removes all directives with #clear" do
+    cache_control = CacheControl.new("max-age=600, must-revalidate")
+    cache_control.clear
+
+    assert cache_control.empty?
+  end
+
+  it "converts self into header String with #to_s" do
+    cache_control = CacheControl.new
+    cache_control["public"] = true
+    cache_control["max-age"] = "600"
+
+    assert_equal ["max-age=600", "public"], cache_control.to_s.split(", ").sort
+  end
+
+  it "sorts alphabetically with boolean directives before value directives" do
+    cache_control = CacheControl.new("foo=bar, z, x, y, bling=baz, zoom=zib, b, a")
+    assert_equal "a, b, x, y, z, bling=baz, foo=bar, zoom=zib", cache_control.to_s
+  end
+
+  it "responds to #max_age with an integer when max-age directive present" do
+    cache_control = CacheControl.new("public, max-age=600")
+    assert 600, cache_control.max_age
+  end
+
+  it "responds to #max_age with nil when no max-age directive present" do
+    cache_control = CacheControl.new("public")
+    assert cache_control.max_age.nil?
+  end
+
+  it "responds to #shared_max_age with an integer when s-maxage directive present" do
+    cache_control = CacheControl.new("public, s-maxage=600")
+    assert 600, cache_control.shared_max_age
+  end
+
+  it "responds to #shared_max_age with nil when no s-maxage directive present" do
+    cache_control = CacheControl.new("public")
+    assert cache_control.shared_max_age.nil?
+  end
+
+  it "responds to #reverse_max_age with an integer when r-maxage directive present" do
+    cache_control = CacheControl.new("public, r-maxage=600")
+    assert_equal 600, cache_control.reverse_max_age
+  end
+
+  it "responds to #reverse_max_age with nil when no r-maxage directive present" do
+    cache_control = CacheControl.new("public")
+    assert cache_control.reverse_max_age.nil?
+  end
+
+  it "responds to #public? truthfully when public directive present" do
+    cache_control = CacheControl.new("public")
+    assert cache_control.public?
+  end
+
+  it "responds to #public? non-truthfully when no public directive present" do
+    cache_control = CacheControl.new("private")
+    refute cache_control.public?
+  end
+
+  it "responds to #private? truthfully when private directive present" do
+    cache_control = CacheControl.new("private")
+    assert cache_control.private?
+  end
+
+  it "responds to #private? non-truthfully when no private directive present" do
+    cache_control = CacheControl.new("public")
+    refute cache_control.private?
+  end
+
+  it "responds to #no_cache? truthfully when no-cache directive present" do
+    cache_control = CacheControl.new("no-cache")
+    assert cache_control.no_cache?
+  end
+
+  it "responds to #no_cache? non-truthfully when no no-cache directive present" do
+    cache_control = CacheControl.new("max-age=600")
+    refute cache_control.no_cache?
+  end
+
+  it "responds to #must_revalidate? truthfully when must-revalidate directive present" do
+    cache_control = CacheControl.new("must-revalidate")
+    assert cache_control.must_revalidate?
+  end
+
+  it "responds to #must_revalidate? non-truthfully when no must-revalidate directive present" do
+    cache_control = CacheControl.new("max-age=600")
+    refute cache_control.no_cache?
+  end
+
+  it "responds to #proxy_revalidate? truthfully when proxy-revalidate directive present" do
+    cache_control = CacheControl.new("proxy-revalidate")
+    assert cache_control.proxy_revalidate?
+  end
+
+  it "responds to #proxy_revalidate? non-truthfully when no proxy-revalidate directive present" do
+    cache_control = CacheControl.new("max-age=600")
+    refute cache_control.proxy_revalidate?
+  end
+end

--- a/test/publishing_api_test.rb
+++ b/test/publishing_api_test.rb
@@ -2173,7 +2173,7 @@ describe GdsApi::PublishingApi do
         ]
 
         expected_documents.each do |document|
-          response.to_a.must_include document
+          assert_includes response.to_a, document
         end
       end
     end
@@ -2305,12 +2305,12 @@ describe GdsApi::PublishingApi do
 
         response = @api_client.get_paged_editions(fields: %w[content_id], per_page: 2).to_a
 
-        response.count.must_equal 2
+        assert_equal 2, response.count
         first_page_content_ids = response[0]["results"].map { |content_item| content_item["content_id"] }
         second_page_content_ids = response[1]["results"].map { |content_item| content_item["content_id"] }
 
-        first_page_content_ids.must_equal [content_id_1, content_id_2]
-        second_page_content_ids.must_equal [content_id_3, content_id_4]
+        assert_equal [content_id_1, content_id_2], first_page_content_ids
+        assert_equal [content_id_3, content_id_4], second_page_content_ids
       end
     end
   end
@@ -2318,20 +2318,28 @@ describe GdsApi::PublishingApi do
   describe "content ID validation" do
     %i[get_content get_links get_linked_items discard_draft].each do |method|
       it "happens on #{method}" do
-        proc { @api_client.send(method, nil) }.must_raise ArgumentError
+        assert_raises ArgumentError do
+          @api_client.send(method, nil)
+        end
       end
     end
 
     it "happens on publish" do
-      proc { @api_client.publish(nil, "major") }.must_raise ArgumentError
+      assert_raises ArgumentError do
+        @api_client.publish(nil, "major")
+      end
     end
 
     it "happens on put_content" do
-      proc { @api_client.put_content(nil, {}) }.must_raise ArgumentError
+      assert_raises ArgumentError do
+        @api_client.put_content(nil, {})
+      end
     end
 
     it "happens on patch_links" do
-      proc { @api_client.patch_links(nil, links: {}) }.must_raise ArgumentError
+      assert_raises ArgumentError do
+        @api_client.patch_links(nil, links: {})
+      end
     end
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -57,3 +57,7 @@ GovukContentSchemaTestHelpers.configure do |config|
   config.schema_type = "publisher_v2"
   config.project_root = File.absolute_path(File.join(File.basename(__FILE__), ".."))
 end
+
+Mocha.configure do |c|
+  c.reinstate_undocumented_behaviour_from_v1_9 = false
+end


### PR DESCRIPTION
This gem is using in a large number of apps and it's always a good idea to reduce dependencies where possible since each gem's lib directory is added to the load path and will be scanned when using `require`.

Using rack-cache to parse the Cache-Control header made sense when the gem was included as a dependency of the actionpack gem but since the release of Rails 4.0 it's no longer included by default. This means that the rack-cache dependency is forced on all apps that use this gem, regardless of whether they use it elsewhere (in fact some apps explicitly set `config.rack_cache = false`). By reimplementing this internally we can remove the dependency for all of those apps that don't need it.

Since the `cache_control` method on the response object is public this commit reimplements the exact same functionality even though the response object only ever uses the `max_age` method.

**NOTE: The implementation of the `CacheControl` class inevitably mirrors closely the implementation in the rack-cache gem (however the method of parsing the header is different). It also borrows the structure of the tests to ensure compatibility but they have been rewritten to follow the assertion style of the tests in this repo and not the original expectation style in the rack-cache repo. Due to this I'm unsure whether we need to include an attribution to comply with the MIT license and if we do where it should go.**