### PR TITLE
Add country_name to Mapit API response and update Local Links Manager test helper stubs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 68.2.0
+
+* Update the local links manager adapter stubs to include country_name - defaults to `England`
+* Add country_name to the Mapit `location_for_postcode` API response
+
 # 68.1.0
 
 * Add a `GdsApi::HTTPBadRequest` exception

--- a/lib/gds_api/mapit.rb
+++ b/lib/gds_api/mapit.rb
@@ -37,6 +37,10 @@ class GdsApi::Mapit < GdsApi::Base
     def postcode
       @response["postcode"]
     end
+
+    def country_name
+      @response["country_name"]
+    end
   end
 
 private

--- a/lib/gds_api/test_helpers/local_links_manager.rb
+++ b/lib/gds_api/test_helpers/local_links_manager.rb
@@ -5,13 +5,14 @@ module GdsApi
     module LocalLinksManager
       LOCAL_LINKS_MANAGER_ENDPOINT = Plek.current.find("local-links-manager")
 
-      def stub_local_links_manager_has_a_link(authority_slug:, lgsl:, lgil:, url:)
+      def stub_local_links_manager_has_a_link(authority_slug:, lgsl:, lgil:, url:, country_name: "England")
         response = {
           "local_authority" => {
             "name" => authority_slug.capitalize,
             "snac" => "00AG",
             "tier" => "unitary",
             "homepage_url" => "http://#{authority_slug}.example.com",
+            "country_name" => country_name,
           },
           "local_interaction" => {
             "lgsl_code" => lgsl,
@@ -25,13 +26,14 @@ module GdsApi
           .to_return(body: response.to_json, status: 200)
       end
 
-      def stub_local_links_manager_has_no_link(authority_slug:, lgsl:, lgil:)
+      def stub_local_links_manager_has_no_link(authority_slug:, lgsl:, lgil:, country_name: "England")
         response = {
           "local_authority" => {
             "name" => authority_slug.capitalize,
             "snac" => "00AG",
             "tier" => "unitary",
             "homepage_url" => "http://#{authority_slug}.example.com",
+            "country_name" => country_name,
           },
         }
 
@@ -40,13 +42,14 @@ module GdsApi
           .to_return(body: response.to_json, status: 200)
       end
 
-      def stub_local_links_manager_has_no_link_and_no_homepage_url(authority_slug:, lgsl:, lgil:)
+      def stub_local_links_manager_has_no_link_and_no_homepage_url(authority_slug:, lgsl:, lgil:, country_name: "England")
         response = {
           "local_authority" => {
             "name" => authority_slug.capitalize,
             "snac" => "00AG",
             "tier" => "unitary",
             "homepage_url" => nil,
+            "country_name" => country_name,
           },
         }
 
@@ -82,6 +85,7 @@ module GdsApi
             {
               "name" => authority_slug.capitalize,
               "homepage_url" => "http://#{authority_slug}.example.com",
+              "country_name" => "England",
               "tier" => "unitary",
             },
           ],
@@ -98,11 +102,13 @@ module GdsApi
             {
               "name" => district_slug.capitalize,
               "homepage_url" => "http://#{district_slug}.example.com",
+              "country_name" => "England",
               "tier" => "district",
             },
             {
               "name" => county_slug.capitalize,
               "homepage_url" => "http://#{county_slug}.example.com",
+              "country_name" => "England",
               "tier" => "county",
             },
           ],
@@ -131,6 +137,7 @@ module GdsApi
             {
               "name" => authority_slug.capitalize,
               "homepage_url" => "",
+              "country_name" => "England",
               "tier" => "unitary",
             },
           ],

--- a/lib/gds_api/test_helpers/mapit.rb
+++ b/lib/gds_api/test_helpers/mapit.rb
@@ -43,6 +43,20 @@ module GdsApi
           .to_return(body: response.to_json, status: 200)
       end
 
+      def stub_mapit_has_a_postcode_and_country_name(postcode, coords, country_name)
+        response = {
+          "wgs84_lat" => coords.first,
+          "wgs84_lon" => coords.last,
+          "postcode" => postcode,
+          "country_name" => country_name,
+        }
+
+        stub_request(:get, "#{MAPIT_ENDPOINT}/postcode/" + postcode.tr(" ", "+") + ".json")
+          .to_return(body: response.to_json, status: 200)
+        stub_request(:get, "#{MAPIT_ENDPOINT}/postcode/partial/" + postcode.split(" ").first + ".json")
+          .to_return(body: response.to_json, status: 200)
+      end
+
       def stub_mapit_does_not_have_a_postcode(postcode)
         stub_request(:get, "#{MAPIT_ENDPOINT}/postcode/" + postcode.tr(" ", "+") + ".json")
           .to_return(body: { "code" => 404, "error" => "No Postcode matches the given query." }.to_json, status: 404)

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = "68.1.0".freeze
+  VERSION = "68.2.0".freeze
 end

--- a/test/local_links_manager_api_test.rb
+++ b/test/local_links_manager_api_test.rb
@@ -18,6 +18,7 @@ describe GdsApi::LocalLinksManager do
           lgsl: 2,
           lgil: 4,
           url: "http://blackburn.example.com/abandoned-shopping-trolleys/report",
+          country_name: "England",
         )
 
         expected_response = {
@@ -26,6 +27,7 @@ describe GdsApi::LocalLinksManager do
             "snac" => "00AG",
             "tier" => "unitary",
             "homepage_url" => "http://blackburn.example.com",
+            "country_name" => "England",
           },
           "local_interaction" => {
             "lgsl_code" => 2,
@@ -43,6 +45,7 @@ describe GdsApi::LocalLinksManager do
           authority_slug: "blackburn",
           lgsl: 2,
           lgil: 4,
+          country_name: "England",
         )
 
         expected_response = {
@@ -51,6 +54,7 @@ describe GdsApi::LocalLinksManager do
             "snac" => "00AG",
             "tier" => "unitary",
             "homepage_url" => "http://blackburn.example.com",
+            "country_name" => "England",
           },
         }
 
@@ -63,6 +67,7 @@ describe GdsApi::LocalLinksManager do
           authority_slug: "blackburn",
           lgsl: 2,
           lgil: 4,
+          country_name: "England",
         )
 
         expected_response = {
@@ -71,6 +76,7 @@ describe GdsApi::LocalLinksManager do
             "snac" => "00AG",
             "tier" => "unitary",
             "homepage_url" => nil,
+            "country_name" => "England",
           },
         }
 
@@ -142,11 +148,13 @@ describe GdsApi::LocalLinksManager do
             {
               "name" => "Blackburn",
               "homepage_url" => "http://blackburn.example.com",
+              "country_name" => "England",
               "tier" => "district",
             },
             {
               "name" => "Rochester",
               "homepage_url" => "http://rochester.example.com",
+              "country_name" => "England",
               "tier" => "county",
             },
           ],
@@ -166,6 +174,7 @@ describe GdsApi::LocalLinksManager do
             {
               "name" => "Blackburn",
               "homepage_url" => "http://blackburn.example.com",
+              "country_name" => "England",
               "tier" => "unitary",
             },
           ],

--- a/test/mapit_test.rb
+++ b/test/mapit_test.rb
@@ -49,6 +49,27 @@ describe GdsApi::Mapit do
       assert_equal "30UN", response.areas.last.codes["ons"]
     end
 
+    it "should return the country name" do
+      stub_mapit_has_a_postcode_and_country_name("SW1A 1AA", [51.5010096, -0.1415870], "England")
+
+      response = @api.location_for_postcode("SW1A 1AA")
+      assert_equal "England", response.country_name
+    end
+
+    it "should allow the country name to be nil" do
+      stub_mapit_has_a_postcode_and_country_name("SW1A 1AA", [51.5010096, -0.1415870], nil)
+
+      response = @api.location_for_postcode("SW1A 1AA")
+      assert_nil response.country_name
+    end
+
+    it "should allow the country name to be an empty string" do
+      stub_mapit_has_a_postcode_and_country_name("SW1A 1AA", [51.5010096, -0.1415870], "")
+
+      response = @api.location_for_postcode("SW1A 1AA")
+      assert_equal "", response.country_name
+    end
+
     it "should raise if a postcode doesn't exist" do
       stub_mapit_does_not_have_a_postcode("SW1A 1AA")
 


### PR DESCRIPTION
## What

The `country_name` - which is available from [Mapit](https://github.com/alphagov/mapit) - is not present in the current Mapit API response.

## Why

Add `country_name` to the Mapit API response so that we can provide a better user experience for the Test and Trace Payment service in situations where the service is unavailable from the user's given postcode.

[Trello](https://trello.com/c/QSY1CoAB/643-test-and-trace-nation-validation)