### PR TITLE
Change default collections branch to main

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@ node("postgresql-9.6") {
       ),
       stringParam(
         name: 'COLLECTIONS_BRANCH',
-        defaultValue: 'master',
+        defaultValue: 'main',
         description: 'Branch of collections to run pacts against'
       ),
       stringParam(


### PR DESCRIPTION
The default branch for Collections has been changed from `master` to `main` so we need to reflect that change here too.