### PR TITLE
Contract tests with Collections's Organisations API

### DIFF
--- a/test/collections/organisations_api_test.rb
+++ b/test/collections/organisations_api_test.rb
@@ -1,0 +1,58 @@
+require "test_helper"
+require "gds_api/organisations"
+require "gds_api/test_helpers/organisations"
+
+describe GdsApi::Organisations do
+  include GdsApi::TestHelpers::Organisations
+
+  before do
+    @base_api_url = Plek.new.website_root
+    @api = GdsApi::Organisations.new(@base_api_url)
+  end
+
+  describe "fetching list of organisations" do
+    it "should get the organisations" do
+      organisation_slugs = %w[ministry-of-fun tea-agency]
+      stub_organisations_api_has_organisations(organisation_slugs)
+
+      response = @api.organisations
+      assert_equal(organisation_slugs, response.map { |r| r["details"]["slug"] })
+      assert_equal "Tea Agency", response["results"][1]["title"]
+    end
+
+    it "should handle the pagination" do
+      organisation_slugs = (1..50).map { |n| "organisation-#{n}" }
+      stub_organisations_api_has_organisations(organisation_slugs)
+
+      response = @api.organisations
+      assert_equal(
+        organisation_slugs,
+        response.with_subsequent_pages.map { |r| r["details"]["slug"] },
+      )
+    end
+
+    it "should raise error if endpoint 404s" do
+      stub_request(:get, "#{@base_api_url}/api/organisations").to_return(status: 404)
+      assert_raises GdsApi::HTTPNotFound do
+        @api.organisations
+      end
+    end
+  end
+
+  describe "fetching an organisation" do
+    it "should return the details" do
+      stub_organisations_api_has_organisation("ministry-of-fun")
+
+      response = @api.organisation("ministry-of-fun")
+      assert_equal "Ministry Of Fun", response["title"]
+    end
+
+    it "should raise for a non-existent organisation" do
+      stub_organisations_api_does_not_have_organisation("non-existent")
+
+      assert_raises(GdsApi::HTTPNotFound) do
+        @api.organisation("non-existent")
+      end
+    end
+  end
+end

--- a/test/organisations_api_test.rb
+++ b/test/organisations_api_test.rb
@@ -108,4 +108,31 @@ describe GdsApi::Organisations do
       assert_equal 40, response.with_subsequent_pages.count
     end
   end
+
+  describe "fetching an organisation by slug" do
+    let(:hmrc) { "hm-revenue-customs" }
+
+    before do
+      organisation_api
+        .given("the organisation hmrc exists")
+        .upon_receiving("a request for hm-revenue-customs")
+        .with(
+          method: :get,
+          path: "/api/organisations/#{hmrc}",
+          headers: GdsApi::JsonClient.default_request_headers,
+        )
+        .will_respond_with(
+          status: 200,
+          body: organisation(slug: hmrc),
+        )
+    end
+
+    it "responds with 200 and the organisation" do
+      response = api_client.organisation(hmrc)
+
+      id = "www.gov.uk/api/organisations/#{hmrc}"
+      assert_equal 200, response.code
+      assert_equal id, response["id"]
+    end
+  end
 end

--- a/test/organisations_api_test.rb
+++ b/test/organisations_api_test.rb
@@ -135,4 +135,28 @@ describe GdsApi::Organisations do
       assert_equal id, response["id"]
     end
   end
+
+  describe "an organisation doesn't exist for a given slug" do
+    before do
+      organisation_api
+        .given("no organisation exists")
+        .upon_receiving("a request for a non-existant organisation")
+        .with(
+          method: :get,
+          path: "/api/organisations/department-for-making-life-better",
+          headers: GdsApi::JsonClient.default_request_headers,
+        )
+        .will_respond_with(
+          status: 404,
+          body: "404 error",
+        )
+    end
+
+    it "returns a 404 error code" do
+      error = assert_raises(GdsApi::HTTPNotFound) do
+        api_client.organisation("department-for-making-life-better")
+      end
+      assert_equal 404, error.code
+    end
+  end
 end

--- a/test/organisations_api_test.rb
+++ b/test/organisations_api_test.rb
@@ -5,5 +5,59 @@ require "gds_api/test_helpers/organisations"
 describe GdsApi::Organisations do
   include GdsApi::TestHelpers::Organisations
   include PactTest
-  
+
+  def base_api_url
+    Plek.new.website_root
+  end
+
+  def api_client
+    @api_client ||= GdsApi::Organisations.new(organisation_api_host)
+  end
+
+  def organisation(slug: "test-department")
+    {
+      "id" => Pact.like("www.gov.uk/api/organisations/#{slug}"),
+      "title" => Pact.like("Test Department"),
+      "updated_at" => Pact.like("2019-05-15T12:12:17.000+01:00"),
+      "web_url" => Pact.like("www.gov.uk/government/organisations/#{slug}"),
+      "details" => {
+        "slug" => Pact.like(slug),
+        "content_id" => Pact.like("b854f170-53c8-4098-bf77-e8ef42f93107"),
+      },
+      "analytics_identifier" => Pact.like("OT1276"),
+      "child_organisations" => [],
+      "superseded_organisations" => [],
+    }
+  end
+
+  describe "fetching list of organisations" do
+    before do
+      organisation_api
+        .given("there is a list of organisations")
+        .upon_receiving("a request for the organisation list")
+        .with(
+          method: :get,
+          path: "/api/organisations",
+          headers: GdsApi::JsonClient.default_request_headers,
+        )
+        .will_respond_with(
+          status: 200,
+          body: {
+            results: [
+              organisation,
+              organisation,
+            ],
+          },
+          headers: {
+            "Content-Type" => "application/json; charset=utf-8",
+          },
+        )
+    end
+
+    it "responds with 200 OK and a list of organisations" do
+      response = api_client.organisations
+      assert_equal 2, response["results"].count
+      assert_equal 200, response.code
+    end
+  end
 end

--- a/test/organisations_api_test.rb
+++ b/test/organisations_api_test.rb
@@ -4,55 +4,6 @@ require "gds_api/test_helpers/organisations"
 
 describe GdsApi::Organisations do
   include GdsApi::TestHelpers::Organisations
-
-  before do
-    @base_api_url = Plek.new.website_root
-    @api = GdsApi::Organisations.new(@base_api_url)
-  end
-
-  describe "fetching list of organisations" do
-    it "should get the organisations" do
-      organisation_slugs = %w[ministry-of-fun tea-agency]
-      stub_organisations_api_has_organisations(organisation_slugs)
-
-      response = @api.organisations
-      assert_equal(organisation_slugs, response.map { |r| r["details"]["slug"] })
-      assert_equal "Tea Agency", response["results"][1]["title"]
-    end
-
-    it "should handle the pagination" do
-      organisation_slugs = (1..50).map { |n| "organisation-#{n}" }
-      stub_organisations_api_has_organisations(organisation_slugs)
-
-      response = @api.organisations
-      assert_equal(
-        organisation_slugs,
-        response.with_subsequent_pages.map { |r| r["details"]["slug"] },
-      )
-    end
-
-    it "should raise error if endpoint 404s" do
-      stub_request(:get, "#{@base_api_url}/api/organisations").to_return(status: 404)
-      assert_raises GdsApi::HTTPNotFound do
-        @api.organisations
-      end
-    end
-  end
-
-  describe "fetching an organisation" do
-    it "should return the details" do
-      stub_organisations_api_has_organisation("ministry-of-fun")
-
-      response = @api.organisation("ministry-of-fun")
-      assert_equal "Ministry Of Fun", response["title"]
-    end
-
-    it "should raise for a non-existent organisation" do
-      stub_organisations_api_does_not_have_organisation("non-existent")
-
-      assert_raises(GdsApi::HTTPNotFound) do
-        @api.organisation("non-existent")
-      end
-    end
-  end
+  include PactTest
+  
 end

--- a/test/test_helpers/pact_helper.rb
+++ b/test/test_helpers/pact_helper.rb
@@ -1,13 +1,26 @@
 PUBLISHING_API_PORT = 3001
+ORGANISATION_API_PORT = 3002
 
 def publishing_api_host
   "http://localhost:#{PUBLISHING_API_PORT}"
+end
+
+def organisation_api_host
+  "http://localhost:#{ORGANISATION_API_PORT}"
 end
 
 Pact.service_consumer "GDS API Adapters" do
   has_pact_with "Publishing API" do
     mock_service :publishing_api do
       port PUBLISHING_API_PORT
+    end
+  end
+end
+
+Pact.service_consumer "GDS API Adapters" do
+  has_pact_with "Collections Organisation API" do
+    mock_service :organisation_api do
+      port ORGANISATION_API_PORT
     end
   end
 end


### PR DESCRIPTION
## What
Collections is the home of the [Organisations api](https://github.com/alphagov/collections/blob/master/docs/api.md#collections-api). For collections to [meet the standards](https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#check-api-contract-tests-pass-ie-adapters-work-with-their-apis) required for continuously deployment, we need contract tests between collections and its api consumer, gds-api-adaptors.
This PR is the first step, allowing the contract tests to be run locally against https://github.com/alphagov/collections/pull/2230.

## Steps to run tests
1. From this branch, `bundle exec rake TEST=test/organisations_api_test.rb` creates a pactfile which defines the pacts with collections. 
2. cd collections and checkout https://github.com/alphagov/collections/pull/2230
3. `bundle exec rake pact:verify`

See https://github.com/alphagov/collections/pull/2230 for next steps. 

-- 
[Trello](https://trello.com/c/Qpd7jgOq/628-add-contract-testing-to-the-collections-app)