### PR TITLE
Add link status to Local Links Manager API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 69.3.0
+
+* Update the local links manager adapter stubs to include the link status - defaults to `ok`
+
 # 69.2.0
 
 * Remove unused email unpublish adapter

--- a/lib/gds_api/test_helpers/local_links_manager.rb
+++ b/lib/gds_api/test_helpers/local_links_manager.rb
@@ -5,7 +5,7 @@ module GdsApi
     module LocalLinksManager
       LOCAL_LINKS_MANAGER_ENDPOINT = Plek.current.find("local-links-manager")
 
-      def stub_local_links_manager_has_a_link(authority_slug:, lgsl:, lgil:, url:, country_name: "England")
+      def stub_local_links_manager_has_a_link(authority_slug:, lgsl:, lgil:, url:, country_name: "England", status: "ok")
         response = {
           "local_authority" => {
             "name" => authority_slug.capitalize,
@@ -18,6 +18,7 @@ module GdsApi
             "lgsl_code" => lgsl,
             "lgil_code" => lgil,
             "url" => url,
+            "status" => status,
           },
         }
 

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = "69.2.0".freeze
+  VERSION = "69.3.0".freeze
 end

--- a/test/local_links_manager_api_test.rb
+++ b/test/local_links_manager_api_test.rb
@@ -19,6 +19,7 @@ describe GdsApi::LocalLinksManager do
           lgil: 4,
           url: "http://blackburn.example.com/abandoned-shopping-trolleys/report",
           country_name: "England",
+          status: "ok",
         )
 
         expected_response = {
@@ -33,6 +34,7 @@ describe GdsApi::LocalLinksManager do
             "lgsl_code" => 2,
             "lgil_code" => 4,
             "url" => "http://blackburn.example.com/abandoned-shopping-trolleys/report",
+            "status" => "ok",
           },
         }
 


### PR DESCRIPTION
## What

We would like to be able to retrieve the link status from the Local Links Manager API response.

[Trello](https://trello.com/c/CcwdnK7A/745-add-link-status-in-api-response)