### PR TITLE
Configure Jenkins to run Pact tests with account-api

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,6 +24,11 @@ node("postgresql-9.6") {
         name: 'FRONTEND_BRANCH',
         defaultValue: 'master',
         description: 'Branch of frontend to run pacts against'
+      ),
+      stringParam(
+        name: 'ACCOUNT_API_BRANCH',
+        defaultValue: 'main',
+        description: 'Branch of account-api to run pacts against'
       )
     ],
     afterTest: {
@@ -39,6 +44,7 @@ node("postgresql-9.6") {
         runPublishingApiPactTests(govuk)
         runCollectionsPactTests(govuk)
         runFrontendPactTests(govuk)
+        runAccountApiPactTests(govuk)
       }
     }
   )
@@ -78,6 +84,17 @@ def runFrontendPactTests(govuk){
     stage("Run frontend pact") {
       govuk.bundleApp()
       lock("frontend-$NODE_NAME-test") {
+        govuk.runRakeTask("pact:verify:branch[${env.BRANCH_NAME}]")
+      }
+    }
+  }
+}
+
+def runAccountApiPactTests(govuk){
+  govuk.checkoutDependent("account-api", [ branch: ACCOUNT_API_BRANCH ]) {
+    stage("Run account-api pact") {
+      govuk.bundleApp()
+      lock("account-api-$NODE_NAME-test") {
         govuk.runRakeTask("pact:verify:branch[${env.BRANCH_NAME}]")
       }
     }


### PR DESCRIPTION
This is step 6 of the [Writing Pact tests](https://docs.publishing.service.gov.uk/manual/pact-broker.html#writing-pact-tests) docs.

---

[Trello card](https://trello.com/c/OcRffYwv/674-set-up-pact-tests-for-our-account-api-app)