### PR TITLE
Remove references to resource monitors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Removed `LinkCheckerApi#upsert_resource_monitor` method as it’s not supported by Link Checker API itself.
+
 # 71.0.0
 
 * BREAKING: Removed support for the Performance Platform.

--- a/lib/gds_api/link_checker_api.rb
+++ b/lib/gds_api/link_checker_api.rb
@@ -89,37 +89,6 @@ class GdsApi::LinkCheckerApi < GdsApi::Base
     )
   end
 
-  # Update or create a set of links to be monitored for a resource.
-  #
-  # Makes a +POST+ request to the link checker api to create a resource monitor.
-  #
-  # @param links [Array] A list of URIs to monitor.
-  # @param reference [String] A unique id for the resource being monitored
-  # @param app [String] The name of the service the call originated e.g. 'whitehall'
-  # @return [MonitorReport] A +SimpleDelegator+ of the +GdsApi::Response+ which
-  #   responds to:
-  #     :id            the ID of the created resource monitor
-  #
-  # @raise [HTTPErrorResponse] if the request returns an error
-
-  def upsert_resource_monitor(links, app, reference)
-    payload = {
-      links: links,
-      app: app,
-      reference: reference,
-    }
-
-    response = post_json("#{endpoint}/monitor", payload)
-
-    MonitorReport.new(response.to_hash)
-  end
-
-  class MonitorReport < SimpleDelegator
-    def id
-      self["id"]
-    end
-  end
-
   class LinkReport < SimpleDelegator
     def uri
       self["uri"]

--- a/lib/gds_api/test_helpers/link_checker_api.rb
+++ b/lib/gds_api/test_helpers/link_checker_api.rb
@@ -72,23 +72,6 @@ module GdsApi
             headers: { "Content-Type" => "application/json" },
           )
       end
-
-      def stub_link_checker_api_upsert_resource_monitor(app:, reference:, links:)
-        response_body = { id: 1 }.to_json
-
-        request_body = {
-          links: links,
-          app: app,
-          reference: reference,
-        }.to_json
-
-        stub_request(:post, "#{LINK_CHECKER_API_ENDPOINT}/monitor")
-          .with(body: request_body)
-          .to_return(
-            body: response_body,
-            headers: { "Content-Type" => "application/json" },
-          )
-      end
     end
   end
 end

--- a/test/link_checker_api_test.rb
+++ b/test/link_checker_api_test.rb
@@ -41,22 +41,4 @@ describe GdsApi::LinkCheckerApi do
       assert_equal "http://example.com", batch_report.links[0].uri
     end
   end
-
-  describe "#upsert_resource_monitor" do
-    it "returns a useful response" do
-      stub_link_checker_api_upsert_resource_monitor(
-        reference: "Test:10",
-        app: "testing",
-        links: ["http://example.com"],
-      )
-
-      resource_monitor = @api.upsert_resource_monitor(
-        ["http://example.com"],
-        "testing",
-        "Test:10",
-      )
-
-      assert resource_monitor.key?("id")
-    end
-  end
 end


### PR DESCRIPTION
These were added to Link Checker API but we didn't end up using them, and they were eventually removed in https://github.com/alphagov/link-checker-api/pull/140 so we don't need API adapters for them anymore.