### PR TITLE
Bump version to 69.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-# Unreleased
+# 69.1.0
 
-* Restore find_subscriber_list adapter
+* Restore find_subscriber_list adapter (for Content Tagger)
 
 # 69.0.0
 

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = "69.0.0".freeze
+  VERSION = "69.1.0".freeze
 end


### PR DESCRIPTION
https://trello.com/c/dgdLhy2H/777-update-transition-to-brexit-in-email-notifications-for-transition-taxon