### PR TITLE
Bump version to 69.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 69.0.0
 
 * BREAKING: remove redundant test helpers for finding subscriber lists
 * BREAKING: Switch "find_or_create_subscriber_list" to only call "create" endpoint

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = "68.2.0".freeze
+  VERSION = "69.0.0".freeze
 end


### PR DESCRIPTION
https://trello.com/c/dgdLhy2H/777-update-transition-to-brexit-in-email-notifications-for-transition-taxon