### PR TITLE
Add Pact tests for Link Checker API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Removed `LinkCheckerApi#upsert_resource_monitor` method as it’s not supported by Link Checker API itself.
 * Add optional `level_of_authentication` parameter to Account API `get_sign_in_url`.
 * Store response body in new `http_body` field of HTTP exceptions
+* Added Pact tests for the `LinkCheckerApi` adapters.
 
 # 71.0.0
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,6 +29,11 @@ node("postgresql-9.6") {
         name: 'ACCOUNT_API_BRANCH',
         defaultValue: 'main',
         description: 'Branch of account-api to run pacts against'
+      ),
+      stringParam(
+        name: 'LINK_CHECKER_API_BRANCH',
+        defaultValue: 'main',
+        description: 'Branch of link-checker-api to run pacts against'
       )
     ],
     afterTest: {
@@ -45,6 +50,7 @@ node("postgresql-9.6") {
         runPactTests(govuk, "collections", COLLECTIONS_BRANCH)
         runPactTests(govuk, "frontend", FRONTEND_BRANCH)
         runPactTests(govuk, "account-api", ACCOUNT_API_BRANCH, [ resetDatabase: true ])
+        runPactTests(govuk, "link-checker-api", LINK_CHECKER_API_BRANCH, [ resetDatabase: true ])
       }
     }
   )

--- a/test/link_checker_api_test.rb
+++ b/test/link_checker_api_test.rb
@@ -4,6 +4,7 @@ require "gds_api/test_helpers/link_checker_api"
 
 describe GdsApi::LinkCheckerApi do
   include GdsApi::TestHelpers::LinkCheckerApi
+  include PactTest
 
   describe "test helpers" do
     let(:base_url) { Plek.find("link-checker-api") }
@@ -38,6 +39,102 @@ describe GdsApi::LinkCheckerApi do
 
         assert_equal :completed, batch_report.status
         assert_equal "http://example.com", batch_report.links[0].uri
+      end
+    end
+  end
+
+  describe "contract tests" do
+    let(:api_client) { GdsApi::LinkCheckerApi.new(link_checker_api_host) }
+
+    describe "#check" do
+      it "responds with the details of the checked link" do
+        link_checker_api
+          .upon_receiving("the request to check a URI")
+          .with(
+            method: :get,
+            path: "/check",
+            headers: GdsApi::JsonClient.default_request_headers,
+            query: { uri: "https://www.gov.uk" },
+          )
+          .will_respond_with(
+            status: 200,
+            body: {
+              uri: "https://www.gov.uk",
+              status: "pending",
+              checked: nil,
+              errors: [],
+              warnings: [],
+              problem_summary: nil,
+              suggested_fix: nil,
+            },
+            headers: {
+              "Content-Type" => "application/json; charset=utf-8",
+            },
+          )
+
+        api_client.check("https://www.gov.uk")
+      end
+    end
+
+    describe "#create_batch" do
+      it "responds with details of the created batch" do
+        link_checker_api
+          .upon_receiving("the request to create a batch")
+          .with(
+            method: :post,
+            path: "/batch",
+            headers: GdsApi::JsonClient.default_request_with_json_body_headers,
+            body: { uris: ["https://www.gov.uk"] },
+          )
+          .will_respond_with(
+            status: 202,
+            body: {
+              id: Pact.like(1),
+              status: "in_progress",
+              links: [
+                {
+                  uri: "https://www.gov.uk",
+                  status: "pending",
+                },
+              ],
+            },
+            headers: {
+              "Content-Type" => "application/json; charset=utf-8",
+            },
+          )
+
+        api_client.create_batch(["https://www.gov.uk"])
+      end
+    end
+
+    describe "#get_batch" do
+      it "responds with the details of the batch" do
+        link_checker_api
+          .given("a batch exists with id 99 and uris https://www.gov.uk")
+          .upon_receiving("the request to get a batch")
+          .with(
+            method: :get,
+            path: "/batch/99",
+            headers: GdsApi::JsonClient.default_request_headers,
+          )
+          .will_respond_with(
+            status: 200,
+            body: {
+              id: 99,
+              status: "in_progress",
+              links: [
+                {
+                  uri: "https://www.gov.uk",
+                  status: "pending",
+                },
+              ],
+            },
+            headers: {
+              "Content-Type" => "application/json; charset=utf-8",
+            },
+          )
+
+        api_client.get_batch(99)
       end
     end
   end

--- a/test/link_checker_api_test.rb
+++ b/test/link_checker_api_test.rb
@@ -5,40 +5,40 @@ require "gds_api/test_helpers/link_checker_api"
 describe GdsApi::LinkCheckerApi do
   include GdsApi::TestHelpers::LinkCheckerApi
 
-  before do
-    @base_api_url = Plek.find("link-checker-api")
-    @api = GdsApi::LinkCheckerApi.new(@base_api_url)
-  end
+  describe "test helpers" do
+    let(:base_url) { Plek.find("link-checker-api") }
+    let(:api_client) { GdsApi::LinkCheckerApi.new(base_url) }
 
-  describe "#check" do
-    it "returns a useful response" do
-      stub_link_checker_api_check(uri: "http://example.com", status: :broken)
+    describe "#check" do
+      it "returns a useful response" do
+        stub_link_checker_api_check(uri: "http://example.com", status: :broken)
 
-      link_report = @api.check("http://example.com")
+        link_report = api_client.check("http://example.com")
 
-      assert_equal :broken, link_report.status
+        assert_equal :broken, link_report.status
+      end
     end
-  end
 
-  describe "#create_batch" do
-    it "returns a useful response" do
-      stub_link_checker_api_create_batch(uris: ["http://example.com"])
+    describe "#create_batch" do
+      it "returns a useful response" do
+        stub_link_checker_api_create_batch(uris: ["http://example.com"])
 
-      batch_report = @api.create_batch(["http://example.com"])
+        batch_report = api_client.create_batch(["http://example.com"])
 
-      assert_equal :in_progress, batch_report.status
-      assert_equal "http://example.com", batch_report.links[0].uri
+        assert_equal :in_progress, batch_report.status
+        assert_equal "http://example.com", batch_report.links[0].uri
+      end
     end
-  end
 
-  describe "#get_batch" do
-    it "returns a useful response" do
-      stub_link_checker_api_get_batch(id: 10, links: [{ uri: "http://example.com" }])
+    describe "#get_batch" do
+      it "returns a useful response" do
+        stub_link_checker_api_get_batch(id: 10, links: [{ uri: "http://example.com" }])
 
-      batch_report = @api.get_batch(10)
+        batch_report = api_client.get_batch(10)
 
-      assert_equal :completed, batch_report.status
-      assert_equal "http://example.com", batch_report.links[0].uri
+        assert_equal :completed, batch_report.status
+        assert_equal "http://example.com", batch_report.links[0].uri
+      end
     end
   end
 end

--- a/test/test_helpers/pact_helper.rb
+++ b/test/test_helpers/pact_helper.rb
@@ -2,6 +2,7 @@ PUBLISHING_API_PORT = 3001
 ORGANISATION_API_PORT = 3002
 BANK_HOLIDAYS_API_PORT = 3003
 ACCOUNT_API_PORT = 3004
+LINK_CHECKER_API_PORT = 3005
 
 def publishing_api_host
   "http://localhost:#{PUBLISHING_API_PORT}"
@@ -17,6 +18,10 @@ end
 
 def account_api_host
   "http://localhost:#{ACCOUNT_API_PORT}"
+end
+
+def link_checker_api_host
+  "http://localhost:#{LINK_CHECKER_API_PORT}"
 end
 
 Pact.service_consumer "GDS API Adapters" do
@@ -41,6 +46,12 @@ Pact.service_consumer "GDS API Adapters" do
   has_pact_with "Account API" do
     mock_service :account_api do
       port ACCOUNT_API_PORT
+    end
+  end
+
+  has_pact_with "Link Checker API" do
+    mock_service :link_checker_api do
+      port LINK_CHECKER_API_PORT
     end
   end
 end


### PR DESCRIPTION
This adds Pact tests for the Link Checker API interface. See individual commits for more details.

[Trello Card](https://trello.com/c/nxdo2zYY/2495-run-group-session-introducing-pact-tests)