### PR TITLE
Add account-api transition checker email endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * BREAKING: Minimum ruby version supported is updated to 2.6
 * BREAKING: `content_store_endpoint` helper now accepts a keyword argument instead of a boolean
-* Add new account-api adapter with auth endpoints
+* Add new account-api adapter with auth and transition checker email subscription endpoints
 
 # 69.3.0
 

--- a/lib/gds_api/test_helpers/account_api.rb
+++ b/lib/gds_api/test_helpers/account_api.rb
@@ -37,6 +37,40 @@ module GdsApi
             body: { state_id: state_id }.to_json,
           )
       end
+
+      def stub_account_api_has_email_subscription(govuk_account_session: nil, new_govuk_account_session: nil)
+        if govuk_account_session
+          stub_request(:get, "#{ACCOUNT_API_ENDPOINT}/api/transition-checker-email-subscription")
+            .with(headers: { GdsApi::AccountApi::AUTH_HEADER_NAME => govuk_account_session })
+            .to_return(status: 200, body: { govuk_account_session: new_govuk_account_session, has_subscription: true }.compact.to_json)
+        else
+          stub_request(:get, "#{ACCOUNT_API_ENDPOINT}/api/transition-checker-email-subscription")
+            .to_return(status: 200, body: { govuk_account_session: new_govuk_account_session, has_subscription: true }.compact.to_json)
+        end
+      end
+
+      def stub_account_api_does_not_have_email_subscription(govuk_account_session: nil, new_govuk_account_session: nil)
+        if govuk_account_session
+          stub_request(:get, "#{ACCOUNT_API_ENDPOINT}/api/transition-checker-email-subscription")
+            .with(headers: { GdsApi::AccountApi::AUTH_HEADER_NAME => govuk_account_session })
+            .to_return(status: 200, body: { govuk_account_session: new_govuk_account_session, has_subscription: false }.compact.to_json)
+        else
+          stub_request(:get, "#{ACCOUNT_API_ENDPOINT}/api/transition-checker-email-subscription")
+            .to_return(status: 200, body: { govuk_account_session: new_govuk_account_session, has_subscription: false }.compact.to_json)
+        end
+      end
+
+      def stub_account_api_set_email_subscription(govuk_account_session: nil, slug: "slug", new_govuk_account_session: nil)
+        if govuk_account_session
+          stub_request(:post, "#{ACCOUNT_API_ENDPOINT}/api/transition-checker-email-subscription")
+            .with(body: hash_including({ slug: slug }.compact), headers: { GdsApi::AccountApi::AUTH_HEADER_NAME => govuk_account_session })
+            .to_return(status: 200, body: { govuk_account_session: new_govuk_account_session }.compact.to_json)
+        else
+          stub_request(:post, "#{ACCOUNT_API_ENDPOINT}/api/transition-checker-email-subscription")
+            .with(body: hash_including({ slug: slug }.compact))
+            .to_return(status: 200, body: { govuk_account_session: new_govuk_account_session }.compact.to_json)
+        end
+      end
     end
   end
 end

--- a/test/account_api_test.rb
+++ b/test/account_api_test.rb
@@ -30,4 +30,33 @@ describe GdsApi::AccountApi do
     stub_account_api_create_registration_state(attributes: { foo: "bar" }, state_id: "state-id")
     assert_equal("state-id", api_client.create_registration_state(attributes: { foo: "bar" }).to_hash["state_id"])
   end
+
+  describe "a transition checker subscription exists" do
+    before { stub_account_api_has_email_subscription(new_govuk_account_session: "new-session") }
+
+    it "checks if the user has an email subscription" do
+      assert(api_client.check_for_email_subscription(govuk_account_session: "foo")["has_subscription"])
+    end
+
+    it "returns the new session value" do
+      assert_equal("new-session", api_client.check_for_email_subscription(govuk_account_session: "foo")["govuk_account_session"])
+    end
+  end
+
+  describe "a transition checker subscription does not exist" do
+    before { stub_account_api_does_not_have_email_subscription(new_govuk_account_session: "new-session") }
+
+    it "checks if the user has an email subscription" do
+      assert(api_client.check_for_email_subscription(govuk_account_session: "foo")["has_subscription"] == false)
+    end
+
+    it "returns the new session value" do
+      assert_equal("new-session", api_client.check_for_email_subscription(govuk_account_session: "foo")["govuk_account_session"])
+    end
+  end
+
+  it "returns a new session when setting the email subscription" do
+    stub_account_api_set_email_subscription(new_govuk_account_session: "new-session")
+    assert_equal("new-session", api_client.set_email_subscription(govuk_account_session: "foo", slug: "slug").to_hash["govuk_account_session"])
+  end
 end


### PR DESCRIPTION
See https://github.com/alphagov/account-api/pull/5

---

[Trello card](https://trello.com/c/N49KKdOW/666-move-transition-checker-email-management-from-finder-frontend-to-the-new-app)