### PR TITLE
Add account-api attribute endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * BREAKING: Minimum ruby version supported is updated to 2.6
 * BREAKING: `content_store_endpoint` helper now accepts a keyword argument instead of a boolean
-* Add new account-api adapter with auth and transition checker email subscription endpoints
+* Add new account-api adapter with auth, transition checker email subscription, and attribute endpoints
 
 # 69.3.0
 

--- a/lib/gds_api/account_api.rb
+++ b/lib/gds_api/account_api.rb
@@ -57,6 +57,27 @@ class GdsApi::AccountApi < GdsApi::Base
     post_json("#{endpoint}/api/transition-checker-email-subscription", { slug: slug }, auth_headers(govuk_account_session))
   end
 
+  # Look up the values of a user's attributes
+  #
+  # @param [String] attributes Names of the attributes to check
+  # @param [String] govuk_account_session Value of the session header
+  #
+  # @return [Hash] The attribute values (if present), and a new session header
+  def get_attributes(attributes:, govuk_account_session:)
+    querystring = nested_query_string({ attributes: attributes }.compact)
+    get_json("#{endpoint}/api/attributes?#{querystring}", auth_headers(govuk_account_session))
+  end
+
+  # Create or update attributes for a user
+  #
+  # @param [String] attributes Hash of new attribute values
+  # @param [String] govuk_account_session Value of the session header
+  #
+  # @return [Hash] A new session header
+  def set_attributes(attributes:, govuk_account_session:)
+    patch_json("#{endpoint}/api/attributes", { attributes: attributes.transform_values(&:to_json) }, auth_headers(govuk_account_session))
+  end
+
 private
 
   def nested_query_string(params)

--- a/lib/gds_api/test_helpers/account_api.rb
+++ b/lib/gds_api/test_helpers/account_api.rb
@@ -71,6 +71,30 @@ module GdsApi
             .to_return(status: 200, body: { govuk_account_session: new_govuk_account_session }.compact.to_json)
         end
       end
+
+      def stub_account_api_has_attributes(govuk_account_session: nil, attributes: [], values: {}, new_govuk_account_session: nil)
+        querystring = Rack::Utils.build_nested_query({ attributes: attributes }.compact)
+        if govuk_account_session
+          stub_request(:get, "#{ACCOUNT_API_ENDPOINT}/api/attributes?#{querystring}")
+            .with(headers: { GdsApi::AccountApi::AUTH_HEADER_NAME => govuk_account_session })
+            .to_return(status: 200, body: { govuk_account_session: new_govuk_account_session, values: values }.compact.to_json)
+        else
+          stub_request(:get, "#{ACCOUNT_API_ENDPOINT}/api/attributes?#{querystring}")
+            .to_return(status: 200, body: { govuk_account_session: new_govuk_account_session, values: values }.compact.to_json)
+        end
+      end
+
+      def stub_account_api_set_attributes(govuk_account_session: nil, attributes: nil, new_govuk_account_session: nil)
+        if govuk_account_session
+          stub_request(:patch, "#{ACCOUNT_API_ENDPOINT}/api/attributes")
+            .with(body: hash_including({ attributes: attributes&.transform_values(&:to_json) }.compact), headers: { GdsApi::AccountApi::AUTH_HEADER_NAME => govuk_account_session })
+            .to_return(status: 200, body: { govuk_account_session: new_govuk_account_session }.compact.to_json)
+        else
+          stub_request(:patch, "#{ACCOUNT_API_ENDPOINT}/api/attributes")
+            .with(body: hash_including({ attributes: attributes&.transform_values(&:to_json) }.compact))
+            .to_return(status: 200, body: { govuk_account_session: new_govuk_account_session }.compact.to_json)
+        end
+      end
     end
   end
 end

--- a/test/account_api_test.rb
+++ b/test/account_api_test.rb
@@ -59,4 +59,23 @@ describe GdsApi::AccountApi do
     stub_account_api_set_email_subscription(new_govuk_account_session: "new-session")
     assert_equal("new-session", api_client.set_email_subscription(govuk_account_session: "foo", slug: "slug").to_hash["govuk_account_session"])
   end
+
+  describe "attributes exist" do
+    before { stub_account_api_has_attributes(attributes: attributes.keys, values: attributes, new_govuk_account_session: "new-session") }
+
+    let(:attributes) { { "foo" => { "bar" => %w[baz] } } }
+
+    it "returns the attribute values" do
+      assert(api_client.get_attributes(attributes: attributes.keys, govuk_account_session: "foo")["values"] == attributes)
+    end
+
+    it "returns the new session value" do
+      assert_equal("new-session", api_client.get_attributes(attributes: attributes.keys, govuk_account_session: "foo")["govuk_account_session"])
+    end
+  end
+
+  it "returns a new session when setting attributes" do
+    stub_account_api_set_attributes(attributes: { foo: %w[bar] }, new_govuk_account_session: "new-session")
+    assert_equal("new-session", api_client.set_attributes(govuk_account_session: "foo", attributes: { foo: %w[bar] }).to_hash["govuk_account_session"])
+  end
 end


### PR DESCRIPTION
See https://github.com/alphagov/account-api/pull/8

---

[Trello card](https://trello.com/c/uRMyiEHZ/654-move-oauth-attribute-logic-from-the-transition-checker-to-the-new-app)