### PR TITLE
Add helper for creating lists in Email Alert API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-# Unreleased
+# 67.1.0
 
+* Add assert_email_alert_api_creates_subscriber_list test helper
 * Add double splat operator to last arguments that are keyword parameters
 * Accept params in `stub_publishing_api_does_not_have_item`
 * Upgrade to Ruby 2.7.2

--- a/lib/gds_api/test_helpers/email_alert_api.rb
+++ b/lib/gds_api/test_helpers/email_alert_api.rb
@@ -145,6 +145,17 @@ module GdsApi
           )
       end
 
+      def assert_email_alert_api_creates_subscriber_list(attributes = nil)
+        if attributes
+          matcher = lambda do |request|
+            payload = JSON.parse(request.body)
+            payload.select { |k, _| attributes.key?(k) } == attributes
+          end
+        end
+
+        assert_requested(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscriber-lists", times: 1, &matcher)
+      end
+
       def stub_email_alert_api_refuses_to_create_subscriber_list
         stub_request(:post, build_subscriber_lists_url)
           .to_return(status: 422)

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = "67.0.1".freeze
+  VERSION = "67.1.0".freeze
 end

--- a/test/test_helpers/email_alert_api_test.rb
+++ b/test/test_helpers/email_alert_api_test.rb
@@ -22,6 +22,20 @@ describe GdsApi::TestHelpers::EmailAlertApi do
     end
   end
 
+  describe "#assert_email_alert_api_creates_subscriber_list" do
+    before { stub_any_email_alert_api_call }
+
+    it "matches a post request with any empty attributes by default" do
+      email_alert_api.create_subscriber_list("foo" => "bar")
+      assert_email_alert_api_creates_subscriber_list
+    end
+
+    it "matches a post request subset of attributes" do
+      email_alert_api.create_subscriber_list("foo" => "bar", "baz" => "qux")
+      assert_email_alert_api_creates_subscriber_list("foo" => "bar")
+    end
+  end
+
   describe "#assert_email_alert_api_message_created" do
     before { stub_any_email_alert_api_call }
 


### PR DESCRIPTION
https://trello.com/c/mk5M2aKD/619-general-design-and-stylistic-updates-to-signup-workflow

Currently we stub the adapter in Email Alert Frontend [1], so we're
vulnerable to it changing in future. Note that we can't reuse the
"stub_email_alert_api_creates_subscriber_list" test helper for this
(and assert the requet was made) since the attributes passed to the
helper can be specific to the response (although many will also be
in the request), and we've lost our chance to have a more flexible
"(attributes, returned_attributes)" interface for the helper.

[1]: https://github.com/alphagov/email-alert-frontend/blob/d00c3784fe5b1f7f937b593b8a84082849f879d8/spec/models/content_item_subscriber_list_spec.rb#L17