### PR TITLE
Restore adapter to find_subscriber_list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Restore find_subscriber_list adapter
+
 # 69.0.0
 
 * BREAKING: remove redundant test helpers for finding subscriber lists

--- a/lib/gds_api/email_alert_api.rb
+++ b/lib/gds_api/email_alert_api.rb
@@ -15,13 +15,6 @@ class GdsApi::EmailAlertApi < GdsApi::Base
       raise ArgumentError, message
     end
 
-    create_subscriber_list(attributes)
-  end
-
-  # Post a subscriber list
-  #
-  # @param attributes [Hash] document_type, links, tags used to search existing subscriber lists
-  def create_subscriber_list(attributes)
     post_json("#{endpoint}/subscriber-lists", attributes)
   end
 

--- a/lib/gds_api/email_alert_api.rb
+++ b/lib/gds_api/email_alert_api.rb
@@ -18,6 +18,14 @@ class GdsApi::EmailAlertApi < GdsApi::Base
     post_json("#{endpoint}/subscriber-lists", attributes)
   end
 
+  # Get a subscriber list
+  #
+  # @param attributes [Hash] document_type, links, tags used to search existing subscriber lists
+  def find_subscriber_list(attributes)
+    query_string = nested_query_string(attributes)
+    get_json("#{endpoint}/subscriber-lists?" + query_string)
+  end
+
   # Post a content change
   #
   # @param content_change [Hash] Valid content change attributes

--- a/lib/gds_api/test_helpers/email_alert_api.rb
+++ b/lib/gds_api/test_helpers/email_alert_api.rb
@@ -132,6 +132,19 @@ module GdsApi
           )
       end
 
+      def stub_email_alert_api_has_subscriber_list(attributes)
+        stub_request(:get, build_subscriber_lists_url(attributes))
+          .to_return(
+            status: 200,
+            body: get_subscriber_list_response(attributes).to_json,
+          )
+      end
+
+      def stub_email_alert_api_does_not_have_subscriber_list(attributes)
+        stub_request(:get, build_subscriber_lists_url(attributes))
+          .to_return(status: 404)
+      end
+
       def stub_email_alert_api_refuses_to_create_subscriber_list
         stub_request(:post, build_subscriber_lists_url)
           .to_return(status: 422)

--- a/test/email_alert_api_test.rb
+++ b/test/email_alert_api_test.rb
@@ -662,4 +662,24 @@ describe GdsApi::EmailAlertApi do
       assert_equal(201, api_response.code)
     end
   end
+
+  describe "find_subscriber_list" do
+    describe "a matching list exists" do
+      it "returns 200" do
+        stub_email_alert_api_has_subscriber_list("tags" => tags)
+        api_response = api_client.find_subscriber_list("tags" => tags)
+        assert_equal(200, api_response.code)
+      end
+    end
+
+    describe "no matching list exists" do
+      it "returns 404" do
+        stub_email_alert_api_does_not_have_subscriber_list("tags" => tags)
+
+        assert_raises GdsApi::HTTPNotFound do
+          api_client.find_subscriber_list("tags" => tags)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
https://trello.com/c/dgdLhy2H/777-update-transition-to-brexit-in-email-notifications-for-transition-taxon

Unfortunately this is still used by Content Tagger. Please see the commits
for more details.