### PR TITLE
Upgrade to Ruby 2.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+* Add double splat operator to last arguments that are keyword parameters
+
 ## 67.0.1
 
 * URI encode parameters in Email Alert API methods

--- a/lib/gds_api/test_helpers/email_alert_api.rb
+++ b/lib/gds_api/test_helpers/email_alert_api.rb
@@ -98,9 +98,9 @@ module GdsApi
         subscriptions.each do |id, params|
           latest_id, latest_params = get_latest_matching(params, subscriptions)
           stub_request(:get, "#{EMAIL_ALERT_API_ENDPOINT}/subscriptions/#{id}")
-            .to_return(status: 200, body: get_subscription_response(id, params).to_json)
+            .to_return(status: 200, body: get_subscription_response(id, **params).to_json)
           stub_request(:get, "#{EMAIL_ALERT_API_ENDPOINT}/subscriptions/#{id}/latest")
-            .to_return(status: 200, body: get_subscription_response(latest_id, latest_params).to_json)
+            .to_return(status: 200, body: get_subscription_response(latest_id, **latest_params).to_json)
         end
       end
 


### PR DESCRIPTION
These are the changes necessary for Ruby 2.7.1

I've left the Ruby version as 2.6.6 since there is a script that updates all the apps' Ruby versions at once. 