### PR TITLE
Remove explicit JSON encoding of account-api attribute values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * BREAKING: Removed support for the Performance Platform.
 * Add Pact tests for account-api
+* Remove explicit JSON encoding of attribute values now that account-api parses non-string values correctly
 
 # 70.0.0
 

--- a/lib/gds_api/account_api.rb
+++ b/lib/gds_api/account_api.rb
@@ -75,7 +75,7 @@ class GdsApi::AccountApi < GdsApi::Base
   #
   # @return [Hash] A new session header
   def set_attributes(attributes:, govuk_account_session:)
-    patch_json("#{endpoint}/api/attributes", { attributes: attributes.transform_values(&:to_json) }, auth_headers(govuk_account_session))
+    patch_json("#{endpoint}/api/attributes", { attributes: attributes }, auth_headers(govuk_account_session))
   end
 
 private

--- a/lib/gds_api/test_helpers/account_api.rb
+++ b/lib/gds_api/test_helpers/account_api.rb
@@ -87,11 +87,11 @@ module GdsApi
       def stub_account_api_set_attributes(govuk_account_session: nil, attributes: nil, new_govuk_account_session: nil)
         if govuk_account_session
           stub_request(:patch, "#{ACCOUNT_API_ENDPOINT}/api/attributes")
-            .with(body: hash_including({ attributes: attributes&.transform_values(&:to_json) }.compact), headers: { GdsApi::AccountApi::AUTH_HEADER_NAME => govuk_account_session })
+            .with(body: hash_including({ attributes: attributes }.compact), headers: { GdsApi::AccountApi::AUTH_HEADER_NAME => govuk_account_session })
             .to_return(status: 200, body: { govuk_account_session: new_govuk_account_session }.compact.to_json)
         else
           stub_request(:patch, "#{ACCOUNT_API_ENDPOINT}/api/attributes")
-            .with(body: hash_including({ attributes: attributes&.transform_values(&:to_json) }.compact))
+            .with(body: hash_including({ attributes: attributes }.compact))
             .to_return(status: 200, body: { govuk_account_session: new_govuk_account_session }.compact.to_json)
         end
       end

--- a/test/account_api_test.rb
+++ b/test/account_api_test.rb
@@ -256,7 +256,7 @@ describe GdsApi::AccountApi do
           .with(
             method: :patch,
             path: "/api/attributes",
-            body: { attributes: attributes.transform_values(&:to_json) },
+            body: { attributes: attributes },
             headers: GdsApi::JsonClient.default_request_with_json_body_headers.merge(authenticated_headers),
           )
           .will_respond_with(


### PR DESCRIPTION
account-api previously required attribute values to be given as
strings of JSON, rather than just as part of a regular JSON PATCH
request.  So in practice rather than sending data like

    {
      "attributes": {
        "foo": {
          "bar": ["baz", "bat", "qux"]
        }
      }
    }

We would instead send

    {
      "attributes": {
        "foo": "{\"bar\": [\"baz\", \"bat\", \"qux\"]}"
      }
    }

The need for this has been removed:
https://github.com/alphagov/account-api/pull/17

So now gds-api-adapters can remove the extra encoding step.  When this
change has gone out, the compatibility code which makes both encodings
work can be removed from account-api, switching us fully over to the
new encoding.

---

[Trello card](https://trello.com/c/E5J5kzNP/679-remove-the-redundant-json-encoding-of-attribute-values-in-account-api)