### PR TITLE
Fix email-alert-api subscription helpers returning incorrect field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Fix email-alert-api subscription creation test helpers returning `subscription_id` instead of `id`
+
 # 67.1.0
 
 * Remove unused "redirect" param for email subscriber verification adapter

--- a/lib/gds_api/test_helpers/email_alert_api.rb
+++ b/lib/gds_api/test_helpers/email_alert_api.rb
@@ -222,14 +222,14 @@ module GdsApi
         stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscriptions")
           .with(
             body: { subscriber_list_id: subscriber_list_id, address: address, frequency: frequency }.to_json,
-          ).to_return(status: 201, body: { subscription_id: returned_subscription_id }.to_json)
+          ).to_return(status: 201, body: { id: returned_subscription_id }.to_json)
       end
 
       def stub_email_alert_api_creates_an_existing_subscription(subscriber_list_id, address, frequency, returned_subscription_id)
         stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscriptions")
           .with(
             body: { subscriber_list_id: subscriber_list_id, address: address, frequency: frequency }.to_json,
-          ).to_return(status: 200, body: { subscription_id: returned_subscription_id }.to_json)
+          ).to_return(status: 200, body: { id: returned_subscription_id }.to_json)
       end
 
       def stub_email_alert_api_refuses_to_create_subscription(subscriber_list_id, address, frequency)

--- a/test/email_alert_api_test.rb
+++ b/test/email_alert_api_test.rb
@@ -487,7 +487,7 @@ describe GdsApi::EmailAlertApi do
         )
         api_response = api_client.subscribe(subscriber_list_id: subscriber_list_id, address: address, frequency: frequency)
         assert_equal(201, api_response.code)
-        assert_equal({ "subscription_id" => 1 }, api_response.to_h)
+        assert_equal({ "id" => 1 }, api_response.to_h)
       end
     end
 
@@ -506,7 +506,7 @@ describe GdsApi::EmailAlertApi do
         )
         api_response = api_client.subscribe(subscriber_list_id: subscriber_list_id, address: address)
         assert_equal(201, api_response.code)
-        assert_equal({ "subscription_id" => 1 }, api_response.to_h)
+        assert_equal({ "id" => 1 }, api_response.to_h)
       end
     end
   end
@@ -526,7 +526,7 @@ describe GdsApi::EmailAlertApi do
       )
       api_response = api_client.subscribe(subscriber_list_id: subscriber_list_id, address: address, frequency: frequency)
       assert_equal(200, api_response.code)
-      assert_equal({ "subscription_id" => 1 }, api_response.to_h)
+      assert_equal({ "id" => 1 }, api_response.to_h)
     end
   end
 


### PR DESCRIPTION
email-alert-api returns an "id" field (see
SubscriptionsController#create), but the test helper returns a
"subscription_id" field.

We're using this field in the account-manager so we can update
someone's email subscription if they update their transition checker
answers (see https://github.com/alphagov/govuk-account-manager-prototype/pull/383).

It's unlikely this change will break anyone's tests as not even
email-alert-frontend uses this field.