### PR TITLE
Accept params in stub_publishing_api_does_not_have_item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
-## Unreleased
-* Add double splat operator to last arguments that are keyword parameters
+# Unreleased
 
-## 67.0.1
+* Add double splat operator to last arguments that are keyword parameters
+* Accept params in `stub_publishing_api_does_not_have_item`
+
+# 67.0.1
 
 * URI encode parameters in Email Alert API methods
 * Remove dependency on rack-cache gem

--- a/lib/gds_api/test_helpers/publishing_api.rb
+++ b/lib/gds_api/test_helpers/publishing_api.rb
@@ -394,9 +394,11 @@ module GdsApi
       # Stub GET /v2/content/:content_id to return a 404 response
       #
       # @param content_id [UUID]
-      def stub_publishing_api_does_not_have_item(content_id)
+      def stub_publishing_api_does_not_have_item(content_id, params = {})
         url = PUBLISHING_API_V2_ENDPOINT + "/content/" + content_id
-        stub_request(:get, url).to_return(status: 404, body: resource_not_found(content_id, "content item").to_json, headers: {})
+        stub_request(:get, url)
+          .with(query: hash_including(params))
+          .to_return(status: 404, body: resource_not_found(content_id, "content item").to_json, headers: {})
       end
 
       # Stub a request to links endpoint


### PR DESCRIPTION
To allow for stubbing when the locale is used as a parameter. I'm
adding this to use in Specialist Publisher.