### PR TITLE
Fix URLs that point to documentation for search-api

### DIFF
--- a/lib/gds_api/search.rb
+++ b/lib/gds_api/search.rb
@@ -67,7 +67,7 @@ module GdsApi
     #
     # @param args [Hash] A valid search query. See search-api documentation for options.
     #
-    # @see https://github.com/alphagov/search-api/blob/master/doc/search-api.md
+    # @see https://github.com/alphagov/search-api/blob/master/docs/search-api.md
     def search(args, additional_headers = {})
       request_url = "#{base_url}/search.json?#{Rack::Utils.build_nested_query(args)}"
       get_json(request_url, additional_headers)
@@ -77,7 +77,7 @@ module GdsApi
     #
     # @param searches [Array] An array valid search queries. Maximum of 6. See search-api documentation for options.
     #
-    # # @see https://github.com/alphagov/search-api/blob/master/doc/search-api.md
+    # # @see https://github.com/alphagov/search-api/blob/master/docs/search-api.md
     def batch_search(searches, additional_headers = {})
       url_friendly_searches = searches.each_with_index.map do |search, index|
         { index => search }
@@ -95,7 +95,7 @@ module GdsApi
     # @param args [Hash] A valid search query. See search-api documentation for options.
     # @param page_size [Integer] Number of results in each page.
     #
-    # @see https://github.com/alphagov/search-api/blob/master/doc/search-api.md
+    # @see https://github.com/alphagov/search-api/blob/master/docs/search-api.md
     def search_enum(args, page_size: 100, additional_headers: {})
       Enumerator.new do |yielder|
         (0..Float::INFINITY).step(page_size).each do |index|
@@ -120,7 +120,7 @@ module GdsApi
     #   GOV.UK - we only allow deletion from metasearch
     # @return [GdsApi::Response] A status code of 202 indicates the document has been successfully queued.
     #
-    # @see https://github.com/alphagov/search-api/blob/master/doc/documents.md
+    # @see https://github.com/alphagov/search-api/blob/master/docs/documents.md
     def add_document(*args)
       @api.add_document(*args)
     end
@@ -132,7 +132,7 @@ module GdsApi
     # and contacts, which may be deleted with `delete_document`.
     #
     # @param base_path Base path of the page on GOV.UK.
-    # @see https://github.com/alphagov/search-api/blob/master/doc/content-api.md
+    # @see https://github.com/alphagov/search-api/blob/master/docs/content-api.md
     def delete_content(base_path)
       request_url = "#{base_url}/content?link=#{base_path}"
       delete_json(request_url)
@@ -145,7 +145,7 @@ module GdsApi
     # and contacts.
     #
     # @param base_path [String] Base path of the page on GOV.UK.
-    # @see https://github.com/alphagov/search-api/blob/master/doc/content-api.md
+    # @see https://github.com/alphagov/search-api/blob/master/docs/content-api.md
     def get_content(base_path)
       request_url = "#{base_url}/content?link=#{base_path}"
       get_json(request_url)


### PR DESCRIPTION
It seems that at some point the directory was renamed from doc to docs, but never reflected in the adaptor.