### PR TITLE
Remove redundant Jenkinsfile config

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,6 @@ node("postgresql-9.6") {
   govuk.setEnvar("PACT_BROKER_BASE_URL", "https://pact-broker.cloudapps.digital")
 
   govuk.buildProject(
-    rubyLintDiff: false,
     extraParameters: [
       stringParam(
         name: 'PUBLISHING_API_BRANCH',


### PR DESCRIPTION
The rubyLintDiff option no longer has any affect.