### PR TITLE
Configure Jenkins to run pact tests with Collections

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,6 +14,11 @@ node("postgresql-9.6") {
         name: 'PUBLISHING_API_BRANCH',
         defaultValue: 'master',
         description: 'Branch of publishing-api to run pacts against'
+      ),
+      stringParam(
+        name: 'COLLECTIONS_BRANCH',
+        defaultValue: 'master',
+        description: 'Branch of collections to run pacts against'
       )
     ],
     afterTest: {
@@ -27,6 +32,7 @@ node("postgresql-9.6") {
       ]) {
         publishPacts(govuk, env.BRANCH_NAME == 'master')
         runPublishingApiPactTests(govuk)
+        runCollectionsPactTests(govuk)
       }
     }
   )
@@ -44,6 +50,16 @@ def runPublishingApiPactTests(govuk) {
       govuk.bundleApp()
       lock("publishing-api-$NODE_NAME-test") {
         govuk.runRakeTask("db:reset")
+        govuk.runRakeTask("pact:verify:branch[${env.BRANCH_NAME}]")
+      }
+    }
+  }
+}
+def runCollectionsPactTests(govuk){
+  govuk.checkoutDependent("collections", [ branch: COLLECTIONS_BRANCH ]) {
+    stage("Run collections pact") {
+      govuk.bundleApp()
+      lock("collections-$NODE_NAME-test") {
         govuk.runRakeTask("pact:verify:branch[${env.BRANCH_NAME}]")
       }
     }


### PR DESCRIPTION
## What

Following pact tests defined in #1024, run the pact tests as part of the deployment pipeline.

This PR is blocked by https://github.com/alphagov/collections/pull/2281 which defines the pact:verify:branch rake task that [this PR configures Jenkins to run](https://github.com/alphagov/gds-api-adapters/blob/5cd13fa8d0d170e83bdd8b1ddd35a6760a7e8003/Jenkinsfile#L63).

Related PR's in collections:
- https://github.com/alphagov/collections/pull/2230
- https://github.com/alphagov/collections/pull/2281

[Trello](https://trello.com/c/Qpd7jgOq/628-add-contract-testing-to-the-collections-app) 