### PR TITLE
Remove support for email subscriber list fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * BREAKING: make subscribe test helper interface more flexible
 * BREAKING: update email test helper to match new API behaviour
+* Remove support for unused subscription_url subscriber list field
+* Remove support for unused govdelivery_title subscriber list field
 
 # 67.2.1
 

--- a/lib/gds_api/email_alert_api.rb
+++ b/lib/gds_api/email_alert_api.rb
@@ -24,7 +24,6 @@ class GdsApi::EmailAlertApi < GdsApi::Base
     document_type = attributes["document_type"]
     email_document_supertype = attributes["email_document_supertype"]
     government_document_supertype = attributes["government_document_supertype"]
-    gov_delivery_id = attributes["gov_delivery_id"]
     combine_mode = attributes["combine_mode"]
 
     if tags && links
@@ -38,7 +37,6 @@ class GdsApi::EmailAlertApi < GdsApi::Base
     params[:document_type] = document_type if document_type
     params[:email_document_supertype] = email_document_supertype if email_document_supertype
     params[:government_document_supertype] = government_document_supertype if government_document_supertype
-    params[:gov_delivery_id] = gov_delivery_id if gov_delivery_id
     params[:combine_mode] = combine_mode if combine_mode
 
     query_string = nested_query_string(params)
@@ -131,7 +129,6 @@ class GdsApi::EmailAlertApi < GdsApi::Base
   # @return [Hash] subscriber_list: {
   #  id
   #  title
-  #  gov_delivery_id
   #  created_at
   #  updated_at
   #  document_type

--- a/lib/gds_api/test_helpers/email_alert_api.rb
+++ b/lib/gds_api/test_helpers/email_alert_api.rb
@@ -398,7 +398,6 @@ module GdsApi
           document_type = attributes["document_type"]
           email_document_supertype = attributes["email_document_supertype"]
           government_document_supertype = attributes["government_document_supertype"]
-          gov_delivery_id = attributes["gov_delivery_id"]
           content_purpose_supergroup = attributes["content_purpose_supergroup"]
           combine_mode = attributes["combine_mode"]
 
@@ -408,7 +407,6 @@ module GdsApi
           params[:document_type] = document_type if document_type
           params[:email_document_supertype] = email_document_supertype if email_document_supertype
           params[:government_document_supertype] = government_document_supertype if government_document_supertype
-          params[:gov_delivery_id] = gov_delivery_id if gov_delivery_id
           params[:content_purpose_supergroup] = content_purpose_supergroup if content_purpose_supergroup
           params[:combine_mode] = combine_mode if combine_mode
 

--- a/test/email_alert_api_test.rb
+++ b/test/email_alert_api_test.rb
@@ -217,8 +217,6 @@ describe GdsApi::EmailAlertApi do
   end
 
   describe "subscriber lists" do
-    let(:expected_subscription_url) { "a subscription url" }
-
     describe "#find_or_create_subscriber_list_by_tags" do
       let(:params) do
         {
@@ -236,7 +234,7 @@ describe GdsApi::EmailAlertApi do
           stub_email_alert_api_creates_subscriber_list(
             "title" => title,
             "tags" => tags,
-            "subscription_url" => expected_subscription_url,
+            "slug" => "slug",
           )
         end
 
@@ -246,8 +244,8 @@ describe GdsApi::EmailAlertApi do
             .fetch("subscriber_list")
 
           assert_equal(
-            expected_subscription_url,
-            subscriber_list_attrs.fetch("subscription_url"),
+            "slug",
+            subscriber_list_attrs.fetch("slug"),
           )
 
           assert_equal(
@@ -262,7 +260,7 @@ describe GdsApi::EmailAlertApi do
           stub_email_alert_api_has_subscriber_list(
             "title" => "Some Title",
             "tags" => tags,
-            "subscription_url" => expected_subscription_url,
+            "slug" => "slug",
           )
         end
 
@@ -272,8 +270,8 @@ describe GdsApi::EmailAlertApi do
             .fetch("subscriber_list")
 
           assert_equal(
-            expected_subscription_url,
-            subscriber_list_attrs.fetch("subscription_url"),
+            "slug",
+            subscriber_list_attrs.fetch("slug"),
           )
         end
       end
@@ -292,7 +290,6 @@ describe GdsApi::EmailAlertApi do
             "title" => "Some Title",
             "tags" => tags,
             "document_type" => "travel_advice",
-            "subscription_url" => expected_subscription_url,
           )
         end
 
@@ -324,7 +321,6 @@ describe GdsApi::EmailAlertApi do
             "tags" => tags,
             "email_document_supertype" => "publications",
             "government_document_supertype" => "travel_advice",
-            "subscription_url" => expected_subscription_url,
           )
         end
 
@@ -364,7 +360,6 @@ describe GdsApi::EmailAlertApi do
             "title" => "Some Title",
             "tags" => tags,
             "links" => links,
-            "subscription_url" => expected_subscription_url,
           )
         end
 

--- a/test/email_alert_api_test.rb
+++ b/test/email_alert_api_test.rb
@@ -344,36 +344,6 @@ describe GdsApi::EmailAlertApi do
         end
       end
 
-      describe "when the optional 'gov_delivery_id' is provided" do
-        let(:params) do
-          {
-            "title" => title,
-            "tags" => tags,
-            "gov_delivery_id" => "TOPIC-A",
-          }
-        end
-
-        before do
-          stub_email_alert_api_has_subscriber_list(
-            "title" => "Some Title",
-            "tags" => tags,
-            "gov_delivery_id" => "TOPIC-A",
-            "subscription_url" => expected_subscription_url,
-          )
-        end
-
-        it "returns the subscriber list attributes" do
-          subscriber_list_attrs = api_client.find_or_create_subscriber_list(params)
-            .to_hash
-            .fetch("subscriber_list")
-
-          assert_equal(
-            "TOPIC-A",
-            subscriber_list_attrs.fetch("gov_delivery_id"),
-          )
-        end
-      end
-
       describe "when both tags and links are provided" do
         let(:links) do
           {
@@ -578,7 +548,6 @@ describe GdsApi::EmailAlertApi do
         slug: "test123",
         returned_attributes: {
           id: 1,
-          gov_delivery_id: "test123",
         },
       )
       api_response = api_client.get_subscriber_list(slug: "test123")


### PR DESCRIPTION
Depends on: https://github.com/alphagov/email-alert-api/pull/1517

Please see the commits for more details.