### PR TITLE
Bump to 68.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 68.1.0
 
 * Add a `GdsApi::HTTPBadRequest` exception
 * Remove redundant adapter to send ad-hoc email

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = "68.0.0".freeze
+  VERSION = "68.1.0".freeze
 end


### PR DESCRIPTION
* Add a `GdsApi::HTTPBadRequest` exception
* Remove redundant adapter to send ad-hoc email