### PR TITLE
Write "Consumer" Pact for Bank Holidays API

### DIFF
--- a/test/calendars_test.rb
+++ b/test/calendars_test.rb
@@ -1,0 +1,95 @@
+require "test_helper"
+require "gds_api/calendars"
+require "gds_api/test_helpers/calendars"
+
+describe GdsApi::Calendars do
+  include GdsApi::TestHelpers::Calendars
+  include PactTest
+
+  def base_api_url
+    Plek.new.website_root
+  end
+
+  def api_client
+    @api_client ||= GdsApi::Calendars.new(bank_holidays_api_host)
+  end
+
+  def event
+    {
+      "title" => Pact.like("New Year's Day"),
+      "date" => Pact.like("2016-01-01"),
+      "notes" => Pact.like("Substitute day"),
+      "bunting" => Pact.like(true),
+    }
+  end
+
+  describe "fetching all bank holidays" do
+    before do
+      bank_holidays_api
+        .given("there is a list of all bank holidays")
+        .upon_receiving("the request for the list of all bank holidays")
+        .with(
+          method: :get,
+          path: "/bank-holidays.json",
+          headers: GdsApi::JsonClient.default_request_headers,
+        )
+        .will_respond_with(
+          status: 200,
+          body: {
+            "england-and-wales": {
+              division: "england-and-wales",
+              events: Pact.each_like(event),
+            },
+            "scotland": {
+              division: "scotland",
+              events: Pact.each_like(event),
+            },
+            "northern-ireland": {
+              division: "northern-ireland",
+              events: Pact.each_like(event),
+            },
+          },
+          headers: {
+            "Content-Type" => "application/json; charset=utf-8",
+          },
+        )
+    end
+
+    it "responds with 200 OK and a list of bank holidays for each nation" do
+      response = api_client.bank_holidays
+      assert response["england-and-wales"]["events"].count.positive?
+      assert response["scotland"]["events"].count.positive?
+      assert response["northern-ireland"]["events"].count.positive?
+      assert_equal 200, response.code
+    end
+  end
+
+  describe "fetching only Scottish bank holidays" do
+    before do
+      bank_holidays_api
+        .given("there is a list of all bank holidays")
+        .upon_receiving("the request for the list of Scottish bank holidays")
+        .with(
+          method: :get,
+          path: "/bank-holidays/scotland.json",
+          headers: GdsApi::JsonClient.default_request_headers,
+        )
+        .will_respond_with(
+          status: 200,
+          body: {
+            division: "scotland",
+            events: Pact.each_like(event),
+          },
+          headers: {
+            "Content-Type" => "application/json; charset=utf-8",
+          },
+        )
+    end
+
+    it "responds with 200 OK and a list of bank holidays" do
+      response = api_client.bank_holidays("scotland")
+      assert response["events"].count.positive?
+      assert_equal 200, response.code
+    end
+  end
+end

--- a/test/frontend/bank_holidays_api_test.rb
+++ b/test/frontend/bank_holidays_api_test.rb
@@ -1,4 +1,4 @@
-require_relative "test_helper"
+require "test_helper"
 require "gds_api/calendars"
 require "gds_api/test_helpers/calendars"
 

--- a/test/test_helpers/pact_helper.rb
+++ b/test/test_helpers/pact_helper.rb
@@ -1,5 +1,6 @@
 PUBLISHING_API_PORT = 3001
 ORGANISATION_API_PORT = 3002
+BANK_HOLIDAYS_API_PORT = 3003
 
 def publishing_api_host
   "http://localhost:#{PUBLISHING_API_PORT}"
@@ -7,6 +8,10 @@ end
 
 def organisation_api_host
   "http://localhost:#{ORGANISATION_API_PORT}"
+end
+
+def bank_holidays_api_host
+  "http://localhost:#{BANK_HOLIDAYS_API_PORT}"
 end
 
 Pact.service_consumer "GDS API Adapters" do
@@ -21,6 +26,14 @@ Pact.service_consumer "GDS API Adapters" do
   has_pact_with "Collections Organisation API" do
     mock_service :organisation_api do
       port ORGANISATION_API_PORT
+    end
+  end
+end
+
+Pact.service_consumer "GDS API Adapters" do
+  has_pact_with "Bank Holidays API" do
+    mock_service :bank_holidays_api do
+      port BANK_HOLIDAYS_API_PORT
     end
   end
 end


### PR DESCRIPTION
## What
Frontend is the home of the Bank Holidays API, [relied upon by Smart Answers](https://github.com/alphagov/smart-answers/blob/cf2c69430e3abae5ef949321469162a35e651ce1/lib/working_days.rb#L6) and [by Publisher](https://github.com/alphagov/publisher/blob/ebbaee15f760087ce2b735f75d7c15ca58b73742/lib/working_days_calculator.rb#L28). For Frontend to [meet the standards](https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#check-api-contract-tests-pass-ie-adapters-work-with-their-apis) required of it for continuously deployment, we need contract tests between Frontend and its API consumer, gds-api-adaptors.

This PR is the first step, allowing the contract tests to be run locally against: https://github.com/alphagov/frontend/pull/2643

## Steps to run tests

1. From this branch, `govuk-docker-run bundle exec rake test`, which generates a git-ignored `spec/pacts` directory containing a pactfile (`gds_api_adapters-bank_holidays_api.json`) which defines the pacts with Frontend. 
2. `cd ../frontend` and checkout the branch at https://github.com/alphagov/frontend/pull/2643.
3. `govuk-docker-run bundle exec rake pact:verify`

Trello: https://trello.com/c/Pvoq4sQY/2370-5-enable-continuous-deployment-for-frontend