### PR TITLE
Set `PACT_CONSUMER_VERSION` ENV before running Pact tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,7 +41,7 @@ node("postgresql-9.6") {
         ]
       ]) {
         publishPacts(govuk, env.BRANCH_NAME == 'master')
-        govuk.setEnvar("GDS_API_ADAPTERS_PACT_VERSION", "branch-${env.BRANCH_NAME}")
+        govuk.setEnvar("PACT_CONSUMER_VERSION", "branch-${env.BRANCH_NAME}")
         runPublishingApiPactTests(govuk)
         runCollectionsPactTests(govuk)
         runFrontendPactTests(govuk)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,6 +7,7 @@ node("postgresql-9.6") {
   def pact_branch = (env.BRANCH_NAME == 'master' ? 'master' : "branch-${env.BRANCH_NAME}")
   govuk.setEnvar("PACT_TARGET_BRANCH", pact_branch)
   govuk.setEnvar("PACT_BROKER_BASE_URL", "https://pact-broker.cloudapps.digital")
+  govuk.setEnvar("PACT_CONSUMER_VERSION", "branch-${env.BRANCH_NAME}")
 
   govuk.buildProject(
     extraParameters: [
@@ -41,7 +42,6 @@ node("postgresql-9.6") {
         ]
       ]) {
         publishPacts(govuk, env.BRANCH_NAME == 'master')
-        govuk.setEnvar("PACT_CONSUMER_VERSION", "branch-${env.BRANCH_NAME}")
         runPublishingApiPactTests(govuk)
         runCollectionsPactTests(govuk)
         runFrontendPactTests(govuk)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -63,7 +63,7 @@ def runPublishingApiPactTests(govuk) {
       govuk.bundleApp()
       lock("publishing-api-$NODE_NAME-test") {
         govuk.runRakeTask("db:reset")
-        govuk.runRakeTask("pact:verify:branch[${env.BRANCH_NAME}]")
+        govuk.runRakeTask("pact:verify")
       }
     }
   }
@@ -74,7 +74,7 @@ def runCollectionsPactTests(govuk){
     stage("Run collections pact") {
       govuk.bundleApp()
       lock("collections-$NODE_NAME-test") {
-        govuk.runRakeTask("pact:verify:branch[${env.BRANCH_NAME}]")
+        govuk.runRakeTask("pact:verify")
       }
     }
   }
@@ -96,7 +96,7 @@ def runAccountApiPactTests(govuk){
     stage("Run account-api pact") {
       govuk.bundleApp()
       lock("account-api-$NODE_NAME-test") {
-        govuk.runRakeTask("pact:verify:branch[${env.BRANCH_NAME}]")
+        govuk.runRakeTask("pact:verify")
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,6 +41,7 @@ node("postgresql-9.6") {
         ]
       ]) {
         publishPacts(govuk, env.BRANCH_NAME == 'master')
+        govuk.setEnvar("GDS_API_ADAPTERS_PACT_VERSION", "branch-${env.BRANCH_NAME}")
         runPublishingApiPactTests(govuk)
         runCollectionsPactTests(govuk)
         runFrontendPactTests(govuk)
@@ -84,7 +85,7 @@ def runFrontendPactTests(govuk){
     stage("Run frontend pact") {
       govuk.bundleApp()
       lock("frontend-$NODE_NAME-test") {
-        govuk.runRakeTask("pact:verify:branch[${env.BRANCH_NAME}]")
+        govuk.runRakeTask("pact:verify")
       }
     }
   }

--- a/test/organisations_api_test.rb
+++ b/test/organisations_api_test.rb
@@ -62,9 +62,20 @@ describe GdsApi::Organisations do
   end
 
   describe "fetching a paginated list of organisations" do
+    let(:host_agnostic_endpoint_regex) { %r{https?://(?:[^/]+)/api/organisations} }
     let(:api_client_endpoint) { "#{organisation_api_host}/api/organisations" }
-    let(:page_one_links) { %(<#{api_client_endpoint}?page=2>; rel="next", <#{api_client_endpoint}?page=1>; rel="self") }
-    let(:page_two_links) { %(<#{api_client_endpoint}?page=1>; rel="previous", <#{api_client_endpoint}?page=2>; rel="self") }
+    let(:page_one_links) do
+      Pact.term(
+        generate: %(<#{api_client_endpoint}?page=2>; rel="next", <#{api_client_endpoint}?page=1>; rel="self"),
+        matcher: /^<#{host_agnostic_endpoint_regex}\?page=2>; rel="next", <#{host_agnostic_endpoint_regex}\?page=1>; rel="self"$/,
+      )
+    end
+    let(:page_two_links) do
+      Pact.term(
+        generate: %(<#{api_client_endpoint}?page=1>; rel="previous", <#{api_client_endpoint}?page=2>; rel="self"),
+        matcher: /^<#{host_agnostic_endpoint_regex}\?page=1>; rel="previous", <#{host_agnostic_endpoint_regex}\?page=2>; rel="self"$/,
+      )
+    end
 
     let(:request) do
       {


### PR DESCRIPTION
This PR is necessary to remove the unneeded `pact:verify:branch` Rake tasks from the Pact provider apps, as per below:

- https://github.com/alphagov/frontend/pull/2712
- https://github.com/alphagov/account-api/pull/40
- https://github.com/alphagov/collections/pull/2355
- https://github.com/alphagov/publishing-api/pull/1932

Here is a passing build that references all of the branches above: https://ci.integration.publishing.service.gov.uk/job/gds-api-adapters/job/simplify-pact-verify/8/console. Therefore we can be reasonably confident everything works nicely 🎉  

Once all of these are merged, the end result should be the same: Pact tests that are run on every PR for both provider/Consumer. This is just a simplified way of achieving that.

We're doing the same thing in the Publishing API / Content Store Pact tests: https://github.com/alphagov/publishing-api/pull/1934

Trello: https://trello.com/c/rnfUFP5o/2453-experiment-with-common-configuration-for-pact-tests-timebox-2-days