### PR TITLE
Release version 67.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 67.2.1
 
 * Fix bug in special route publishing
 

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = "67.2.0".freeze
+  VERSION = "67.2.1".freeze
 end


### PR DESCRIPTION
Includes:

- Fix bug in special route publishing ([PR 1013](https://github.com/alphagov/gds-api-adapters/pull/1013))