### PR TITLE
Remove redundant adapter to send ad-hoc email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 * Add a `GdsApi::HTTPBadRequest` exception
+* Remove redundant adapter to send ad-hoc email
 
 # 68.0.0
 

--- a/lib/gds_api/email_alert_api.rb
+++ b/lib/gds_api/email_alert_api.rb
@@ -64,13 +64,6 @@ class GdsApi::EmailAlertApi < GdsApi::Base
     post_json("#{endpoint}/messages", message, headers)
   end
 
-  # Send email
-  #
-  # @param email_params [Hash] address, subject, body
-  def create_email(email_params)
-    post_json("#{endpoint}/emails", email_params)
-  end
-
   # Unpublishing alert
   #
   # @param message [Hash] content_id

--- a/test/email_alert_api_test.rb
+++ b/test/email_alert_api_test.rb
@@ -73,15 +73,6 @@ describe GdsApi::EmailAlertApi do
     end
   end
 
-  it "posts a new email" do
-    stub_email_alert_api_accepts_email
-    email_params = { address: "test@test.com", subject: "Subject", body: "Description of thing" }
-
-    assert api_client.create_email(email_params)
-
-    assert_requested(:post, "#{base_url}/emails", body: email_params.to_json)
-  end
-
   let(:unpublish_message) do
     {
       "content_id" => "content-id",


### PR DESCRIPTION
This is unused [1].

[1]: https://github.com/alphagov/email-alert-api/issues/1531