### PR TITLE
Add account-api adapter with auth endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * BREAKING: Minimum ruby version supported is updated to 2.6
 * BREAKING: `content_store_endpoint` helper now accepts a keyword argument instead of a boolean
+* Add new account-api adapter with auth endpoints
 
 # 69.3.0
 

--- a/lib/gds_api.rb
+++ b/lib/gds_api.rb
@@ -1,6 +1,7 @@
 require "addressable"
 require "plek"
 require "time"
+require "gds_api/account_api"
 require "gds_api/asset_manager"
 require "gds_api/calendars"
 require "gds_api/content_store"
@@ -21,6 +22,19 @@ require "gds_api/worldwide"
 
 # @api documented
 module GdsApi
+  # Creates a GdsApi::AccountApi adapter
+  #
+  # This will set a bearer token if a ACCOUNT_API_BEARER_TOKEN environment
+  # variable is set
+  #
+  # @return [GdsApi::AccountApi]
+  def self.account_api(options = {})
+    GdsApi::AccountApi.new(
+      Plek.find("account-api"),
+      { bearer_token: ENV["ACCOUNT_API_BEARER_TOKEN"] }.merge(options),
+    )
+  end
+
   # Creates a GdsApi::AssetManager adapter
   #
   # This will set a bearer token if a ASSET_MANAGER_BEARER_TOKEN environment

--- a/lib/gds_api/account_api.rb
+++ b/lib/gds_api/account_api.rb
@@ -1,0 +1,44 @@
+require_relative "base"
+require_relative "exceptions"
+
+# Adapter for the Account API
+#
+# @see https://github.com/alphagov/account-api
+# @api documented
+class GdsApi::AccountApi < GdsApi::Base
+  # Get an OAuth sign-in URL to redirect the user to
+  #
+  # @param [String, nil] redirect_path path on GOV.UK to send the user to after authentication
+  # @param [String, nil] state_id identifier originally returned by #create_registration_state
+  #
+  # @return [Hash] An authentication URL and the OAuth state parameter (for CSRF protection)
+  def get_sign_in_url(redirect_path: nil, state_id: nil)
+    querystring = nested_query_string({ redirect_path: redirect_path, state_id: state_id }.compact)
+    get_json("#{endpoint}/api/oauth2/sign-in?#{querystring}")
+  end
+
+  # Validate an OAuth authentication response
+  #
+  # @param [String] code The OAuth code parameter, from the auth server.
+  # @param [String] state The OAuth state parameter, from the auth server.
+  #
+  # @return [Hash] The value for the govuk_account_session header, the path to redirect the user to, and the GA client ID (if there is one)
+  def validate_auth_response(code:, state:)
+    post_json("#{endpoint}/api/oauth2/callback", code: code, state: state)
+  end
+
+  # Register some initial state, to pass to get_sign_in_url, which is used to initialise the account if the user signs up
+  #
+  # @param [Hash, nil] attributes Initial attributes to store
+  #
+  # @return [Hash] The state ID to pass to get_sign_in_url
+  def create_registration_state(attributes:)
+    post_json("#{endpoint}/api/oauth2/state", attributes: attributes)
+  end
+
+private
+
+  def nested_query_string(params)
+    Rack::Utils.build_nested_query(params)
+  end
+end

--- a/lib/gds_api/test_helpers/account_api.rb
+++ b/lib/gds_api/test_helpers/account_api.rb
@@ -1,0 +1,42 @@
+require "json"
+
+module GdsApi
+  module TestHelpers
+    module AccountApi
+      ACCOUNT_API_ENDPOINT = Plek.find("account-api")
+
+      def stub_account_api_get_sign_in_url(redirect_path: nil, state_id: nil, auth_uri: "http://auth/provider", state: "state")
+        querystring = Rack::Utils.build_nested_query({ redirect_path: redirect_path, state_id: state_id }.compact)
+        stub_request(:get, "#{ACCOUNT_API_ENDPOINT}/api/oauth2/sign-in?#{querystring}")
+          .to_return(
+            status: 200,
+            body: { auth_uri: auth_uri, state: state }.to_json,
+          )
+      end
+
+      def stub_account_api_validates_auth_response(code: nil, state: nil, govuk_account_session: "govuk-account-session", redirect_path: "/", ga_client_id: "ga-client-id")
+        stub_request(:post, "#{ACCOUNT_API_ENDPOINT}/api/oauth2/callback")
+          .with(body: hash_including({ code: code, state: state }.compact))
+          .to_return(
+            status: 200,
+            body: { govuk_account_session: govuk_account_session, redirect_path: redirect_path, ga_client_id: ga_client_id }.to_json,
+          )
+      end
+
+      def stub_account_api_rejects_auth_response(code: nil, state: nil)
+        stub_request(:post, "#{ACCOUNT_API_ENDPOINT}/api/oauth2/callback")
+          .with(body: hash_including({ code: code, state: state }.compact))
+          .to_return(status: 401)
+      end
+
+      def stub_account_api_create_registration_state(attributes: nil, state_id: "state-id")
+        stub_request(:post, "#{ACCOUNT_API_ENDPOINT}/api/oauth2/state")
+          .with(body: hash_including({ attributes: attributes }.compact))
+          .to_return(
+            status: 200,
+            body: { state_id: state_id }.to_json,
+          )
+      end
+    end
+  end
+end

--- a/test/account_api_test.rb
+++ b/test/account_api_test.rb
@@ -1,0 +1,33 @@
+require "test_helper"
+require "gds_api/account_api"
+require "gds_api/test_helpers/account_api"
+
+describe GdsApi::AccountApi do
+  include GdsApi::TestHelpers::AccountApi
+
+  let(:base_url)      { Plek.find("account-api") }
+  let(:api_client)    { GdsApi::AccountApi.new(base_url) }
+
+  it "gets a sign in URL" do
+    stub_account_api_get_sign_in_url(auth_uri: "https://www.example.com")
+    assert_equal("https://www.example.com", api_client.get_sign_in_url.to_hash["auth_uri"])
+  end
+
+  it "gives a session ID if the auth response validates" do
+    stub_account_api_validates_auth_response(code: "foo", state: "bar")
+    assert(!api_client.validate_auth_response(code: "foo", state: "bar")["govuk_account_session"].nil?)
+  end
+
+  it "throws a 401 if the auth response does not validate" do
+    stub_account_api_rejects_auth_response(code: "foo", state: "bar")
+
+    assert_raises GdsApi::HTTPUnauthorized do
+      api_client.validate_auth_response(code: "foo", state: "bar")
+    end
+  end
+
+  it "gets a state ID" do
+    stub_account_api_create_registration_state(attributes: { foo: "bar" }, state_id: "state-id")
+    assert_equal("state-id", api_client.create_registration_state(attributes: { foo: "bar" }).to_hash["state_id"])
+  end
+end


### PR DESCRIPTION
See https://github.com/alphagov/account-api/pull/3

---

[Trello card](https://trello.com/c/Y8z5rsJl/653-move-oauth-sign-in-logic-from-the-transition-checker-to-the-new-app)