### PR TITLE
Remove special case for master branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,7 +41,7 @@ node("postgresql-9.6") {
           passwordVariable: 'PACT_BROKER_PASSWORD'
         ]
       ]) {
-        publishPacts(govuk, env.BRANCH_NAME == 'master')
+        publishPacts(govuk)
         runPactTests(govuk, "publishing-api", PUBLISHING_API_BRANCH, [ resetDatabase: true ])
         runPactTests(govuk, "collections", COLLECTIONS_BRANCH)
         runPactTests(govuk, "frontend", FRONTEND_BRANCH)
@@ -51,7 +51,7 @@ node("postgresql-9.6") {
   )
 }
 
-def publishPacts(govuk, releasedVersion) {
+def publishPacts(govuk) {
   stage("Publish pacts") {
     govuk.runRakeTask("pact:publish:branch")
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,8 +4,7 @@ library("govuk")
 
 node("postgresql-9.6") {
 
-  def pact_branch = (env.BRANCH_NAME == 'master' ? 'master' : "branch-${env.BRANCH_NAME}")
-  govuk.setEnvar("PACT_TARGET_BRANCH", pact_branch)
+  govuk.setEnvar("PACT_TARGET_BRANCH", "branch-${env.BRANCH_NAME}")
   govuk.setEnvar("PACT_BROKER_BASE_URL", "https://pact-broker.cloudapps.digital")
   govuk.setEnvar("PACT_CONSUMER_VERSION", "branch-${env.BRANCH_NAME}")
 


### PR DESCRIPTION
This ensures that the `master` branch is published to the Pact broker as `branch-master` as with all the other branches for consistency. This also avoids us needing to have this sort of logic in our other apps.

I believe this will also fix an issue where the `master` branch of GDS API Adapters has been failing since #1049 but rather than re-introduce the logic, I'd prefer `master` to not be treated special. ([Example failing build](https://ci.integration.publishing.service.gov.uk/job/gds-api-adapters/job/master/407/console))

I notice this was originally introduced in d12aeb5 but I don't fully understand the reasoning.