### PR TITLE
Update subscribe test helper to match new API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unversioned
+
+* BREAKING: update email test helper to match new API behaviour
+
 # 67.2.1
 
 * Fix bug in special route publishing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unversioned
 
+* BREAKING: make subscribe test helper interface more flexible
 * BREAKING: update email test helper to match new API behaviour
 
 # 67.2.1

--- a/lib/gds_api/test_helpers/email_alert_api.rb
+++ b/lib/gds_api/test_helpers/email_alert_api.rb
@@ -219,6 +219,12 @@ module GdsApi
       end
 
       def stub_email_alert_api_creates_a_subscription(subscriber_list_id, address, frequency, returned_subscription_id, skip_confirmation_email: false)
+        response = get_subscription_response(
+          returned_subscription_id,
+          frequency: frequency,
+          subscriber_list_id: subscriber_list_id,
+        )
+
         stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscriptions")
           .with(
             body: {
@@ -227,10 +233,16 @@ module GdsApi
               frequency: frequency,
               skip_confirmation_email: skip_confirmation_email,
             }.to_json,
-          ).to_return(status: 201, body: { id: returned_subscription_id }.to_json)
+          ).to_return(status: 200, body: response.to_json)
       end
 
       def stub_email_alert_api_creates_an_existing_subscription(subscriber_list_id, address, frequency, returned_subscription_id)
+        response = get_subscription_response(
+          returned_subscription_id,
+          frequency: frequency,
+          subscriber_list_id: subscriber_list_id,
+        )
+
         stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscriptions")
           .with(
             body: hash_including(
@@ -238,7 +250,7 @@ module GdsApi
               address: address,
               frequency: frequency,
             ),
-          ).to_return(status: 200, body: { id: returned_subscription_id }.to_json)
+          ).to_return(status: 200, body: response.to_json)
       end
 
       def stub_email_alert_api_refuses_to_create_subscription(subscriber_list_id, address, frequency)

--- a/lib/gds_api/test_helpers/email_alert_api.rb
+++ b/lib/gds_api/test_helpers/email_alert_api.rb
@@ -218,22 +218,31 @@ module GdsApi
           .to_return(status: 404)
       end
 
-      def stub_email_alert_api_creates_a_subscription(subscriber_list_id, address, frequency, returned_subscription_id, skip_confirmation_email: false)
+      def stub_email_alert_api_creates_a_subscription(
+        subscriber_list_id: nil,
+        address: nil,
+        frequency: nil,
+        returned_subscription_id: nil,
+        skip_confirmation_email: false,
+        subscriber_id: nil
+      )
         response = get_subscription_response(
           returned_subscription_id,
           frequency: frequency,
           subscriber_list_id: subscriber_list_id,
+          subscriber_id: subscriber_id,
         )
 
+        request_params = {
+          subscriber_list_id: subscriber_list_id,
+          address: address,
+          frequency: frequency,
+          skip_confirmation_email: skip_confirmation_email,
+        }
+
         stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscriptions")
-          .with(
-            body: {
-              subscriber_list_id: subscriber_list_id,
-              address: address,
-              frequency: frequency,
-              skip_confirmation_email: skip_confirmation_email,
-            }.to_json,
-          ).to_return(status: 200, body: response.to_json)
+          .with(body: hash_including(request_params.compact))
+          .to_return(status: 200, body: response.to_json)
       end
 
       def stub_email_alert_api_refuses_to_create_subscription(subscriber_list_id, address, frequency)

--- a/lib/gds_api/test_helpers/email_alert_api.rb
+++ b/lib/gds_api/test_helpers/email_alert_api.rb
@@ -236,23 +236,6 @@ module GdsApi
           ).to_return(status: 200, body: response.to_json)
       end
 
-      def stub_email_alert_api_creates_an_existing_subscription(subscriber_list_id, address, frequency, returned_subscription_id)
-        response = get_subscription_response(
-          returned_subscription_id,
-          frequency: frequency,
-          subscriber_list_id: subscriber_list_id,
-        )
-
-        stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscriptions")
-          .with(
-            body: hash_including(
-              subscriber_list_id: subscriber_list_id,
-              address: address,
-              frequency: frequency,
-            ),
-          ).to_return(status: 200, body: response.to_json)
-      end
-
       def stub_email_alert_api_refuses_to_create_subscription(subscriber_list_id, address, frequency)
         stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscriptions")
           .with(

--- a/test/email_alert_api_test.rb
+++ b/test/email_alert_api_test.rb
@@ -474,68 +474,78 @@ describe GdsApi::EmailAlertApi do
   describe "subscribing and a subscription is created" do
     describe "with a frequency specified" do
       it "returns a 200 and the subscription id" do
-        subscriber_list_id = 5
-        address = "test@test.com"
-        created_subscription_id = 1
-        frequency = "daily"
+        params = {
+          subscriber_list_id: 5,
+          address: "test@test.com",
+          frequency: "daily",
+        }
 
         stub_email_alert_api_creates_a_subscription(
-          subscriber_list_id,
-          address,
-          frequency,
-          created_subscription_id,
+          params.merge(returned_subscription_id: 1),
         )
-        api_response = api_client.subscribe(subscriber_list_id: subscriber_list_id, address: address, frequency: frequency)
+
+        api_response = api_client.subscribe(**params)
         assert_equal(200, api_response.code)
         parsed_body = api_response.to_h
-        assert_equal(created_subscription_id, parsed_body["subscription"]["id"])
+        assert_equal(1, parsed_body["subscription"]["id"])
       end
     end
 
     describe "without a frequency specified" do
       it "returns a 200 and the subscription id" do
-        subscriber_list_id = 6
-        address = "test@test.com"
-        created_subscription_id = 1
-        frequency = "immediately"
+        params = {
+          subscriber_list_id: 6,
+          address: "test@test.com",
+          frequency: "immediately",
+        }
 
         stub_email_alert_api_creates_a_subscription(
-          subscriber_list_id,
-          address,
-          frequency,
-          created_subscription_id,
+          params.merge(returned_subscription_id: 1),
         )
-        api_response = api_client.subscribe(subscriber_list_id: subscriber_list_id, address: address)
+
+        api_response = api_client.subscribe(**params)
         assert_equal(200, api_response.code)
         parsed_body = api_response.to_h
-        assert_equal(created_subscription_id, parsed_body["subscription"]["id"])
+        assert_equal(1, parsed_body["subscription"]["id"])
       end
     end
 
     describe "without a confirmation email" do
       it "returns a 200 and the subscription id" do
-        subscriber_list_id = 6
-        address = "test@test.com"
-        created_subscription_id = 1
-        frequency = "immediately"
+        params = {
+          subscriber_list_id: 6,
+          address: "test@test.com",
+          frequency: "immediately",
+          skip_confirmation_email: true,
+        }
 
         stub_email_alert_api_creates_a_subscription(
-          subscriber_list_id,
-          address,
-          frequency,
-          created_subscription_id,
-          skip_confirmation_email: true,
+          params.merge(returned_subscription_id: 1),
         )
 
-        api_response = api_client.subscribe(
-          subscriber_list_id: subscriber_list_id,
-          address: address,
-          skip_confirmation_email: true,
-        )
-
+        api_response = api_client.subscribe(**params)
         assert_equal(200, api_response.code)
         parsed_body = api_response.to_h
-        assert_equal(created_subscription_id, parsed_body["subscription"]["id"])
+        assert_equal(1, parsed_body["subscription"]["id"])
+      end
+    end
+
+    describe "with a specified subscriber" do
+      it "returns a 200 and the subscriber id" do
+        params = {
+          subscriber_list_id: 6,
+          address: "test@test.com",
+          frequency: "immediately",
+        }
+
+        stub_email_alert_api_creates_a_subscription(
+          params.merge(subscriber_id: 1),
+        )
+
+        api_response = api_client.subscribe(**params)
+        assert_equal(200, api_response.code)
+        parsed_body = api_response.to_h
+        assert_equal(1, parsed_body["subscription"]["subscriber"]["id"])
       end
     end
   end

--- a/test/email_alert_api_test.rb
+++ b/test/email_alert_api_test.rb
@@ -511,7 +511,7 @@ describe GdsApi::EmailAlertApi do
     end
 
     describe "without a confirmation email" do
-      it "returns a 200 and the subscription id" do
+      it "returns a 200" do
         params = {
           subscriber_list_id: 6,
           address: "test@test.com",
@@ -519,14 +519,9 @@ describe GdsApi::EmailAlertApi do
           skip_confirmation_email: true,
         }
 
-        stub_email_alert_api_creates_a_subscription(
-          params.merge(returned_subscription_id: 1),
-        )
-
+        stub_email_alert_api_creates_a_subscription(params)
         api_response = api_client.subscribe(**params)
         assert_equal(200, api_response.code)
-        parsed_body = api_response.to_h
-        assert_equal(1, parsed_body["subscription"]["id"])
       end
     end
 

--- a/test/email_alert_api_test.rb
+++ b/test/email_alert_api_test.rb
@@ -540,26 +540,6 @@ describe GdsApi::EmailAlertApi do
     end
   end
 
-  describe "subscribing and a subscription already exists" do
-    it "returns a 200 and the subscription id" do
-      subscriber_list_id = 5
-      address = "test@test.com"
-      existing_subscription_id = 1
-      frequency = "immediately"
-
-      stub_email_alert_api_creates_an_existing_subscription(
-        subscriber_list_id,
-        address,
-        frequency,
-        existing_subscription_id,
-      )
-      api_response = api_client.subscribe(subscriber_list_id: subscriber_list_id, address: address, frequency: frequency)
-      assert_equal(200, api_response.code)
-      parsed_body = api_response.to_h
-      assert_equal(existing_subscription_id, parsed_body["subscription"]["id"])
-    end
-  end
-
   describe "subscribing with an invalid address" do
     it "raises an unprocessable entity error" do
       subscriber_list_id = 123

--- a/test/email_alert_api_test.rb
+++ b/test/email_alert_api_test.rb
@@ -473,7 +473,7 @@ describe GdsApi::EmailAlertApi do
 
   describe "subscribing and a subscription is created" do
     describe "with a frequency specified" do
-      it "returns a 201 and the subscription id" do
+      it "returns a 200 and the subscription id" do
         subscriber_list_id = 5
         address = "test@test.com"
         created_subscription_id = 1
@@ -486,13 +486,14 @@ describe GdsApi::EmailAlertApi do
           created_subscription_id,
         )
         api_response = api_client.subscribe(subscriber_list_id: subscriber_list_id, address: address, frequency: frequency)
-        assert_equal(201, api_response.code)
-        assert_equal({ "id" => 1 }, api_response.to_h)
+        assert_equal(200, api_response.code)
+        parsed_body = api_response.to_h
+        assert_equal(created_subscription_id, parsed_body["subscription"]["id"])
       end
     end
 
     describe "without a frequency specified" do
-      it "returns a 201 and the subscription id" do
+      it "returns a 200 and the subscription id" do
         subscriber_list_id = 6
         address = "test@test.com"
         created_subscription_id = 1
@@ -505,13 +506,14 @@ describe GdsApi::EmailAlertApi do
           created_subscription_id,
         )
         api_response = api_client.subscribe(subscriber_list_id: subscriber_list_id, address: address)
-        assert_equal(201, api_response.code)
-        assert_equal({ "id" => 1 }, api_response.to_h)
+        assert_equal(200, api_response.code)
+        parsed_body = api_response.to_h
+        assert_equal(created_subscription_id, parsed_body["subscription"]["id"])
       end
     end
 
     describe "without a confirmation email" do
-      it "returns a 201 and the subscription id" do
+      it "returns a 200 and the subscription id" do
         subscriber_list_id = 6
         address = "test@test.com"
         created_subscription_id = 1
@@ -531,8 +533,9 @@ describe GdsApi::EmailAlertApi do
           skip_confirmation_email: true,
         )
 
-        assert_equal(201, api_response.code)
-        assert_equal({ "id" => 1 }, api_response.to_h)
+        assert_equal(200, api_response.code)
+        parsed_body = api_response.to_h
+        assert_equal(created_subscription_id, parsed_body["subscription"]["id"])
       end
     end
   end
@@ -552,7 +555,8 @@ describe GdsApi::EmailAlertApi do
       )
       api_response = api_client.subscribe(subscriber_list_id: subscriber_list_id, address: address, frequency: frequency)
       assert_equal(200, api_response.code)
-      assert_equal({ "id" => 1 }, api_response.to_h)
+      parsed_body = api_response.to_h
+      assert_equal(existing_subscription_id, parsed_body["subscription"]["id"])
     end
   end
 


### PR DESCRIPTION
https://trello.com/c/hdOrNhuC/669-sign-in-after-subscribing

This makes a couple of breaking changes:

- Change the stub response for the test helper
- Make the interface to the test helper more flexible

Although these are breaking changes, they're only to the
test helper, so doesn't seem worthy of a major version.