### PR TITLE
Remove unused email unpublishing adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Remove unused email unpublish adapter
+
 # 69.1.0
 
 * Restore find_subscriber_list adapter (for Content Tagger)

--- a/lib/gds_api/email_alert_api.rb
+++ b/lib/gds_api/email_alert_api.rb
@@ -40,17 +40,6 @@ class GdsApi::EmailAlertApi < GdsApi::Base
     post_json("#{endpoint}/messages", message, headers)
   end
 
-  # Unpublishing alert
-  #
-  # @param message [Hash] content_id
-  #
-  # Used by email-alert-service to send a message to email-alert-api
-  # when an unpublishing message is put on the Rabbitmq queue by
-  # publishing-api
-  def send_unpublish_message(message)
-    post_json("#{endpoint}/unpublish-messages", message)
-  end
-
   # Get topic matches
   #
   # @param attributes [Hash] tags, links, document_type,

--- a/lib/gds_api/test_helpers/email_alert_api.rb
+++ b/lib/gds_api/test_helpers/email_alert_api.rb
@@ -150,11 +150,6 @@ module GdsApi
           .to_return(status: 422)
       end
 
-      def stub_email_alert_api_accepts_unpublishing_message
-        stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/unpublish-messages")
-          .to_return(status: 202, body: {}.to_json)
-      end
-
       def stub_email_alert_api_accepts_content_change
         stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/content-changes")
           .to_return(status: 202, body: {}.to_json)

--- a/test/email_alert_api_test.rb
+++ b/test/email_alert_api_test.rb
@@ -73,24 +73,6 @@ describe GdsApi::EmailAlertApi do
     end
   end
 
-  let(:unpublish_message) do
-    {
-      "content_id" => "content-id",
-    }
-  end
-
-  describe "unpublishing messages" do
-    before do
-      stub_email_alert_api_accepts_unpublishing_message
-    end
-
-    it "sends an unpublish message" do
-      assert api_client.send_unpublish_message(unpublish_message)
-
-      assert_requested(:post, "#{base_url}/unpublish-messages", body: unpublish_message.to_json)
-    end
-  end
-
   describe "subscriptions" do
     describe "URI encoding ids" do
       it "encodes the id for #get_subscription" do


### PR DESCRIPTION
https://trello.com/c/fbmVmwG3/666-remove-the-undocumented-taxon-unpublish-redirect-feature

See here for more information about this change [1].

[1]: https://github.com/alphagov/email-alert-api/issues/1572