### PR TITLE
Allow developer to specify PACT_URI for Frontend Pact tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,6 +24,10 @@ node("postgresql-9.6") {
         name: 'FRONTEND_BRANCH',
         defaultValue: 'master',
         description: 'Branch of frontend to run pacts against'
+      ),
+      stringParam(
+        name: 'FRONTEND_PACT_URI',
+        description: 'Local pactfile for Frontend to test against (will test against Pact Broker if left blank). Example: "../gds-api-adapters/spec/pacts/gds_api_adapters-bank_holidays_api.json"'
       )
     ],
     afterTest: {
@@ -76,9 +80,12 @@ def runCollectionsPactTests(govuk){
 def runFrontendPactTests(govuk){
   govuk.checkoutDependent("frontend", [ branch: FRONTEND_BRANCH ]) {
     stage("Run frontend pact") {
+      environment { 
+        PACT_URI = FRONTEND_PACT_URI
+      }
       govuk.bundleApp()
       lock("frontend-$NODE_NAME-test") {
-        govuk.runRakeTask("pact:verify:branch[${env.BRANCH_NAME}]")
+        govuk.runRakeTask("pact:verify")
       }
     }
   }


### PR DESCRIPTION
This is to simplify the Frontend codebase. See
https://github.com/alphagov/frontend/pull/2647

I've made this configurable field called `FRONTEND_PACT_URI`,
rather than `PACT_URI`, so that we can provide different `PACT_URI`
values for each provider (otherwise if they all implement the
`PACT_URI` approach, all but one would fail as a result of
pointing to the wrong pactfile).