### PR TITLE
Add a specific HTTPBadRequest exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Add a `GdsApi::HTTPBadRequest` exception
+
 # 68.0.0
 
 * BREAKING: make subscribe test helper interface more flexible

--- a/lib/gds_api/exceptions.rb
+++ b/lib/gds_api/exceptions.rb
@@ -40,6 +40,7 @@ module GdsApi
   class HTTPForbidden < HTTPClientError; end
   class HTTPConflict < HTTPClientError; end
   class HTTPUnprocessableEntity < HTTPClientError; end
+  class HTTPBadRequest < HTTPClientError; end
   class HTTPTooManyRequests < HTTPIntermittentClientError; end
 
   # Superclass & fallback for all 5XX errors
@@ -60,6 +61,8 @@ module GdsApi
 
     def error_class_for_code(code)
       case code
+      when 400
+        GdsApi::HTTPBadRequest
       when 401
         GdsApi::HTTPUnauthorized
       when 403


### PR DESCRIPTION
This seemed to be a curious omission from the other named exception
classes where the various other common 4xx errors seemed to have named
exceptions.

This has been added in due to challenges of working with exceptions when
an app may return a Bad Request response as per [1].

Unfortunately this repo doesn't have any tests for this error handling
set-up so it wasn't consistent to add a test for this.

[1]: https://github.com/alphagov/collections/blob/abfdf508d30d12704df22bba9349ae9559a445af/app/models/mapit_location.rb#L18-L19