### PR TITLE
Fix bug in special route publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Fix bug in special route publishing
+
 # 67.2.0
 
 * Support non-en locales for special routes

--- a/lib/gds_api/publishing_api/special_route_publisher.rb
+++ b/lib/gds_api/publishing_api/special_route_publisher.rb
@@ -12,6 +12,9 @@ module GdsApi
       def publish(options)
         logger.info("Publishing #{options.fetch(:type)} route #{options.fetch(:base_path)}, routing to #{options.fetch(:rendering_app)}")
 
+        update_type = options.fetch(:update_type, "major")
+        locale = options.fetch(:locale, "en")
+
         put_content_response = publishing_api.put_content(
           options.fetch(:content_id),
           base_path: options.fetch(:base_path),
@@ -19,7 +22,7 @@ module GdsApi
           schema_name: options.fetch(:schema_name, "special_route"),
           title: options.fetch(:title),
           description: options.fetch(:description, ""),
-          locale: options.fetch(:locale, "en"),
+          locale: locale,
           details: {},
           routes: [
             {
@@ -30,11 +33,11 @@ module GdsApi
           publishing_app: options.fetch(:publishing_app),
           rendering_app: options.fetch(:rendering_app),
           public_updated_at: time.now.iso8601,
-          update_type: options.fetch(:update_type, "major"),
+          update_type: update_type,
         )
 
         publishing_api.patch_links(options.fetch(:content_id), links: options[:links]) if options[:links]
-        publishing_api.publish(options.fetch(:content_id))
+        publishing_api.publish(options.fetch(:content_id), update_type, locale: locale)
         put_content_response
       end
 

--- a/test/publishing_api/special_route_publisher_test.rb
+++ b/test/publishing_api/special_route_publisher_test.rb
@@ -57,6 +57,15 @@ describe GdsApi::PublishingApi::SpecialRoutePublisher do
       end
     end
 
+    it "publishes non-English locales" do
+      publisher.publish(special_route.merge(locale: "cy"))
+
+      assert_requested(:put, "#{endpoint}/v2/content/#{content_id}") do |req|
+        JSON.parse(req.body)["locale"] == "cy"
+      end
+      assert_publishing_api_publish(content_id, { update_type: "major", locale: "cy" })
+    end
+
     it "publishes customized document type" do
       publisher.publish(special_route.merge(document_type: "other_document_type"))
 


### PR DESCRIPTION
When updating the `put_content` request to send the locale of the content item to publishing-api, I missed the fact that it needed to be added to the [`publish`](https://github.com/alphagov/gds-api-adapters/blob/967b8565a7745f21a58bd8e2e043b96022f635e2/lib/gds_api/publishing_api.rb#L123-L133) call as well.