### PR TITLE
[DO NOT MERGE] Switch email list adapter to just use "create"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* BREAKING: remove redundant test helpers for finding subscriber lists
 * BREAKING: Switch "find_or_create_subscriber_list" to only call "create" endpoint
 
 # 68.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* BREAKING: Switch "find_or_create_subscriber_list" to only call "create" endpoint
+
 # 68.2.0
 
 * Update the local links manager adapter stubs to include country_name - defaults to `England`

--- a/lib/gds_api/email_alert_api.rb
+++ b/lib/gds_api/email_alert_api.rb
@@ -10,37 +10,12 @@ class GdsApi::EmailAlertApi < GdsApi::Base
   #
   # @param attributes [Hash] document_type, links, tags used to search existing subscriber lists
   def find_or_create_subscriber_list(attributes)
-    find_subscriber_list(attributes)
-  rescue GdsApi::HTTPNotFound
-    create_subscriber_list(attributes)
-  end
-
-  # Get a subscriber list
-  #
-  # @param attributes [Hash] document_type, links, tags used to search existing subscriber lists
-  def find_subscriber_list(attributes)
-    tags = attributes["tags"]
-    links = attributes["links"]
-    document_type = attributes["document_type"]
-    email_document_supertype = attributes["email_document_supertype"]
-    government_document_supertype = attributes["government_document_supertype"]
-    combine_mode = attributes["combine_mode"]
-
-    if tags && links
+    if attributes["tags"] && attributes["links"]
       message = "please provide either tags or links (or neither), but not both"
       raise ArgumentError, message
     end
 
-    params = {}
-    params[:tags] = tags if tags
-    params[:links] = links if links
-    params[:document_type] = document_type if document_type
-    params[:email_document_supertype] = email_document_supertype if email_document_supertype
-    params[:government_document_supertype] = government_document_supertype if government_document_supertype
-    params[:combine_mode] = combine_mode if combine_mode
-
-    query_string = nested_query_string(params)
-    get_json("#{endpoint}/subscriber-lists?" + query_string)
+    create_subscriber_list(attributes)
   end
 
   # Post a subscriber list

--- a/lib/gds_api/test_helpers/email_alert_api.rb
+++ b/lib/gds_api/test_helpers/email_alert_api.rb
@@ -124,19 +124,6 @@ module GdsApi
         matching.last
       end
 
-      def stub_email_alert_api_has_subscriber_list(attributes)
-        stub_request(:get, build_subscriber_lists_url(attributes))
-          .to_return(
-            status: 200,
-            body: get_subscriber_list_response(attributes).to_json,
-          )
-      end
-
-      def stub_email_alert_api_does_not_have_subscriber_list(attributes)
-        stub_request(:get, build_subscriber_lists_url(attributes))
-          .to_return(status: 404)
-      end
-
       def stub_email_alert_api_creates_subscriber_list(attributes)
         stub_request(:post, build_subscriber_lists_url)
           .to_return(

--- a/test/email_alert_api_test.rb
+++ b/test/email_alert_api_test.rb
@@ -218,10 +218,6 @@ describe GdsApi::EmailAlertApi do
 
       describe "a subscriber list with that tag set does not yet exist" do
         before do
-          stub_email_alert_api_does_not_have_subscriber_list(
-            "tags" => tags,
-          )
-
           stub_email_alert_api_creates_subscriber_list(
             "title" => title,
             "tags" => tags,
@@ -248,7 +244,8 @@ describe GdsApi::EmailAlertApi do
 
       describe "a subscriber list with that tag set does already exist" do
         before do
-          stub_email_alert_api_has_subscriber_list(
+          # the "create" endpoint returns existing lists
+          stub_email_alert_api_creates_subscriber_list(
             "title" => "Some Title",
             "tags" => tags,
             "slug" => "slug",
@@ -277,7 +274,7 @@ describe GdsApi::EmailAlertApi do
         end
 
         before do
-          stub_email_alert_api_has_subscriber_list(
+          stub_email_alert_api_creates_subscriber_list(
             "title" => "Some Title",
             "tags" => tags,
             "document_type" => "travel_advice",
@@ -307,7 +304,7 @@ describe GdsApi::EmailAlertApi do
         end
 
         before do
-          stub_email_alert_api_has_subscriber_list(
+          stub_email_alert_api_creates_subscriber_list(
             "title" => "Some Title",
             "tags" => tags,
             "email_document_supertype" => "publications",
@@ -344,14 +341,6 @@ describe GdsApi::EmailAlertApi do
             "tags" => tags,
             "links" => links,
           }
-        end
-
-        before do
-          stub_email_alert_api_has_subscriber_list(
-            "title" => "Some Title",
-            "tags" => tags,
-            "links" => links,
-          )
         end
 
         it "excludes that attribute from the query string" do


### PR DESCRIPTION
https://trello.com/c/dgdLhy2H/777-update-transition-to-brexit-in-email-notifications-for-transition-taxon

Depends on: https://github.com/alphagov/email-alert-api/pull/1569

Previously calling "find_or_create_subscriber_list" would result in
up to 2 API calls. Since we've changed the "create" endpoint to also
return an existing list [1], we can simplify the adapter to just use
that, with the added benefit of keeping titles/URLs in-sync.

[1]: https://github.com/alphagov/email-alert-api/pull/1569