### PR TITLE
Remove unused "redirect" param for subscriber auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-# Unreleased
+# 67.1.0
 
+* Remove unused "redirect" param for email subscriber verification adapter
 * Add double splat operator to last arguments that are keyword parameters
 * Accept params in `stub_publishing_api_does_not_have_item`
 * Upgrade to Ruby 2.7.2

--- a/lib/gds_api/email_alert_api.rb
+++ b/lib/gds_api/email_alert_api.rb
@@ -224,16 +224,14 @@ class GdsApi::EmailAlertApi < GdsApi::Base
   #
   # @param [string]       address       Address to send verification email to
   # @param [string]       destination   Path on GOV.UK that subscriber will be emailed
-  # @param [string, nil]  redirect      Path on GOV.UK to be encoded into the token for redirecting
   #
   # @return [Hash]  subscriber
   #
-  def send_subscriber_verification_email(address:, destination:, redirect: nil)
+  def send_subscriber_verification_email(address:, destination:)
     post_json(
       "#{endpoint}/subscribers/auth-token",
       address: address,
       destination: destination,
-      redirect: redirect,
     )
   end
 

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = "67.0.1".freeze
+  VERSION = "67.1.0".freeze
 end


### PR DESCRIPTION
https://trello.com/c/sgJIkObA/662-authenticate-before-unsubscribing-from-digest-emails

This has never been used, and support has now been removed [1].

[1]: https://github.com/alphagov/email-alert-api/pull/1502