### PR TITLE
Allow locales for special routes

### DIFF
--- a/lib/gds_api/publishing_api/special_route_publisher.rb
+++ b/lib/gds_api/publishing_api/special_route_publisher.rb
@@ -19,7 +19,7 @@ module GdsApi
           schema_name: options.fetch(:schema_name, "special_route"),
           title: options.fetch(:title),
           description: options.fetch(:description, ""),
-          locale: "en",
+          locale: options.fetch(:locale, "en"),
           details: {},
           routes: [
             {


### PR DESCRIPTION
Locale seems to be the only field that we can't override (apart from details).

We need to publish a series of related routes that link to translations of each other. Locales are the way to do this, so let's allow that please.