### PR TITLE
Move Pact host ports information to GovukTest

### DIFF
--- a/gds-api-adapters.gemspec
+++ b/gds-api-adapters.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
   s.files        = Dir.glob("lib/**/*") + Dir.glob("test/fixtures/**/*") + %w[README.md Rakefile]
   s.require_path = "lib"
   s.add_dependency "addressable"
+  s.add_dependency "govuk_test"
   s.add_dependency "link_header"
   s.add_dependency "null_logger"
   s.add_dependency "plek", ">= 1.9.0"

--- a/test/account_api_test.rb
+++ b/test/account_api_test.rb
@@ -4,7 +4,7 @@ require "gds_api/account_api"
 describe GdsApi::AccountApi do
   include PactTest
 
-  let(:api_client) { GdsApi::AccountApi.new(account_api_host) }
+  let(:api_client) { GdsApi::AccountApi.new(GdsTest::Pact.host(:account_api)) }
 
   let(:authenticated_headers) { { "GOVUK-Account-Session" => govuk_account_session } }
   let(:govuk_account_session) { "logged-in-user-session" }

--- a/test/calendars_test.rb
+++ b/test/calendars_test.rb
@@ -11,7 +11,7 @@ describe GdsApi::Calendars do
   end
 
   def api_client
-    @api_client ||= GdsApi::Calendars.new(bank_holidays_api_host)
+    @api_client ||= GdsApi::Calendars.new(GdsTest::Pact.host(:bank_holidays_api))
   end
 
   def event

--- a/test/organisations_api_test.rb
+++ b/test/organisations_api_test.rb
@@ -11,7 +11,7 @@ describe GdsApi::Organisations do
   end
 
   def api_client
-    @api_client ||= GdsApi::Organisations.new(organisation_api_host)
+    @api_client ||= GdsApi::Organisations.new(GdsTest::Pact.host(:organisation_api))
   end
 
   def organisation(slug: "test-department")
@@ -62,7 +62,7 @@ describe GdsApi::Organisations do
   end
 
   describe "fetching a paginated list of organisations" do
-    let(:api_client_endpoint) { "#{organisation_api_host}/api/organisations" }
+    let(:api_client_endpoint) { "#{GdsTest::Pact.host(:organisation_api)}/api/organisations" }
     let(:page_one_links) { %(<#{api_client_endpoint}?page=2>; rel="next", <#{api_client_endpoint}?page=1>; rel="self") }
     let(:page_two_links) { %(<#{api_client_endpoint}?page=1>; rel="previous", <#{api_client_endpoint}?page=2>; rel="self") }
 

--- a/test/test_helpers/pact_helper.rb
+++ b/test/test_helpers/pact_helper.rb
@@ -1,28 +1,7 @@
-PUBLISHING_API_PORT = 3001
-ORGANISATION_API_PORT = 3002
-BANK_HOLIDAYS_API_PORT = 3003
-ACCOUNT_API_PORT = 3004
-
-def publishing_api_host
-  "http://localhost:#{PUBLISHING_API_PORT}"
-end
-
-def organisation_api_host
-  "http://localhost:#{ORGANISATION_API_PORT}"
-end
-
-def bank_holidays_api_host
-  "http://localhost:#{BANK_HOLIDAYS_API_PORT}"
-end
-
-def account_api_host
-  "http://localhost:#{ACCOUNT_API_PORT}"
-end
-
 Pact.service_consumer "GDS API Adapters" do
   has_pact_with "Publishing API" do
     mock_service :publishing_api do
-      port PUBLISHING_API_PORT
+      port PUBLISHING_API_PORT GdsTest::Pact.host_port(:publishing_api)
     end
   end
 end
@@ -30,7 +9,7 @@ end
 Pact.service_consumer "GDS API Adapters" do
   has_pact_with "Collections Organisation API" do
     mock_service :organisation_api do
-      port ORGANISATION_API_PORT
+      port GdsTest::Pact.host_port(:organisation_api)
     end
   end
 end
@@ -38,7 +17,7 @@ end
 Pact.service_consumer "GDS API Adapters" do
   has_pact_with "Bank Holidays API" do
     mock_service :bank_holidays_api do
-      port BANK_HOLIDAYS_API_PORT
+      port GdsTest::Pact.host_port(:bank_holidays_api)
     end
   end
 end
@@ -46,7 +25,7 @@ end
 Pact.service_consumer "GDS API Adapters" do
   has_pact_with "Account API" do
     mock_service :account_api do
-      port ACCOUNT_API_PORT
+      port GdsTest::Pact.host_port(:account_api)
     end
   end
 end


### PR DESCRIPTION
We've moved the host information to GovukTest in https://github.com/alphagov/govuk_test/pull/39. This PR won't pass until that PR is merged (and may need a couple of tweaks) but should give an idea of where this work is heading.

This should mean we only have to update such information in one place.

Trello: https://trello.com/c/rnfUFP5o/2453-experiment-with-common-configuration-for-pact-tests-timebox-2-days