### PR TITLE
Support param to skip subscribe confirmation email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 67.2.0
 
+* Support non-en locales for special routes
 * Support param to skip confirmation email when subscribing (for accounts)
 
 # 67.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 67.2.0
+
+* Support param to skip confirmation email when subscribing (for accounts)
+
 # 67.1.1
 
 * Fix email-alert-api subscription creation test helpers returning `subscription_id` instead of `id`

--- a/lib/gds_api/email_alert_api.rb
+++ b/lib/gds_api/email_alert_api.rb
@@ -116,12 +116,13 @@ class GdsApi::EmailAlertApi < GdsApi::Base
   # Subscribe
   #
   # @return [Hash] subscription_id
-  def subscribe(subscriber_list_id:, address:, frequency: "immediately")
+  def subscribe(subscriber_list_id:, address:, frequency: "immediately", skip_confirmation_email: false)
     post_json(
       "#{endpoint}/subscriptions",
       subscriber_list_id: subscriber_list_id,
       address: address,
       frequency: frequency,
+      skip_confirmation_email: skip_confirmation_email,
     )
   end
 

--- a/lib/gds_api/test_helpers/email_alert_api.rb
+++ b/lib/gds_api/test_helpers/email_alert_api.rb
@@ -218,24 +218,37 @@ module GdsApi
           .to_return(status: 404)
       end
 
-      def stub_email_alert_api_creates_a_subscription(subscriber_list_id, address, frequency, returned_subscription_id)
+      def stub_email_alert_api_creates_a_subscription(subscriber_list_id, address, frequency, returned_subscription_id, skip_confirmation_email: false)
         stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscriptions")
           .with(
-            body: { subscriber_list_id: subscriber_list_id, address: address, frequency: frequency }.to_json,
+            body: {
+              subscriber_list_id: subscriber_list_id,
+              address: address,
+              frequency: frequency,
+              skip_confirmation_email: skip_confirmation_email,
+            }.to_json,
           ).to_return(status: 201, body: { id: returned_subscription_id }.to_json)
       end
 
       def stub_email_alert_api_creates_an_existing_subscription(subscriber_list_id, address, frequency, returned_subscription_id)
         stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscriptions")
           .with(
-            body: { subscriber_list_id: subscriber_list_id, address: address, frequency: frequency }.to_json,
+            body: hash_including(
+              subscriber_list_id: subscriber_list_id,
+              address: address,
+              frequency: frequency,
+            ),
           ).to_return(status: 200, body: { id: returned_subscription_id }.to_json)
       end
 
       def stub_email_alert_api_refuses_to_create_subscription(subscriber_list_id, address, frequency)
         stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscriptions")
           .with(
-            body: { subscriber_list_id: subscriber_list_id, address: address, frequency: frequency }.to_json,
+            body: hash_including(
+              subscriber_list_id: subscriber_list_id,
+              address: address,
+              frequency: frequency,
+            ),
           ).to_return(status: 422)
       end
 

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = "67.1.1".freeze
+  VERSION = "67.2.0".freeze
 end

--- a/test/email_alert_api_test.rb
+++ b/test/email_alert_api_test.rb
@@ -509,6 +509,32 @@ describe GdsApi::EmailAlertApi do
         assert_equal({ "id" => 1 }, api_response.to_h)
       end
     end
+
+    describe "without a confirmation email" do
+      it "returns a 201 and the subscription id" do
+        subscriber_list_id = 6
+        address = "test@test.com"
+        created_subscription_id = 1
+        frequency = "immediately"
+
+        stub_email_alert_api_creates_a_subscription(
+          subscriber_list_id,
+          address,
+          frequency,
+          created_subscription_id,
+          skip_confirmation_email: true,
+        )
+
+        api_response = api_client.subscribe(
+          subscriber_list_id: subscriber_list_id,
+          address: address,
+          skip_confirmation_email: true,
+        )
+
+        assert_equal(201, api_response.code)
+        assert_equal({ "id" => 1 }, api_response.to_h)
+      end
+    end
   end
 
   describe "subscribing and a subscription already exists" do

--- a/test/email_alert_api_test.rb
+++ b/test/email_alert_api_test.rb
@@ -532,7 +532,15 @@ describe GdsApi::EmailAlertApi do
 
   describe "subscribing with an invalid address" do
     it "raises an unprocessable entity error" do
-      stub_email_alert_api_refuses_to_create_subscription(123, "invalid", "weekly")
+      subscriber_list_id = 123
+      address = "invalid"
+      frequency = "weekly"
+
+      stub_email_alert_api_refuses_to_create_subscription(
+        subscriber_list_id,
+        address,
+        frequency,
+      )
 
       assert_raises GdsApi::HTTPUnprocessableEntity do
         api_client.subscribe(subscriber_list_id: 123, address: "invalid", frequency: "weekly")


### PR DESCRIPTION
https://trello.com/c/gbYVX8lK/690-send-users-a-link-to-their-results-as-part-of-subscribing-to-the-checker

Relates to: https://github.com/alphagov/email-alert-api/pull/1503

This is required to prevent sending two emails with conflicting content /
links when a user subscribes via a GOV.UK Account, which sends its own
confirmation email. In order to keep the test stubs simple, I've switched
to using "hash_including" for stubs where the parameter is (for now) not
relevant.