### PR TITLE
DRY up the Pact tests

### DIFF
--- a/test/account_api_test.rb
+++ b/test/account_api_test.rb
@@ -10,9 +10,7 @@ describe GdsApi::AccountApi do
   let(:govuk_account_session) { "logged-in-user-session" }
 
   describe "getting a sign-in URL" do
-    let(:redirect_path) { nil }
-
-    before do
+    it "responds with 200 OK, an authentication URI, and a state for CSRF protection" do
       account_api
         .upon_receiving("a sign-in request")
         .with(
@@ -28,18 +26,13 @@ describe GdsApi::AccountApi do
             state: Pact.like("value-to-use-for-csrf-prevention"),
           },
         )
-    end
 
-    it "responds with 200 OK, an authentication URI, and a state for CSRF protection" do
-      response = api_client.get_sign_in_url
-      assert response["auth_uri"].present?
-      assert response["state"].present?
-      assert_equal 200, response.code
+      api_client.get_sign_in_url
     end
   end
 
   describe "validating an OAuth response" do
-    before do
+    it "responds with 200 OK and a govuk_account_session" do
       account_api
         .given("there is a valid OAuth response")
         .upon_receiving("a validation request")
@@ -59,20 +52,15 @@ describe GdsApi::AccountApi do
             govuk_account_session: Pact.like("user-session-id"),
           },
         )
-    end
 
-    it "responds with 200 OK and a govuk_account_session" do
-      response = api_client.validate_auth_response(code: "code", state: "state")
-      assert response["govuk_account_session"].present?
-      assert response["redirect_path"].nil?
-      assert_equal 200, response.code
+      api_client.validate_auth_response(code: "code", state: "state")
     end
   end
 
   describe "validating an OAuth response with a redirect path" do
     let(:redirect_path) { "/some-arbitrary-path" }
 
-    before do
+    it "responds with a redirect_path" do
       account_api
         .given("there is a valid OAuth response, with the redirect path '/some-arbitrary-path'")
         .upon_receiving("a validation request")
@@ -93,18 +81,15 @@ describe GdsApi::AccountApi do
             redirect_path: Pact.like(redirect_path),
           },
         )
-    end
 
-    it "responds with a redirect_path" do
-      response = api_client.validate_auth_response(code: "code", state: "state")
-      assert_equal redirect_path, response["redirect_path"]
+      api_client.validate_auth_response(code: "code", state: "state")
     end
   end
 
   describe "creating a registration state" do
     let(:attributes) { { foo: "bar" } }
 
-    before do
+    it "responds with 200 OK and a state_id" do
       account_api
         .upon_receiving("a create-state request")
         .with(
@@ -120,12 +105,8 @@ describe GdsApi::AccountApi do
             state_id: Pact.like("reference-to-pass-to-get_sign_in_url"),
           },
         )
-    end
 
-    it "responds with 200 OK and a state_id" do
-      response = api_client.create_registration_state(attributes: attributes)
-      assert response["state_id"].present?
-      assert_equal 200, response.code
+      api_client.create_registration_state(attributes: attributes)
     end
   end
 
@@ -154,10 +135,7 @@ describe GdsApi::AccountApi do
       end
 
       it "responds with 200 OK, a new govuk_account_session, and says that the subscription does not exist" do
-        response = api_client.check_for_email_subscription(govuk_account_session: govuk_account_session)
-        assert response["govuk_account_session"].present?
-        assert_equal false, response["has_subscription"]
-        assert_equal 200, response.code
+        api_client.check_for_email_subscription(govuk_account_session: govuk_account_session)
       end
 
       describe "a subscription exists" do
@@ -165,8 +143,7 @@ describe GdsApi::AccountApi do
         let(:has_subscription) { true }
 
         it "says that the subscription exists" do
-          response = api_client.check_for_email_subscription(govuk_account_session: govuk_account_session)
-          assert response["has_subscription"]
+          api_client.check_for_email_subscription(govuk_account_session: govuk_account_session)
         end
       end
     end
@@ -174,7 +151,7 @@ describe GdsApi::AccountApi do
 
   describe "setting the transition checker email subscription" do
     describe "the user is logged in" do
-      before do
+      it "responds with 200 OK and a new govuk_account_session" do
         account_api
           .given("there is a valid user session")
           .upon_receiving("a set-subscription request")
@@ -191,12 +168,8 @@ describe GdsApi::AccountApi do
               govuk_account_session: Pact.like("user-session-id"),
             },
           )
-      end
 
-      it "responds with 200 OK and a new govuk_account_session" do
-        response = api_client.set_email_subscription(govuk_account_session: govuk_account_session, slug: "brexit-emails-123")
-        assert response["govuk_account_session"].present?
-        assert_equal 200, response.code
+        api_client.set_email_subscription(govuk_account_session: govuk_account_session, slug: "brexit-emails-123")
       end
     end
   end
@@ -227,10 +200,7 @@ describe GdsApi::AccountApi do
       end
 
       it "responds with 200 OK, a new govuk_account_session, and no attributes" do
-        response = api_client.get_attributes(govuk_account_session: govuk_account_session, attributes: %w[foo])
-        assert response["govuk_account_session"].present?
-        assert_equal attributes, response["values"]
-        assert_equal 200, response.code
+        api_client.get_attributes(govuk_account_session: govuk_account_session, attributes: %w[foo])
       end
 
       describe "attributes exist" do
@@ -238,8 +208,7 @@ describe GdsApi::AccountApi do
         let(:attributes) { { foo: { bar: "baz" } } }
 
         it "responds with the attribute values" do
-          response = api_client.get_attributes(govuk_account_session: govuk_account_session, attributes: %w[foo])
-          assert_equal attributes[:foo][:bar], response["values"]["foo"]["bar"]
+          api_client.get_attributes(govuk_account_session: govuk_account_session, attributes: %w[foo])
         end
       end
     end
@@ -249,7 +218,7 @@ describe GdsApi::AccountApi do
     let(:attributes) { { foo: [1, 2, 3], bar: { nested: "json" } } }
 
     describe "the user is logged in" do
-      before do
+      it "responds with 200 OK and a new govuk_account_session" do
         account_api
           .given("there is a valid user session")
           .upon_receiving("a set-attributes request")
@@ -266,12 +235,8 @@ describe GdsApi::AccountApi do
               govuk_account_session: Pact.like("user-session-id"),
             },
           )
-      end
 
-      it "responds with 200 OK and a new govuk_account_session" do
-        response = api_client.set_attributes(govuk_account_session: govuk_account_session, attributes: attributes)
-        assert response["govuk_account_session"].present?
-        assert_equal 200, response.code
+        api_client.set_attributes(govuk_account_session: govuk_account_session, attributes: attributes)
       end
     end
   end

--- a/test/calendars_test.rb
+++ b/test/calendars_test.rb
@@ -18,7 +18,7 @@ describe GdsApi::Calendars do
   end
 
   describe "fetching all bank holidays" do
-    before do
+    it "responds with 200 OK and a list of bank holidays for each nation" do
       bank_holidays_api
         .given("there is a list of all bank holidays")
         .upon_receiving("the request for the list of all bank holidays")
@@ -47,19 +47,13 @@ describe GdsApi::Calendars do
             "Content-Type" => "application/json; charset=utf-8",
           },
         )
-    end
 
-    it "responds with 200 OK and a list of bank holidays for each nation" do
-      response = api_client.bank_holidays
-      assert response["england-and-wales"]["events"].count.positive?
-      assert response["scotland"]["events"].count.positive?
-      assert response["northern-ireland"]["events"].count.positive?
-      assert_equal 200, response.code
+      api_client.bank_holidays
     end
   end
 
   describe "fetching only Scottish bank holidays" do
-    before do
+    it "responds with 200 OK and a list of bank holidays" do
       bank_holidays_api
         .given("there is a list of all bank holidays")
         .upon_receiving("the request for the list of Scottish bank holidays")
@@ -78,12 +72,8 @@ describe GdsApi::Calendars do
             "Content-Type" => "application/json; charset=utf-8",
           },
         )
-    end
 
-    it "responds with 200 OK and a list of bank holidays" do
-      response = api_client.bank_holidays("scotland")
-      assert response["events"].count.positive?
-      assert_equal 200, response.code
+      api_client.bank_holidays("scotland")
     end
   end
 end

--- a/test/organisations_api_test.rb
+++ b/test/organisations_api_test.rb
@@ -26,6 +26,9 @@ describe GdsApi::Organisations do
     }
   end
 
+  let(:host_agnostic_endpoint_regex) { %r{https?://(?:[^/]+)/api/organisations} }
+  let(:api_client_endpoint) { "#{organisation_api_host}/api/organisations" }
+
   it "fetches a list of organisations" do
     organisation_api
       .given("there is a list of organisations")
@@ -52,8 +55,6 @@ describe GdsApi::Organisations do
   end
 
   describe "fetching a paginated list of organisations" do
-    let(:host_agnostic_endpoint_regex) { %r{https?://(?:[^/]+)/api/organisations} }
-    let(:api_client_endpoint) { "#{organisation_api_host}/api/organisations" }
     let(:page_one_links) do
       Pact.term(
         generate: %(<#{api_client_endpoint}?page=2>; rel="next", <#{api_client_endpoint}?page=1>; rel="self"),
@@ -108,7 +109,10 @@ describe GdsApi::Organisations do
   it "fetches an organisation by slug" do
     hmrc = "hm-revenue-customs"
     api_response = organisation(slug: hmrc)
-    api_response["id"] = "www.gov.uk/api/organisations/#{hmrc}"
+    api_response["id"] = Pact.term(
+      generate: %(#{api_client_endpoint}/#{hmrc}),
+      matcher: /^#{host_agnostic_endpoint_regex}\/#{hmrc}$/,
+    )
 
     organisation_api
       .given("the organisation hmrc exists")

--- a/test/publishing_api/get_expanded_links_test.rb
+++ b/test/publishing_api/get_expanded_links_test.rb
@@ -30,17 +30,7 @@ describe GdsApi::PublishingApi do
           },
         )
 
-      response = @api_client.get_expanded_links(@content_id)
-
-      expected_body = {
-        "expanded_links" => {
-          "organisations" => [
-            { "content_id" => "20583132-1619-4c68-af24-77583172c070" },
-          ],
-        },
-      }
-      assert_equal 200, response.code
-      assert_equal expected_body, response.to_h
+      @api_client.get_expanded_links(@content_id)
     end
 
     it "responds with the empty thing set if there's an empty link set" do
@@ -59,10 +49,7 @@ describe GdsApi::PublishingApi do
           },
         )
 
-      response = @api_client.get_expanded_links(@content_id)
-
-      assert_equal 200, response.code
-      assert_equal({}, response.to_h["expanded_links"])
+      @api_client.get_expanded_links(@content_id)
     end
 
     it "responds with 404 if there's no link set entry" do

--- a/test/publishing_api/get_links_test.rb
+++ b/test/publishing_api/get_links_test.rb
@@ -5,84 +5,63 @@ require "json"
 describe GdsApi::PublishingApi do
   include PactTest
 
-  before do
-    @api_client = GdsApi::PublishingApi.new(publishing_api_host)
-    @content_id = "bed722e6-db68-43e5-9079-063f623335a7"
-  end
+  let(:api_client) { GdsApi::PublishingApi.new(publishing_api_host) }
+  let(:content_id) { "bed722e6-db68-43e5-9079-063f623335a7" }
 
   describe "#get_links" do
-    describe "when there's a links entry with links" do
-      before do
-        publishing_api
-          .given("organisation links exist for content_id #{@content_id}")
-          .upon_receiving("a get-links request")
-          .with(
-            method: :get,
-            path: "/v2/links/#{@content_id}",
-          )
-          .will_respond_with(
-            status: 200,
-            body: {
-              links: {
-                organisations: %w[20583132-1619-4c68-af24-77583172c070],
-              },
-            },
-          )
-      end
-
-      it "responds with the links" do
-        response = @api_client.get_links(@content_id)
-        assert_equal 200, response.code
-        assert_equal(
-          %w[20583132-1619-4c68-af24-77583172c070],
-          response["links"]["organisations"],
+    it "responds with links when there's a links entry with links" do
+      publishing_api
+        .given("organisation links exist for content_id #{content_id}")
+        .upon_receiving("a get-links request")
+        .with(
+          method: :get,
+          path: "/v2/links/#{content_id}",
         )
-      end
-    end
-
-    describe "when there's an empty links entry" do
-      before do
-        publishing_api
-          .given("empty links exist for content_id #{@content_id}")
-          .upon_receiving("a get-links request")
-          .with(
-            method: :get,
-            path: "/v2/links/#{@content_id}",
-          )
-          .will_respond_with(
-            status: 200,
-            body: {
-              links: {
-              },
+        .will_respond_with(
+          status: 200,
+          body: {
+            links: {
+              organisations: %w[20583132-1619-4c68-af24-77583172c070],
             },
-          )
-      end
+          },
+        )
 
-      it "responds with the empty link set" do
-        response = @api_client.get_links(@content_id)
-        assert_equal 200, response.code
-        assert_equal({}, response["links"])
-      end
+      api_client.get_links(content_id)
     end
 
-    describe "when there's no links entry" do
-      before do
-        publishing_api
-          .given("no links exist for content_id #{@content_id}")
-          .upon_receiving("a get-links request")
-          .with(
-            method: :get,
-            path: "/v2/links/#{@content_id}",
-          )
-          .will_respond_with(
-            status: 404,
-          )
-      end
+    it "responds with the empty link set when there's an empty links entry" do
+      publishing_api
+        .given("empty links exist for content_id #{content_id}")
+        .upon_receiving("a get-links request")
+        .with(
+          method: :get,
+          path: "/v2/links/#{content_id}",
+        )
+        .will_respond_with(
+          status: 200,
+          body: {
+            links: {
+            },
+          },
+        )
 
-      it "responds with 404" do
-        assert_raises(GdsApi::HTTPNotFound) do
-          @api_client.get_links(@content_id)
-        end
+      api_client.get_links(content_id)
+    end
+
+    it "responds with 404 when there's no links entry" do
+      publishing_api
+        .given("no links exist for content_id #{content_id}")
+        .upon_receiving("a get-links request")
+        .with(
+          method: :get,
+          path: "/v2/links/#{content_id}",
+        )
+        .will_respond_with(
+          status: 404,
+        )
+
+      assert_raises(GdsApi::HTTPNotFound) do
+        api_client.get_links(content_id)
       end
     end
   end

--- a/test/publishing_api/lookup_test.rb
+++ b/test/publishing_api/lookup_test.rb
@@ -58,9 +58,7 @@ describe GdsApi::PublishingApi do
           },
         )
 
-      content_id = @api_client.lookup_content_id(base_path: "/foo", with_drafts: true)
-
-      assert_equal "cbb460a7-60de-4a74-b5be-0b27c6d6af9b", content_id
+      @api_client.lookup_content_id(base_path: "/foo", with_drafts: true)
     end
   end
 
@@ -89,9 +87,7 @@ describe GdsApi::PublishingApi do
           body: reponse_hash,
         )
 
-      content_id = @api_client.lookup_content_ids(base_paths: ["/foo", "/bar"])
-
-      assert_equal(reponse_hash, content_id)
+      @api_client.lookup_content_ids(base_paths: ["/foo", "/bar"])
     end
   end
 end

--- a/test/publishing_api_test.rb
+++ b/test/publishing_api_test.rb
@@ -41,13 +41,110 @@ describe GdsApi::PublishingApi do
   end
 
   describe "#put_content" do
-    describe "if the entry is valid" do
-      before do
-        @content_item = content_item_for_content_id(@content_id)
+    it "responds with 200 OK if the entry is valid" do
+      @content_item = content_item_for_content_id(@content_id)
+
+      publishing_api
+        .given("no content exists")
+        .upon_receiving("a request to create a content item without links")
+        .with(
+          method: :put,
+          path: "/v2/content/#{@content_id}",
+          body: @content_item,
+          headers: GdsApi::JsonClient.default_request_with_json_body_headers.merge(
+            "Authorization" => "Bearer #{@bearer_token}",
+          ),
+        )
+        .will_respond_with(
+          status: 200,
+        )
+
+      @api_client.put_content(@content_id, @content_item)
+    end
+
+    it "responds with 422 Unprocessable Entity if the path is reserved by a different app" do
+      @content_item = content_item_for_content_id(@content_id, "base_path" => "/test-item", "publishing_app" => "whitehall")
+
+      publishing_api
+        .given("/test-item has been reserved by the Publisher application")
+        .upon_receiving("a request from the Whitehall application to create a content item at /test-item")
+        .with(
+          method: :put,
+          path: "/v2/content/#{@content_id}",
+          body: @content_item,
+          headers: GdsApi::JsonClient.default_request_with_json_body_headers.merge(
+            "Authorization" => "Bearer #{@bearer_token}",
+          ),
+        )
+        .will_respond_with(
+          status: 422,
+          body: {
+            "error" => {
+              "code" => 422,
+              "message" => Pact.term(generate: "Conflict", matcher: /\S+/),
+              "fields" => {
+                "base_path" => Pact.each_like("is already in use by the 'publisher' app", min: 1),
+              },
+            },
+          },
+          headers: {
+            "Content-Type" => "application/json; charset=utf-8",
+          },
+        )
+
+      assert_raises(GdsApi::HTTPUnprocessableEntity) do
+        @api_client.put_content(@content_id, @content_item)
+      end
+    end
+
+    it "responds with 422 Unprocessable Entity when given an invalid item" do
+      @content_item = content_item_for_content_id(@content_id, "base_path" => "not a url path")
+
+      publishing_api
+        .given("no content exists")
+        .upon_receiving("a request to create an invalid content-item")
+        .with(
+          method: :put,
+          path: "/v2/content/#{@content_id}",
+          body: @content_item,
+          headers: GdsApi::JsonClient.default_request_with_json_body_headers.merge(
+            "Authorization" => "Bearer #{@bearer_token}",
+          ),
+        )
+        .will_respond_with(
+          status: 422,
+          body: [
+            {
+              schema: Pact.like({}),
+              fragment: "#/base_path",
+              message: Pact.like("The property '#/base_path' value \"not a url path\" did not match the regex '^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$' in schema 729a13d6-8ddb-5ba8-b116-3b7604dc3d3d#"),
+              failed_attribute: "Pattern",
+            },
+          ],
+          headers: {
+            "Content-Type" => "application/json; charset=utf-8",
+          },
+        )
+
+      assert_raises(GdsApi::HTTPUnprocessableEntity) do
+        @api_client.put_content(@content_id, @content_item)
+      end
+    end
+
+    describe "optimistic locking" do
+      it "responds with 200 OK if the content item has not changed since it was requested" do
+        @content_item = content_item_for_content_id(
+          @content_id,
+          "document_type" => "manual",
+          "schema_name" => "manual",
+          "locale" => "en",
+          "details" => { "body" => [] },
+          "previous_version" => "3",
+        )
 
         publishing_api
-          .given("no content exists")
-          .upon_receiving("a request to create a content item without links")
+          .given("the content item #{@content_id} is at version 3")
+          .upon_receiving("a request to update the content item at version 3")
           .with(
             method: :put,
             path: "/v2/content/#{@content_id}",
@@ -59,21 +156,23 @@ describe GdsApi::PublishingApi do
           .will_respond_with(
             status: 200,
           )
+
+        @api_client.put_content(@content_id, @content_item)
       end
 
-      it "responds with 200 OK" do
-        response = @api_client.put_content(@content_id, @content_item)
-        assert_equal 200, response.code
-      end
-    end
-
-    describe "if the path is reserved by a different app" do
-      before do
-        @content_item = content_item_for_content_id(@content_id, "base_path" => "/test-item", "publishing_app" => "whitehall")
+      it "responds with 409 Conflict if the content item has changed in the meantime" do
+        @content_item = content_item_for_content_id(
+          @content_id,
+          "document_type" => "manual",
+          "schema_name" => "manual",
+          "locale" => "en",
+          "details" => { "body" => [] },
+          "previous_version" => "2",
+        )
 
         publishing_api
-          .given("/test-item has been reserved by the Publisher application")
-          .upon_receiving("a request from the Whitehall application to create a content item at /test-item")
+          .given("the content item #{@content_id} is at version 3")
+          .upon_receiving("a request to update the content item at version 2")
           .with(
             method: :put,
             path: "/v2/content/#{@content_id}",
@@ -83,13 +182,13 @@ describe GdsApi::PublishingApi do
             ),
           )
           .will_respond_with(
-            status: 422,
+            status: 409,
             body: {
               "error" => {
-                "code" => 422,
+                "code" => 409,
                 "message" => Pact.term(generate: "Conflict", matcher: /\S+/),
                 "fields" => {
-                  "base_path" => Pact.each_like("is already in use by the 'publisher' app", min: 1),
+                  "previous_version" => Pact.each_like("does not match", min: 1),
                 },
               },
             },
@@ -97,744 +196,474 @@ describe GdsApi::PublishingApi do
               "Content-Type" => "application/json; charset=utf-8",
             },
           )
-      end
 
-      it "responds with 422 Unprocessable Entity" do
-        error = assert_raises GdsApi::HTTPUnprocessableEntity do
+        assert_raises(GdsApi::HTTPConflict) do
           @api_client.put_content(@content_id, @content_item)
-        end
-        assert_equal "Conflict", error.error_details["error"]["message"]
-      end
-    end
-
-    describe "with an invalid item" do
-      before do
-        @content_item = content_item_for_content_id(@content_id, "base_path" => "not a url path")
-
-        publishing_api
-          .given("no content exists")
-          .upon_receiving("a request to create an invalid content-item")
-          .with(
-            method: :put,
-            path: "/v2/content/#{@content_id}",
-            body: @content_item,
-            headers: GdsApi::JsonClient.default_request_with_json_body_headers.merge(
-              "Authorization" => "Bearer #{@bearer_token}",
-            ),
-          )
-          .will_respond_with(
-            status: 422,
-            body: [
-              {
-                schema: Pact.like({}),
-                fragment: "#/base_path",
-                message: Pact.like("The property '#/base_path' value \"not a url path\" did not match the regex '^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$' in schema 729a13d6-8ddb-5ba8-b116-3b7604dc3d3d#"),
-                failed_attribute: "Pattern",
-              },
-            ],
-            headers: {
-              "Content-Type" => "application/json; charset=utf-8",
-            },
-          )
-      end
-
-      it "responds with 422 Unprocessable Entity" do
-        assert_raises GdsApi::HTTPUnprocessableEntity do
-          @api_client.put_content(@content_id, @content_item)
-        end
-      end
-    end
-
-    describe "optimistic locking" do
-      describe "if the content item has not changed since it was requested" do
-        before do
-          @content_item = content_item_for_content_id(
-            @content_id,
-            "document_type" => "manual",
-            "schema_name" => "manual",
-            "locale" => "en",
-            "details" => { "body" => [] },
-            "previous_version" => "3",
-          )
-
-          publishing_api
-            .given("the content item #{@content_id} is at version 3")
-            .upon_receiving("a request to update the content item at version 3")
-            .with(
-              method: :put,
-              path: "/v2/content/#{@content_id}",
-              body: @content_item,
-              headers: GdsApi::JsonClient.default_request_with_json_body_headers.merge(
-                "Authorization" => "Bearer #{@bearer_token}",
-              ),
-            )
-            .will_respond_with(
-              status: 200,
-            )
-        end
-
-        it "responds with 200 OK" do
-          response = @api_client.put_content(@content_id, @content_item)
-          assert_equal 200, response.code
-        end
-      end
-
-      describe "if the content item has changed in the meantime" do
-        before do
-          @content_item = content_item_for_content_id(
-            @content_id,
-            "document_type" => "manual",
-            "schema_name" => "manual",
-            "locale" => "en",
-            "details" => { "body" => [] },
-            "previous_version" => "2",
-          )
-
-          publishing_api
-            .given("the content item #{@content_id} is at version 3")
-            .upon_receiving("a request to update the content item at version 2")
-            .with(
-              method: :put,
-              path: "/v2/content/#{@content_id}",
-              body: @content_item,
-              headers: GdsApi::JsonClient.default_request_with_json_body_headers.merge(
-                "Authorization" => "Bearer #{@bearer_token}",
-              ),
-            )
-            .will_respond_with(
-              status: 409,
-              body: {
-                "error" => {
-                  "code" => 409,
-                  "message" => Pact.term(generate: "Conflict", matcher: /\S+/),
-                  "fields" => {
-                    "previous_version" => Pact.each_like("does not match", min: 1),
-                  },
-                },
-              },
-              headers: {
-                "Content-Type" => "application/json; charset=utf-8",
-              },
-            )
-        end
-
-        it "responds with 409 Conflict" do
-          error = assert_raises GdsApi::HTTPClientError do
-            @api_client.put_content(@content_id, @content_item)
-          end
-          assert_equal 409, error.code
-          assert_equal "Conflict", error.error_details["error"]["message"]
         end
       end
     end
   end
 
   describe "#get_content" do
-    describe "when the content item exists" do
-      before do
-        @content_item = content_item_for_content_id(@content_id)
+    it "responds with 200 and the content item when the content item exists" do
+      @content_item = content_item_for_content_id(@content_id)
 
-        publishing_api
-          .given("a content item exists with content_id: #{@content_id}")
-          .upon_receiving("a request to return the content item")
-          .with(
-            method: :get,
-            path: "/v2/content/#{@content_id}",
-            headers: GdsApi::JsonClient.default_request_headers.merge(
-              "Authorization" => "Bearer #{@bearer_token}",
-            ),
-          )
-          .will_respond_with(
-            status: 200,
-            body: {
-              "content_id" => @content_id,
-              "document_type" => Pact.like("special_route"),
-              "schema_name" => Pact.like("special_route"),
-              "publishing_app" => Pact.like("publisher"),
-              "rendering_app" => Pact.like("frontend"),
-              "locale" => Pact.like("en"),
-              "routes" => Pact.like([{}]),
-              "public_updated_at" => Pact.like("2015-07-30T13:58:11.000Z"),
-              "details" => Pact.like({}),
-            },
-            headers: {
-              "Content-Type" => "application/json; charset=utf-8",
-            },
-          )
-      end
+      publishing_api
+        .given("a content item exists with content_id: #{@content_id}")
+        .upon_receiving("a request to return the content item")
+        .with(
+          method: :get,
+          path: "/v2/content/#{@content_id}",
+          headers: GdsApi::JsonClient.default_request_headers.merge(
+            "Authorization" => "Bearer #{@bearer_token}",
+          ),
+        )
+        .will_respond_with(
+          status: 200,
+          body: {
+            "content_id" => @content_id,
+            "document_type" => Pact.like("special_route"),
+            "schema_name" => Pact.like("special_route"),
+            "publishing_app" => Pact.like("publisher"),
+            "rendering_app" => Pact.like("frontend"),
+            "locale" => Pact.like("en"),
+            "routes" => Pact.like([{}]),
+            "public_updated_at" => Pact.like("2015-07-30T13:58:11.000Z"),
+            "details" => Pact.like({}),
+          },
+          headers: {
+            "Content-Type" => "application/json; charset=utf-8",
+          },
+        )
 
-      it "responds with 200 and the content item" do
-        response = @api_client.get_content(@content_id)
-        assert_equal 200, response.code
-        assert_equal @content_item["document_type"], response["document_type"]
-      end
+      @api_client.get_content(@content_id)
     end
 
-    describe "when a content item exists in multiple locales" do
-      before do
-        @content_item = content_item_for_content_id(@content_id)
+    it "responds with 200 and the content item when a content item exists in multiple locales" do
+      @content_item = content_item_for_content_id(@content_id)
 
-        publishing_api
-          .given("a content item exists in multiple locales with content_id: #{@content_id}")
-          .upon_receiving("a request to return the content item")
-          .with(
-            method: :get,
-            path: "/v2/content/#{@content_id}",
-            query: "locale=fr",
-            headers: GdsApi::JsonClient.default_request_headers.merge(
-              "Authorization" => "Bearer #{@bearer_token}",
-            ),
-          )
-          .will_respond_with(
-            status: 200,
-            body: {
-              "content_id" => @content_id,
-              "document_type" => Pact.like("special_route"),
-              "schema_name" => Pact.like("special_route"),
-              "publishing_app" => Pact.like("publisher"),
-              "rendering_app" => Pact.like("frontend"),
-              "locale" => "fr",
-              "routes" => Pact.like([{}]),
-              "public_updated_at" => Pact.like("2015-07-30T13:58:11.000Z"),
-              "details" => Pact.like({}),
-            },
-            headers: {
-              "Content-Type" => "application/json; charset=utf-8",
-            },
-          )
-      end
+      publishing_api
+        .given("a content item exists in multiple locales with content_id: #{@content_id}")
+        .upon_receiving("a request to return the content item")
+        .with(
+          method: :get,
+          path: "/v2/content/#{@content_id}",
+          query: "locale=fr",
+          headers: GdsApi::JsonClient.default_request_headers.merge(
+            "Authorization" => "Bearer #{@bearer_token}",
+          ),
+        )
+        .will_respond_with(
+          status: 200,
+          body: {
+            "content_id" => @content_id,
+            "document_type" => Pact.like("special_route"),
+            "schema_name" => Pact.like("special_route"),
+            "publishing_app" => Pact.like("publisher"),
+            "rendering_app" => Pact.like("frontend"),
+            "locale" => "fr",
+            "routes" => Pact.like([{}]),
+            "public_updated_at" => Pact.like("2015-07-30T13:58:11.000Z"),
+            "details" => Pact.like({}),
+          },
+          headers: {
+            "Content-Type" => "application/json; charset=utf-8",
+          },
+        )
 
-      it "responds with 200 and the content item" do
-        response = @api_client.get_content(@content_id, locale: "fr")
-        assert_equal 200, response.code
-        assert_equal response["locale"], "fr"
-      end
+      @api_client.get_content(@content_id, locale: "fr")
     end
 
-    describe "when a content item exists in with a superseded version" do
-      describe "when requesting the superseded version" do
-        before do
-          @content_item = content_item_for_content_id(@content_id)
+    it "responds with 200 and the superseded content item when requesting the superseded version, when a content item exists in with a superseded version" do
+      @content_item = content_item_for_content_id(@content_id)
 
-          publishing_api
-            .given("a content item exists in with a superseded version with content_id: #{@content_id}")
-            .upon_receiving("a request to return the superseded content item")
-            .with(
-              method: :get,
-              path: "/v2/content/#{@content_id}",
-              query: "version=1",
-              headers: GdsApi::JsonClient.default_request_headers.merge(
-                "Authorization" => "Bearer #{@bearer_token}",
-              ),
-            )
-            .will_respond_with(
-              status: 200,
-              body: {
-                "content_id" => @content_id,
-                "document_type" => Pact.like("special_route"),
-                "schema_name" => Pact.like("special_route"),
-                "publishing_app" => Pact.like("publisher"),
-                "rendering_app" => Pact.like("frontend"),
-                "locale" => Pact.like("en"),
-                "routes" => Pact.like([{}]),
-                "public_updated_at" => Pact.like("2015-07-30T13:58:11.000Z"),
-                "details" => Pact.like({}),
-                "publication_state" => "superseded",
-              },
-              headers: {
-                "Content-Type" => "application/json; charset=utf-8",
-              },
-            )
-        end
+      publishing_api
+        .given("a content item exists in with a superseded version with content_id: #{@content_id}")
+        .upon_receiving("a request to return the superseded content item")
+        .with(
+          method: :get,
+          path: "/v2/content/#{@content_id}",
+          query: "version=1",
+          headers: GdsApi::JsonClient.default_request_headers.merge(
+            "Authorization" => "Bearer #{@bearer_token}",
+          ),
+        )
+        .will_respond_with(
+          status: 200,
+          body: {
+            "content_id" => @content_id,
+            "document_type" => Pact.like("special_route"),
+            "schema_name" => Pact.like("special_route"),
+            "publishing_app" => Pact.like("publisher"),
+            "rendering_app" => Pact.like("frontend"),
+            "locale" => Pact.like("en"),
+            "routes" => Pact.like([{}]),
+            "public_updated_at" => Pact.like("2015-07-30T13:58:11.000Z"),
+            "details" => Pact.like({}),
+            "publication_state" => "superseded",
+          },
+          headers: {
+            "Content-Type" => "application/json; charset=utf-8",
+          },
+        )
 
-        it "responds with 200 and the superseded content item" do
-          response = @api_client.get_content(@content_id, version: 1)
-          assert_equal 200, response.code
-          assert_equal response["publication_state"], "superseded"
-        end
-      end
-
-      describe "when a content item cannot be published because of a path conflict" do
-        before do
-          @content_item = content_item_for_content_id(@content_id)
-
-          publishing_api
-            .given("a draft content item exists with content_id #{@content_id} with a blocking live item at the same path")
-            .upon_receiving("a request to return the draft content item")
-            .with(
-              method: :get,
-              path: "/v2/content/#{@content_id}",
-              headers: GdsApi::JsonClient.default_request_headers.merge(
-                "Authorization" => "Bearer #{@bearer_token}",
-              ),
-            )
-            .will_respond_with(
-              status: 200,
-              body: {
-                "warnings" => Pact.like("content_item_blocking_publish" => "message"),
-                "content_id" => @content_id,
-                "document_type" => Pact.like("special_route"),
-                "schema_name" => Pact.like("special_route"),
-                "publishing_app" => Pact.like("publisher"),
-                "rendering_app" => Pact.like("frontend"),
-                "locale" => Pact.like("en"),
-                "routes" => Pact.like([{}]),
-                "details" => Pact.like({}),
-                "publication_state" => "draft",
-              },
-              headers: {
-                "Content-Type" => "application/json; charset=utf-8",
-              },
-            )
-        end
-
-        it "responds with 200 and the draft content item containing a warning" do
-          response = @api_client.get_content(@content_id, version: 2)
-          assert_equal 200, response.code
-          assert_equal hash_including("content_item_blocking_publish"), response["warnings"]
-        end
-      end
-
-      describe "when requesting the published version" do
-        before do
-          @content_item = content_item_for_content_id(@content_id)
-
-          publishing_api
-            .given("a content item exists in with a superseded version with content_id: #{@content_id}")
-            .upon_receiving("a request to return the published content item")
-            .with(
-              method: :get,
-              path: "/v2/content/#{@content_id}",
-              query: "version=2",
-              headers: GdsApi::JsonClient.default_request_headers.merge(
-                "Authorization" => "Bearer #{@bearer_token}",
-              ),
-            )
-            .will_respond_with(
-              status: 200,
-              body: {
-                "content_id" => @content_id,
-                "document_type" => Pact.like("special_route"),
-                "schema_name" => Pact.like("special_route"),
-                "publishing_app" => Pact.like("publisher"),
-                "rendering_app" => Pact.like("frontend"),
-                "locale" => Pact.like("en"),
-                "routes" => Pact.like([{}]),
-                "public_updated_at" => Pact.like("2015-07-30T13:58:11.000Z"),
-                "details" => Pact.like({}),
-                "publication_state" => "published",
-              },
-              headers: {
-                "Content-Type" => "application/json; charset=utf-8",
-              },
-            )
-        end
-
-        it "responds with 200 and the published content item" do
-          response = @api_client.get_content(@content_id, version: 2)
-          assert_equal 200, response.code
-          assert_equal response["publication_state"], "published"
-        end
-      end
-
-      describe "when requesting no specific version" do
-        before do
-          @content_item = content_item_for_content_id(@content_id)
-
-          publishing_api
-            .given("a content item exists in with a superseded version with content_id: #{@content_id}")
-            .upon_receiving("a request to return the content item")
-            .with(
-              method: :get,
-              path: "/v2/content/#{@content_id}",
-              headers: GdsApi::JsonClient.default_request_headers.merge(
-                "Authorization" => "Bearer #{@bearer_token}",
-              ),
-            )
-            .will_respond_with(
-              status: 200,
-              body: {
-                "content_id" => @content_id,
-                "document_type" => Pact.like("special_route"),
-                "schema_name" => Pact.like("special_route"),
-                "publishing_app" => Pact.like("publisher"),
-                "rendering_app" => Pact.like("frontend"),
-                "locale" => Pact.like("en"),
-                "routes" => Pact.like([{}]),
-                "public_updated_at" => Pact.like("2015-07-30T13:58:11.000Z"),
-                "details" => Pact.like({}),
-                "publication_state" => "published",
-              },
-              headers: {
-                "Content-Type" => "application/json; charset=utf-8",
-              },
-            )
-        end
-
-        it "responds with 200 and the published content item" do
-          response = @api_client.get_content(@content_id)
-          assert_equal 200, response.code
-          assert_equal response["publication_state"], "published"
-        end
-      end
+      @api_client.get_content(@content_id, version: 1)
     end
 
-    describe "a non-existent item" do
-      before do
-        publishing_api
-          .given("no content exists")
-          .upon_receiving("a request for a non-existent content item")
-          .with(
-            method: :get,
-            path: "/v2/content/#{@content_id}",
-            headers: GdsApi::JsonClient.default_request_headers.merge(
-              "Authorization" => "Bearer #{@bearer_token}",
-            ),
-          )
-          .will_respond_with(
-            status: 404,
-            body: {
-              "error" => {
-                "code" => 404,
-                "message" => Pact.term(generate: "not found", matcher: /\S+/),
-              },
-            },
-            headers: {
-              "Content-Type" => "application/json; charset=utf-8",
-            },
-          )
-      end
+    it "responds with 200 and the draft content item containing a warning, when a content item cannot be published because of a path conflict" do
+      @content_item = content_item_for_content_id(@content_id)
 
-      it "responds with 404" do
-        assert_raises(GdsApi::HTTPNotFound) do
-          @api_client.get_content(@content_id)
-        end
+      publishing_api
+        .given("a draft content item exists with content_id #{@content_id} with a blocking live item at the same path")
+        .upon_receiving("a request to return the draft content item")
+        .with(
+          method: :get,
+          path: "/v2/content/#{@content_id}",
+          headers: GdsApi::JsonClient.default_request_headers.merge(
+            "Authorization" => "Bearer #{@bearer_token}",
+          ),
+        )
+        .will_respond_with(
+          status: 200,
+          body: {
+            "warnings" => Pact.like("content_item_blocking_publish" => "message"),
+            "content_id" => @content_id,
+            "document_type" => Pact.like("special_route"),
+            "schema_name" => Pact.like("special_route"),
+            "publishing_app" => Pact.like("publisher"),
+            "rendering_app" => Pact.like("frontend"),
+            "locale" => Pact.like("en"),
+            "routes" => Pact.like([{}]),
+            "details" => Pact.like({}),
+            "publication_state" => "draft",
+          },
+          headers: {
+            "Content-Type" => "application/json; charset=utf-8",
+          },
+        )
+
+      @api_client.get_content(@content_id, version: 2)
+    end
+
+    it "responds with 200 and the published content item when requesting the published version" do
+      @content_item = content_item_for_content_id(@content_id)
+
+      publishing_api
+        .given("a content item exists in with a superseded version with content_id: #{@content_id}")
+        .upon_receiving("a request to return the published content item")
+        .with(
+          method: :get,
+          path: "/v2/content/#{@content_id}",
+          query: "version=2",
+          headers: GdsApi::JsonClient.default_request_headers.merge(
+            "Authorization" => "Bearer #{@bearer_token}",
+          ),
+        )
+        .will_respond_with(
+          status: 200,
+          body: {
+            "content_id" => @content_id,
+            "document_type" => Pact.like("special_route"),
+            "schema_name" => Pact.like("special_route"),
+            "publishing_app" => Pact.like("publisher"),
+            "rendering_app" => Pact.like("frontend"),
+            "locale" => Pact.like("en"),
+            "routes" => Pact.like([{}]),
+            "public_updated_at" => Pact.like("2015-07-30T13:58:11.000Z"),
+            "details" => Pact.like({}),
+            "publication_state" => "published",
+          },
+          headers: {
+            "Content-Type" => "application/json; charset=utf-8",
+          },
+        )
+
+      @api_client.get_content(@content_id, version: 2)
+    end
+
+    it "responds with 200 and the published content item when requesting no specific version" do
+      @content_item = content_item_for_content_id(@content_id)
+
+      publishing_api
+        .given("a content item exists in with a superseded version with content_id: #{@content_id}")
+        .upon_receiving("a request to return the content item")
+        .with(
+          method: :get,
+          path: "/v2/content/#{@content_id}",
+          headers: GdsApi::JsonClient.default_request_headers.merge(
+            "Authorization" => "Bearer #{@bearer_token}",
+          ),
+        )
+        .will_respond_with(
+          status: 200,
+          body: {
+            "content_id" => @content_id,
+            "document_type" => Pact.like("special_route"),
+            "schema_name" => Pact.like("special_route"),
+            "publishing_app" => Pact.like("publisher"),
+            "rendering_app" => Pact.like("frontend"),
+            "locale" => Pact.like("en"),
+            "routes" => Pact.like([{}]),
+            "public_updated_at" => Pact.like("2015-07-30T13:58:11.000Z"),
+            "details" => Pact.like({}),
+            "publication_state" => "published",
+          },
+          headers: {
+            "Content-Type" => "application/json; charset=utf-8",
+          },
+        )
+
+      @api_client.get_content(@content_id)
+    end
+
+    it "responds with 404 when requesting a non-existent item" do
+      publishing_api
+        .given("no content exists")
+        .upon_receiving("a request for a non-existent content item")
+        .with(
+          method: :get,
+          path: "/v2/content/#{@content_id}",
+          headers: GdsApi::JsonClient.default_request_headers.merge(
+            "Authorization" => "Bearer #{@bearer_token}",
+          ),
+        )
+        .will_respond_with(
+          status: 404,
+          body: {
+            "error" => {
+              "code" => 404,
+              "message" => Pact.term(generate: "not found", matcher: /\S+/),
+            },
+          },
+          headers: {
+            "Content-Type" => "application/json; charset=utf-8",
+          },
+        )
+
+      assert_raises(GdsApi::HTTPNotFound) do
+        @api_client.get_content(@content_id)
       end
     end
   end
 
   describe "#get_live_content" do
-    describe "when the latest version of the content item is published" do
-      before do
-        publishing_api
-          .given("a published content item exists with content_id: #{@content_id}")
-          .upon_receiving("a request to return the live content item")
-          .with(
-            method: :get,
-            path: "/v2/content/#{@content_id}",
-            headers: GdsApi::JsonClient.default_request_headers.merge(
-              "Authorization" => "Bearer #{@bearer_token}",
-            ),
-          )
-          .will_respond_with(
-            status: 200,
-            body: {
-              "content_id" => @content_id,
-              "document_type" => Pact.like("special_route"),
-              "schema_name" => Pact.like("special_route"),
-              "publishing_app" => Pact.like("publisher"),
-              "rendering_app" => Pact.like("frontend"),
-              "locale" => Pact.like("en"),
-              "routes" => Pact.like([{}]),
-              "public_updated_at" => Pact.like("2015-07-30T13:58:11.000Z"),
-              "details" => Pact.like({}),
-              "state_history" => { "1" => "published" },
-              "publication_state" => "published",
-            },
-            headers: {
-              "Content-Type" => "application/json; charset=utf-8",
-            },
-          )
-      end
+    it "returns the published content item when the latest version of the content item is published" do
+      publishing_api
+        .given("a published content item exists with content_id: #{@content_id}")
+        .upon_receiving("a request to return the live content item")
+        .with(
+          method: :get,
+          path: "/v2/content/#{@content_id}",
+          headers: GdsApi::JsonClient.default_request_headers.merge(
+            "Authorization" => "Bearer #{@bearer_token}",
+          ),
+        )
+        .will_respond_with(
+          status: 200,
+          body: {
+            "content_id" => @content_id,
+            "document_type" => Pact.like("special_route"),
+            "schema_name" => Pact.like("special_route"),
+            "publishing_app" => Pact.like("publisher"),
+            "rendering_app" => Pact.like("frontend"),
+            "locale" => Pact.like("en"),
+            "routes" => Pact.like([{}]),
+            "public_updated_at" => Pact.like("2015-07-30T13:58:11.000Z"),
+            "details" => Pact.like({}),
+            "state_history" => { "1" => "published" },
+            "publication_state" => "published",
+          },
+          headers: {
+            "Content-Type" => "application/json; charset=utf-8",
+          },
+        )
 
-      it "returns the published content item" do
-        response = @api_client.get_live_content(@content_id)
-        assert_equal 200, response.code
-        assert_equal response["publication_state"], "published"
+      @api_client.get_live_content(@content_id)
+    end
+
+    it "responds with NoLiveVersion when the content item has never been live" do
+      publishing_api
+        .given("a draft content item exists with content_id: #{@content_id}")
+        .upon_receiving("a request to return the live content item")
+        .with(
+          method: :get,
+          path: "/v2/content/#{@content_id}",
+          headers: GdsApi::JsonClient.default_request_headers.merge(
+            "Authorization" => "Bearer #{@bearer_token}",
+          ),
+        )
+        .will_respond_with(
+          status: 200,
+          body: {
+            "content_id" => @content_id,
+            "document_type" => Pact.like("special_route"),
+            "schema_name" => Pact.like("special_route"),
+            "publishing_app" => Pact.like("publisher"),
+            "rendering_app" => Pact.like("frontend"),
+            "locale" => Pact.like("en"),
+            "routes" => Pact.like([{}]),
+            "details" => Pact.like({}),
+            "state_history" => { "1" => "draft" },
+            "publication_state" => "draft",
+          },
+          headers: {
+            "Content-Type" => "application/json; charset=utf-8",
+          },
+        )
+
+      assert_raises(GdsApi::PublishingApi::NoLiveVersion) do
+        @api_client.get_live_content(@content_id)
       end
     end
 
-    describe "when the content item has never been live" do
-      before do
-        publishing_api
-          .given("a draft content item exists with content_id: #{@content_id}")
-          .upon_receiving("a request to return the live content item")
-          .with(
-            method: :get,
-            path: "/v2/content/#{@content_id}",
-            headers: GdsApi::JsonClient.default_request_headers.merge(
-              "Authorization" => "Bearer #{@bearer_token}",
-            ),
-          )
-          .will_respond_with(
-            status: 200,
-            body: {
-              "content_id" => @content_id,
-              "document_type" => Pact.like("special_route"),
-              "schema_name" => Pact.like("special_route"),
-              "publishing_app" => Pact.like("publisher"),
-              "rendering_app" => Pact.like("frontend"),
-              "locale" => Pact.like("en"),
-              "routes" => Pact.like([{}]),
-              "details" => Pact.like({}),
-              "state_history" => { "1" => "draft" },
-              "publication_state" => "draft",
-            },
-            headers: {
-              "Content-Type" => "application/json; charset=utf-8",
-            },
-          )
-      end
+    it "returns the live content item when there is a draft version of live content" do
+      publishing_api
+        .given("a published content item exists with a draft edition for content_id: #{@content_id}")
+        .upon_receiving("a request to return the content item")
+        .with(
+          method: :get,
+          path: "/v2/content/#{@content_id}",
+          query: "locale=en",
+          headers: GdsApi::JsonClient.default_request_headers.merge(
+            "Authorization" => "Bearer #{@bearer_token}",
+          ),
+        )
+        .will_respond_with(
+          status: 200,
+          body: {
+            "content_id" => @content_id,
+            "document_type" => Pact.like("special_route"),
+            "schema_name" => Pact.like("special_route"),
+            "publishing_app" => Pact.like("publisher"),
+            "rendering_app" => Pact.like("frontend"),
+            "locale" => Pact.like("en"),
+            "routes" => Pact.like([{}]),
+            "details" => Pact.like({}),
+            "state_history" => { "1" => "published", "2" => "draft" },
+            "publication_state" => "draft",
+          },
+          headers: {
+            "Content-Type" => "application/json; charset=utf-8",
+          },
+        )
+        .upon_receiving("a request to return the live content item")
+        .with(
+          method: :get,
+          path: "/v2/content/#{@content_id}",
+          query: "locale=en&version=1",
+          headers: GdsApi::JsonClient.default_request_headers.merge(
+            "Authorization" => "Bearer #{@bearer_token}",
+          ),
+        )
+        .will_respond_with(
+          status: 200,
+          body: {
+            "content_id" => @content_id,
+            "document_type" => Pact.like("special_route"),
+            "schema_name" => Pact.like("special_route"),
+            "publishing_app" => Pact.like("publisher"),
+            "rendering_app" => Pact.like("frontend"),
+            "locale" => Pact.like("en"),
+            "routes" => Pact.like([{}]),
+            "public_updated_at" => Pact.like("2015-07-30T13:58:11.000Z"),
+            "details" => Pact.like({}),
+            "state_history" => { "1" => "published", "2" => "draft" },
+            "publication_state" => "published",
+          },
+          headers: {
+            "Content-Type" => "application/json; charset=utf-8",
+          },
+        )
 
-      it "responds with NoLiveVersion" do
-        assert_raises(GdsApi::PublishingApi::NoLiveVersion) do
-          @api_client.get_live_content(@content_id)
-        end
-      end
+      @api_client.get_live_content(@content_id)
     end
 
-    describe "when there is a draft version of live content" do
-      before do
-        publishing_api
-          .given("a published content item exists with a draft edition for content_id: #{@content_id}")
-          .upon_receiving("a request to return the content item")
-          .with(
-            method: :get,
-            path: "/v2/content/#{@content_id}",
-            query: "locale=en",
-            headers: GdsApi::JsonClient.default_request_headers.merge(
-              "Authorization" => "Bearer #{@bearer_token}",
-            ),
-          )
-          .will_respond_with(
-            status: 200,
-            body: {
-              "content_id" => @content_id,
-              "document_type" => Pact.like("special_route"),
-              "schema_name" => Pact.like("special_route"),
-              "publishing_app" => Pact.like("publisher"),
-              "rendering_app" => Pact.like("frontend"),
-              "locale" => Pact.like("en"),
-              "routes" => Pact.like([{}]),
-              "details" => Pact.like({}),
-              "state_history" => { "1" => "published", "2" => "draft" },
-              "publication_state" => "draft",
-            },
-            headers: {
-              "Content-Type" => "application/json; charset=utf-8",
-            },
-          )
-          .upon_receiving("a request to return the live content item")
-          .with(
-            method: :get,
-            path: "/v2/content/#{@content_id}",
-            query: "locale=en&version=1",
-            headers: GdsApi::JsonClient.default_request_headers.merge(
-              "Authorization" => "Bearer #{@bearer_token}",
-            ),
-          )
-          .will_respond_with(
-            status: 200,
-            body: {
-              "content_id" => @content_id,
-              "document_type" => Pact.like("special_route"),
-              "schema_name" => Pact.like("special_route"),
-              "publishing_app" => Pact.like("publisher"),
-              "rendering_app" => Pact.like("frontend"),
-              "locale" => Pact.like("en"),
-              "routes" => Pact.like([{}]),
-              "public_updated_at" => Pact.like("2015-07-30T13:58:11.000Z"),
-              "details" => Pact.like({}),
-              "state_history" => { "1" => "published", "2" => "draft" },
-              "publication_state" => "published",
-            },
-            headers: {
-              "Content-Type" => "application/json; charset=utf-8",
-            },
-          )
-      end
+    it "returns the unpublished content item when the latest version of the content item is unpublished" do
+      publishing_api
+        .given("an unpublished content item exists with content_id: #{@content_id}")
+        .upon_receiving("a request to return the content item")
+        .with(
+          method: :get,
+          path: "/v2/content/#{@content_id}",
+          headers: GdsApi::JsonClient.default_request_headers.merge(
+            "Authorization" => "Bearer #{@bearer_token}",
+          ),
+        )
+        .will_respond_with(
+          status: 200,
+          body: {
+            "content_id" => @content_id,
+            "document_type" => Pact.like("special_route"),
+            "schema_name" => Pact.like("special_route"),
+            "publishing_app" => Pact.like("publisher"),
+            "rendering_app" => Pact.like("frontend"),
+            "locale" => Pact.like("en"),
+            "routes" => Pact.like([{}]),
+            "public_updated_at" => Pact.like("2015-07-30T13:58:11.000Z"),
+            "details" => Pact.like({}),
+            "state_history" => { "1" => "unpublished" },
+            "publication_state" => "unpublished",
+          },
+          headers: {
+            "Content-Type" => "application/json; charset=utf-8",
+          },
+        )
 
-      it "returns the live content item" do
-        response = @api_client.get_live_content(@content_id)
-        assert_equal 200, response.code
-        assert_equal response["publication_state"], "published"
-      end
-    end
-
-    describe "when the latest version of the content item is unpublished" do
-      before do
-        publishing_api
-          .given("an unpublished content item exists with content_id: #{@content_id}")
-          .upon_receiving("a request to return the content item")
-          .with(
-            method: :get,
-            path: "/v2/content/#{@content_id}",
-            headers: GdsApi::JsonClient.default_request_headers.merge(
-              "Authorization" => "Bearer #{@bearer_token}",
-            ),
-          )
-          .will_respond_with(
-            status: 200,
-            body: {
-              "content_id" => @content_id,
-              "document_type" => Pact.like("special_route"),
-              "schema_name" => Pact.like("special_route"),
-              "publishing_app" => Pact.like("publisher"),
-              "rendering_app" => Pact.like("frontend"),
-              "locale" => Pact.like("en"),
-              "routes" => Pact.like([{}]),
-              "public_updated_at" => Pact.like("2015-07-30T13:58:11.000Z"),
-              "details" => Pact.like({}),
-              "state_history" => { "1" => "unpublished" },
-              "publication_state" => "unpublished",
-            },
-            headers: {
-              "Content-Type" => "application/json; charset=utf-8",
-            },
-          )
-      end
-
-      it "returns the unpublished content item" do
-        response = @api_client.get_live_content(@content_id)
-        assert_equal 200, response.code
-        assert_equal response["publication_state"], "unpublished"
-      end
+      @api_client.get_live_content(@content_id)
     end
   end
 
   describe "#republish" do
-    describe "if the republish command succeeds" do
-      before do
-        publishing_api
-          .given("an unpublished content item exists with content_id: #{@content_id}")
-          .upon_receiving("a republish request")
-          .with(
-            method: :post,
-            path: "/v2/content/#{@content_id}/republish",
-            body: {},
-            headers: GdsApi::JsonClient.default_request_with_json_body_headers.merge(
-              "Authorization" => "Bearer #{@bearer_token}",
-            ),
-          )
-          .will_respond_with(
-            status: 200,
-          )
-      end
+    it "responds with 200 if the republish command succeeds" do
+      publishing_api
+        .given("an unpublished content item exists with content_id: #{@content_id}")
+        .upon_receiving("a republish request")
+        .with(
+          method: :post,
+          path: "/v2/content/#{@content_id}/republish",
+          body: {},
+          headers: GdsApi::JsonClient.default_request_with_json_body_headers.merge(
+            "Authorization" => "Bearer #{@bearer_token}",
+          ),
+        )
+        .will_respond_with(
+          status: 200,
+        )
 
-      it "responds with 200 if the publish command succeeds" do
-        response = @api_client.republish(@content_id)
-        assert_equal 200, response.code
-      end
+      @api_client.republish(@content_id)
     end
 
-    describe "if the content item does not exist" do
-      before do
-        publishing_api
-          .given("no content exists")
-          .upon_receiving("a republish request")
-          .with(
-            method: :post,
-            path: "/v2/content/#{@content_id}/republish",
-            body: {},
-            headers: GdsApi::JsonClient.default_request_with_json_body_headers.merge(
-              "Authorization" => "Bearer #{@bearer_token}",
-            ),
-          )
-          .will_respond_with(
-            status: 404,
-          )
-      end
+    it "responds with 404 if the content item does not exist" do
+      publishing_api
+        .given("no content exists")
+        .upon_receiving("a republish request")
+        .with(
+          method: :post,
+          path: "/v2/content/#{@content_id}/republish",
+          body: {},
+          headers: GdsApi::JsonClient.default_request_with_json_body_headers.merge(
+            "Authorization" => "Bearer #{@bearer_token}",
+          ),
+        )
+        .will_respond_with(
+          status: 404,
+        )
 
-      it "responds with 404" do
-        error = assert_raises GdsApi::HTTPClientError do
-          @api_client.republish(@content_id)
-        end
-
-        assert_equal 404, error.code
+      assert_raises(GdsApi::HTTPNotFound) do
+        @api_client.republish(@content_id)
       end
     end
 
     describe "optimistic locking" do
-      describe "if the content item has not changed since it was requested" do
-        before do
-          publishing_api
-            .given("the published content item #{@content_id} is at version 3")
-            .upon_receiving("a republish request for version 3")
-            .with(
-              method: :post,
-              path: "/v2/content/#{@content_id}/republish",
-              body: {
-                previous_version: 3,
-              },
-              headers: GdsApi::JsonClient.default_request_with_json_body_headers.merge(
-                "Authorization" => "Bearer #{@bearer_token}",
-              ),
-            )
-            .will_respond_with(
-              status: 200,
-            )
-        end
-
-        it "responds with 200 OK" do
-          response = @api_client.republish(@content_id, previous_version: 3)
-          assert_equal 200, response.code
-        end
-      end
-
-      describe "if the content item has changed in the meantime" do
-        before do
-          publishing_api
-            .given("the published content item #{@content_id} is at version 3")
-            .upon_receiving("a republish request for version 2")
-            .with(
-              method: :post,
-              path: "/v2/content/#{@content_id}/republish",
-              body: {
-                previous_version: 2,
-              },
-              headers: GdsApi::JsonClient.default_request_with_json_body_headers.merge(
-                "Authorization" => "Bearer #{@bearer_token}",
-              ),
-            )
-            .will_respond_with(
-              status: 409,
-              body: {
-                "error" => {
-                  "code" => 409,
-                  "message" => Pact.term(generate: "Conflict", matcher: /\S+/),
-                  "fields" => {
-                    "previous_version" => Pact.each_like("does not match", min: 1),
-                  },
-                },
-              },
-              headers: {
-                "Content-Type" => "application/json; charset=utf-8",
-              },
-            )
-        end
-
-        it "responds with 409 Conflict" do
-          error = assert_raises GdsApi::HTTPClientError do
-            @api_client.republish(@content_id, previous_version: 2)
-          end
-          assert_equal 409, error.code
-          assert_equal "Conflict", error.error_details["error"]["message"]
-        end
-      end
-    end
-  end
-
-  describe "#publish" do
-    describe "if the publish command succeeds" do
-      before do
+      it "responds with 200 OK if the content item has not changed since it was requested" do
         publishing_api
-          .given("a draft content item exists with content_id: #{@content_id}")
-          .upon_receiving("a publish request")
+          .given("the published content item #{@content_id} is at version 3")
+          .upon_receiving("a republish request for version 3")
           .with(
             method: :post,
-            path: "/v2/content/#{@content_id}/publish",
+            path: "/v2/content/#{@content_id}/republish",
             body: {
-              update_type: "major",
+              previous_version: 3,
             },
             headers: GdsApi::JsonClient.default_request_with_json_body_headers.merge(
               "Authorization" => "Bearer #{@bearer_token}",
@@ -843,92 +672,19 @@ describe GdsApi::PublishingApi do
           .will_respond_with(
             status: 200,
           )
+
+        @api_client.republish(@content_id, previous_version: 3)
       end
 
-      it "responds with 200 if the publish command succeeds" do
-        response = @api_client.publish(@content_id, "major")
-        assert_equal 200, response.code
-      end
-    end
-
-    describe "if the content item does not exist" do
-      before do
+      it "responds with 409 Conflict if the content item has changed in the meantime" do
         publishing_api
-          .given("no content exists")
-          .upon_receiving("a publish request")
+          .given("the published content item #{@content_id} is at version 3")
+          .upon_receiving("a republish request for version 2")
           .with(
             method: :post,
-            path: "/v2/content/#{@content_id}/publish",
+            path: "/v2/content/#{@content_id}/republish",
             body: {
-              update_type: "major",
-            },
-            headers: GdsApi::JsonClient.default_request_with_json_body_headers.merge(
-              "Authorization" => "Bearer #{@bearer_token}",
-            ),
-          )
-          .will_respond_with(
-            status: 404,
-          )
-      end
-
-      it "responds with 404" do
-        error = assert_raises GdsApi::HTTPClientError do
-          @api_client.publish(@content_id, "major")
-        end
-
-        assert_equal 404, error.code
-      end
-    end
-
-    describe "if the update information is invalid" do
-      before do
-        publishing_api
-          .given("a draft content item exists with content_id: #{@content_id}")
-          .upon_receiving("an invalid publish request")
-          .with(
-            method: :post,
-            path: "/v2/content/#{@content_id}/publish",
-            body: {
-              "update_type" => "",
-            },
-            headers: GdsApi::JsonClient.default_request_with_json_body_headers.merge(
-              "Authorization" => "Bearer #{@bearer_token}",
-            ),
-          )
-          .will_respond_with(
-            status: 422,
-            body: {
-              "error" => {
-                "code" => 422,
-                "message" => Pact.term(generate: "Unprocessable entity", matcher: /\S+/),
-                "fields" => {
-                  "update_type" => Pact.each_like("is required", min: 1),
-                },
-              },
-            },
-          )
-      end
-
-      it "responds with 422" do
-        error = assert_raises GdsApi::HTTPUnprocessableEntity do
-          @api_client.publish(@content_id, "")
-        end
-
-        assert_equal 422, error.code
-        assert_equal "Unprocessable entity", error.error_details["error"]["message"]
-      end
-    end
-
-    describe "if the content item is already published" do
-      before do
-        publishing_api
-          .given("a published content item exists with content_id: #{@content_id}")
-          .upon_receiving("a publish request")
-          .with(
-            method: :post,
-            path: "/v2/content/#{@content_id}/publish",
-            body: {
-              update_type: "major",
+              previous_version: 2,
             },
             headers: GdsApi::JsonClient.default_request_with_json_body_headers.merge(
               "Authorization" => "Bearer #{@bearer_token}",
@@ -938,33 +694,163 @@ describe GdsApi::PublishingApi do
             status: 409,
             body: {
               "error" => {
-                "code" => 409, "message" => Pact.term(generate: "Cannot publish an already published content item", matcher: /\S+/)
+                "code" => 409,
+                "message" => Pact.term(generate: "Conflict", matcher: /\S+/),
+                "fields" => {
+                  "previous_version" => Pact.each_like("does not match", min: 1),
+                },
               },
             },
+            headers: {
+              "Content-Type" => "application/json; charset=utf-8",
+            },
           )
-      end
 
-      it "responds with 409" do
-        error = assert_raises GdsApi::HTTPClientError do
-          @api_client.publish(@content_id, "major")
+        assert_raises(GdsApi::HTTPConflict) do
+          @api_client.republish(@content_id, previous_version: 2)
         end
+      end
+    end
+  end
 
-        assert_equal 409, error.code
-        assert_equal "Cannot publish an already published content item", error.error_details["error"]["message"]
+  describe "#publish" do
+    it "responds with 200 if the publish command succeeds" do
+      publishing_api
+        .given("a draft content item exists with content_id: #{@content_id}")
+        .upon_receiving("a publish request")
+        .with(
+          method: :post,
+          path: "/v2/content/#{@content_id}/publish",
+          body: {
+            update_type: "major",
+          },
+          headers: GdsApi::JsonClient.default_request_with_json_body_headers.merge(
+            "Authorization" => "Bearer #{@bearer_token}",
+          ),
+        )
+        .will_respond_with(
+          status: 200,
+        )
+
+      @api_client.publish(@content_id, "major")
+    end
+
+    it "responds with 404 if the content item does not exist" do
+      publishing_api
+        .given("no content exists")
+        .upon_receiving("a publish request")
+        .with(
+          method: :post,
+          path: "/v2/content/#{@content_id}/publish",
+          body: {
+            update_type: "major",
+          },
+          headers: GdsApi::JsonClient.default_request_with_json_body_headers.merge(
+            "Authorization" => "Bearer #{@bearer_token}",
+          ),
+        )
+        .will_respond_with(
+          status: 404,
+        )
+
+      assert_raises(GdsApi::HTTPNotFound) do
+        @api_client.publish(@content_id, "major")
       end
     end
 
-    describe "if the update information contains a locale" do
-      before do
+    it "responds with 422 if the update information is invalid" do
+      publishing_api
+        .given("a draft content item exists with content_id: #{@content_id}")
+        .upon_receiving("an invalid publish request")
+        .with(
+          method: :post,
+          path: "/v2/content/#{@content_id}/publish",
+          body: {
+            "update_type" => "",
+          },
+          headers: GdsApi::JsonClient.default_request_with_json_body_headers.merge(
+            "Authorization" => "Bearer #{@bearer_token}",
+          ),
+        )
+        .will_respond_with(
+          status: 422,
+          body: {
+            "error" => {
+              "code" => 422,
+              "message" => Pact.term(generate: "Unprocessable entity", matcher: /\S+/),
+              "fields" => {
+                "update_type" => Pact.each_like("is required", min: 1),
+              },
+            },
+          },
+        )
+
+      assert_raises(GdsApi::HTTPUnprocessableEntity) do
+        @api_client.publish(@content_id, "")
+      end
+    end
+
+    it "responds with 409 if the content item is already published" do
+      publishing_api
+        .given("a published content item exists with content_id: #{@content_id}")
+        .upon_receiving("a publish request")
+        .with(
+          method: :post,
+          path: "/v2/content/#{@content_id}/publish",
+          body: {
+            update_type: "major",
+          },
+          headers: GdsApi::JsonClient.default_request_with_json_body_headers.merge(
+            "Authorization" => "Bearer #{@bearer_token}",
+          ),
+        )
+        .will_respond_with(
+          status: 409,
+          body: {
+            "error" => {
+              "code" => 409, "message" => Pact.term(generate: "Cannot publish an already published content item", matcher: /\S+/)
+            },
+          },
+        )
+
+      assert_raises(GdsApi::HTTPConflict) do
+        @api_client.publish(@content_id, "major")
+      end
+    end
+
+    it "responds with 200 if the update information contains a locale" do
+      publishing_api
+        .given("a draft content item exists with content_id: #{@content_id} and locale: fr")
+        .upon_receiving("a publish request")
+        .with(
+          method: :post,
+          path: "/v2/content/#{@content_id}/publish",
+          body: {
+            update_type: "major",
+            locale: "fr",
+          },
+          headers: GdsApi::JsonClient.default_request_with_json_body_headers.merge(
+            "Authorization" => "Bearer #{@bearer_token}",
+          ),
+        )
+        .will_respond_with(
+          status: 200,
+        )
+
+      @api_client.publish(@content_id, "major", locale: "fr")
+    end
+
+    describe "optimistic locking" do
+      it "responds with 200 OK if the content item has not changed since it was requested" do
         publishing_api
-          .given("a draft content item exists with content_id: #{@content_id} and locale: fr")
-          .upon_receiving("a publish request")
+          .given("the content item #{@content_id} is at version 3")
+          .upon_receiving("a publish request for version 3")
           .with(
             method: :post,
             path: "/v2/content/#{@content_id}/publish",
             body: {
-              update_type: "major",
-              locale: "fr",
+              update_type: "minor",
+              previous_version: 3,
             },
             headers: GdsApi::JsonClient.default_request_with_json_body_headers.merge(
               "Authorization" => "Bearer #{@bearer_token}",
@@ -973,490 +859,370 @@ describe GdsApi::PublishingApi do
           .will_respond_with(
             status: 200,
           )
+
+        @api_client.publish(@content_id, "minor", previous_version: 3)
       end
 
-      it "responds with 200 if the publish command succeeds" do
-        response = @api_client.publish(@content_id, "major", locale: "fr")
-        assert_equal 200, response.code
-      end
-    end
-
-    describe "optimistic locking" do
-      describe "if the content item has not changed since it was requested" do
-        before do
-          publishing_api
-            .given("the content item #{@content_id} is at version 3")
-            .upon_receiving("a publish request for version 3")
-            .with(
-              method: :post,
-              path: "/v2/content/#{@content_id}/publish",
-              body: {
-                update_type: "minor",
-                previous_version: 3,
-              },
-              headers: GdsApi::JsonClient.default_request_with_json_body_headers.merge(
-                "Authorization" => "Bearer #{@bearer_token}",
-              ),
-            )
-            .will_respond_with(
-              status: 200,
-            )
-        end
-
-        it "responds with 200 OK" do
-          response = @api_client.publish(@content_id, "minor", previous_version: 3)
-          assert_equal 200, response.code
-        end
-      end
-
-      describe "if the content item has changed in the meantime" do
-        before do
-          publishing_api
-            .given("the content item #{@content_id} is at version 3")
-            .upon_receiving("a publish request for version 2")
-            .with(
-              method: :post,
-              path: "/v2/content/#{@content_id}/publish",
-              body: {
-                update_type: "minor",
-                previous_version: 2,
-              },
-              headers: GdsApi::JsonClient.default_request_with_json_body_headers.merge(
-                "Authorization" => "Bearer #{@bearer_token}",
-              ),
-            )
-            .will_respond_with(
-              status: 409,
-              body: {
-                "error" => {
-                  "code" => 409,
-                  "message" => Pact.term(generate: "Conflict", matcher: /\S+/),
-                  "fields" => {
-                    "previous_version" => Pact.each_like("does not match", min: 1),
-                  },
+      it "responds with 409 Conflict if the content item has changed in the meantime" do
+        publishing_api
+          .given("the content item #{@content_id} is at version 3")
+          .upon_receiving("a publish request for version 2")
+          .with(
+            method: :post,
+            path: "/v2/content/#{@content_id}/publish",
+            body: {
+              update_type: "minor",
+              previous_version: 2,
+            },
+            headers: GdsApi::JsonClient.default_request_with_json_body_headers.merge(
+              "Authorization" => "Bearer #{@bearer_token}",
+            ),
+          )
+          .will_respond_with(
+            status: 409,
+            body: {
+              "error" => {
+                "code" => 409,
+                "message" => Pact.term(generate: "Conflict", matcher: /\S+/),
+                "fields" => {
+                  "previous_version" => Pact.each_like("does not match", min: 1),
                 },
               },
-              headers: {
-                "Content-Type" => "application/json; charset=utf-8",
-              },
-            )
-        end
+            },
+            headers: {
+              "Content-Type" => "application/json; charset=utf-8",
+            },
+          )
 
-        it "responds with 409 Conflict" do
-          error = assert_raises GdsApi::HTTPClientError do
-            @api_client.publish(@content_id, "minor", previous_version: 2)
-          end
-          assert_equal 409, error.code
-          assert_equal "Conflict", error.error_details["error"]["message"]
+        assert_raises(GdsApi::HTTPConflict) do
+          @api_client.publish(@content_id, "minor", previous_version: 2)
         end
       end
     end
   end
 
   describe "#unpublish" do
-    describe "if the unpublish command succeeds" do
-      before do
-        publishing_api
-          .given("a published content item exists with content_id: #{@content_id}")
-          .upon_receiving("an unpublish request")
-          .with(
-            method: :post,
-            path: "/v2/content/#{@content_id}/unpublish",
-            body: {
-              type: "gone",
-            },
-            headers: GdsApi::JsonClient.default_request_with_json_body_headers.merge(
-              "Authorization" => "Bearer #{@bearer_token}",
-            ),
-          )
-          .will_respond_with(
-            status: 200,
-          )
-      end
+    it "responds with 200 if the unpublish command succeeds" do
+      publishing_api
+        .given("a published content item exists with content_id: #{@content_id}")
+        .upon_receiving("an unpublish request")
+        .with(
+          method: :post,
+          path: "/v2/content/#{@content_id}/unpublish",
+          body: {
+            type: "gone",
+          },
+          headers: GdsApi::JsonClient.default_request_with_json_body_headers.merge(
+            "Authorization" => "Bearer #{@bearer_token}",
+          ),
+        )
+        .will_respond_with(
+          status: 200,
+        )
 
-      it "responds with 200" do
-        response = @api_client.unpublish(@content_id, type: "gone")
-        assert_equal 200, response.code
+      @api_client.unpublish(@content_id, type: "gone")
+    end
+
+    it "responds with 404 if the content item does not exist" do
+      publishing_api
+        .given("no content exists")
+        .upon_receiving("an unpublish request")
+        .with(
+          method: :post,
+          path: "/v2/content/#{@content_id}/unpublish",
+          body: {
+            type: "gone",
+          },
+          headers: GdsApi::JsonClient.default_request_with_json_body_headers.merge(
+            "Authorization" => "Bearer #{@bearer_token}",
+          ),
+        )
+        .will_respond_with(
+          status: 404,
+        )
+
+      assert_raises(GdsApi::HTTPNotFound) do
+        @api_client.unpublish(@content_id, type: "gone")
       end
     end
 
-    describe "if the content item does not exist" do
-      before do
-        publishing_api
-          .given("no content exists")
-          .upon_receiving("an unpublish request")
-          .with(
-            method: :post,
-            path: "/v2/content/#{@content_id}/unpublish",
-            body: {
-              type: "gone",
+    it "responds with 422 if the type is incorrect" do
+      publishing_api
+        .given("a published content item exists with content_id: #{@content_id}")
+        .upon_receiving("an invalid unpublish request")
+        .with(
+          method: :post,
+          path: "/v2/content/#{@content_id}/unpublish",
+          body: {
+            type: "not-a-valid-type",
+          },
+          headers: GdsApi::JsonClient.default_request_with_json_body_headers.merge(
+            "Authorization" => "Bearer #{@bearer_token}",
+          ),
+        )
+        .will_respond_with(
+          status: 422,
+          body: {
+            "error" => {
+              "code" => 422,
+              "message" => Pact.term(generate: "not-a-valid-type is not a valid unpublishing type", matcher: /\S+/),
+              "fields" => {},
             },
-            headers: GdsApi::JsonClient.default_request_with_json_body_headers.merge(
-              "Authorization" => "Bearer #{@bearer_token}",
-            ),
-          )
-          .will_respond_with(
-            status: 404,
-          )
-      end
+          },
+        )
 
-      it "responds with 404" do
-        error = assert_raises GdsApi::HTTPClientError do
-          @api_client.unpublish(@content_id, type: "gone")
-        end
-
-        assert_equal 404, error.code
+      assert_raises(GdsApi::HTTPUnprocessableEntity) do
+        @api_client.unpublish(@content_id, type: "not-a-valid-type")
       end
     end
 
-    describe "if the type is incorrect" do
-      before do
-        publishing_api
-          .given("a published content item exists with content_id: #{@content_id}")
-          .upon_receiving("an invalid unpublish request")
-          .with(
-            method: :post,
-            path: "/v2/content/#{@content_id}/unpublish",
-            body: {
-              type: "not-a-valid-type",
-            },
-            headers: GdsApi::JsonClient.default_request_with_json_body_headers.merge(
-              "Authorization" => "Bearer #{@bearer_token}",
-            ),
-          )
-          .will_respond_with(
-            status: 422,
-            body: {
-              "error" => {
-                "code" => 422,
-                "message" => Pact.term(generate: "not-a-valid-type is not a valid unpublishing type", matcher: /\S+/),
-                "fields" => {},
-              },
-            },
-          )
-      end
+    it "responds with 200 and updates the unpublishing if the content item is already unpublished" do
+      publishing_api
+        .given("an unpublished content item exists with content_id: #{@content_id}")
+        .upon_receiving("an unpublish request")
+        .with(
+          method: :post,
+          path: "/v2/content/#{@content_id}/unpublish",
+          body: {
+            type: "gone",
+          },
+          headers: GdsApi::JsonClient.default_request_with_json_body_headers.merge(
+            "Authorization" => "Bearer #{@bearer_token}",
+          ),
+        )
+        .will_respond_with(
+          status: 200,
+        )
 
-      it "responds with 422" do
-        error = assert_raises GdsApi::HTTPUnprocessableEntity do
-          @api_client.unpublish(@content_id, type: "not-a-valid-type")
-        end
-
-        assert_equal 422, error.code
-        assert_equal "not-a-valid-type is not a valid unpublishing type", error.error_details["error"]["message"]
-      end
-    end
-
-    describe "if the content item is already unpublished" do
-      before do
-        publishing_api
-          .given("an unpublished content item exists with content_id: #{@content_id}")
-          .upon_receiving("an unpublish request")
-          .with(
-            method: :post,
-            path: "/v2/content/#{@content_id}/unpublish",
-            body: {
-              type: "gone",
-            },
-            headers: GdsApi::JsonClient.default_request_with_json_body_headers.merge(
-              "Authorization" => "Bearer #{@bearer_token}",
-            ),
-          )
-          .will_respond_with(
-            status: 200,
-          )
-      end
-
-      it "responds with 200 and updates the unpublishing" do
-        response = @api_client.unpublish(@content_id, type: "gone")
-        assert_equal 200, response.code
-      end
+      @api_client.unpublish(@content_id, type: "gone")
     end
 
     describe "optimistic locking" do
-      describe "if the content item has not changed since it was requested" do
-        before do
-          publishing_api
-            .given("the published content item #{@content_id} is at version 3")
-            .upon_receiving("an unpublish request for version 3")
-            .with(
-              method: :post,
-              path: "/v2/content/#{@content_id}/unpublish",
-              body: {
-                type: "gone",
-                previous_version: 3,
-              },
-              headers: GdsApi::JsonClient.default_request_with_json_body_headers.merge(
-                "Authorization" => "Bearer #{@bearer_token}",
-              ),
-            )
-            .will_respond_with(
-              status: 200,
-            )
-        end
+      it "responds with 200 OK if the content item has not changed since it was requested" do
+        publishing_api
+          .given("the published content item #{@content_id} is at version 3")
+          .upon_receiving("an unpublish request for version 3")
+          .with(
+            method: :post,
+            path: "/v2/content/#{@content_id}/unpublish",
+            body: {
+              type: "gone",
+              previous_version: 3,
+            },
+            headers: GdsApi::JsonClient.default_request_with_json_body_headers.merge(
+              "Authorization" => "Bearer #{@bearer_token}",
+            ),
+          )
+          .will_respond_with(
+            status: 200,
+          )
 
-        it "responds with 200 OK" do
-          response = @api_client.unpublish(@content_id, type: "gone", previous_version: 3)
-          assert_equal 200, response.code
-        end
+        @api_client.unpublish(@content_id, type: "gone", previous_version: 3)
       end
 
-      describe "if the content item has changed in the meantime" do
-        before do
-          publishing_api
-            .given("the published content item #{@content_id} is at version 3")
-            .upon_receiving("an unpublish request for version 2")
-            .with(
-              method: :post,
-              path: "/v2/content/#{@content_id}/unpublish",
-              body: {
-                type: "gone",
-                previous_version: 2,
-              },
-              headers: GdsApi::JsonClient.default_request_with_json_body_headers.merge(
-                "Authorization" => "Bearer #{@bearer_token}",
-              ),
-            )
-            .will_respond_with(
-              status: 409,
-              body: {
-                "error" => {
-                  "code" => 409,
-                  "message" => Pact.term(generate: "Conflict", matcher: /\S+/),
-                  "fields" => {
-                    "previous_version" => Pact.each_like("does not match", min: 1),
-                  },
+      it "responds with 409 Conflict if the content item has changed in the meantime" do
+        publishing_api
+          .given("the published content item #{@content_id} is at version 3")
+          .upon_receiving("an unpublish request for version 2")
+          .with(
+            method: :post,
+            path: "/v2/content/#{@content_id}/unpublish",
+            body: {
+              type: "gone",
+              previous_version: 2,
+            },
+            headers: GdsApi::JsonClient.default_request_with_json_body_headers.merge(
+              "Authorization" => "Bearer #{@bearer_token}",
+            ),
+          )
+          .will_respond_with(
+            status: 409,
+            body: {
+              "error" => {
+                "code" => 409,
+                "message" => Pact.term(generate: "Conflict", matcher: /\S+/),
+                "fields" => {
+                  "previous_version" => Pact.each_like("does not match", min: 1),
                 },
               },
-              headers: {
-                "Content-Type" => "application/json; charset=utf-8",
-              },
-            )
-        end
+            },
+            headers: {
+              "Content-Type" => "application/json; charset=utf-8",
+            },
+          )
 
-        it "responds with 409 Conflict" do
-          error = assert_raises GdsApi::HTTPClientError do
-            @api_client.unpublish(@content_id, type: "gone", previous_version: 2)
-          end
-          assert_equal 409, error.code
-          assert_equal "Conflict", error.error_details["error"]["message"]
+        assert_raises(GdsApi::HTTPConflict) do
+          @api_client.unpublish(@content_id, type: "gone", previous_version: 2)
         end
       end
     end
   end
 
   describe "#patch_links" do
-    describe "when setting links of the same type" do
-      before do
-        publishing_api
-          .given("organisation links exist for content_id #{@content_id}")
-          .upon_receiving("a patch organisation links request")
-          .with(
-            method: :patch,
-            path: "/v2/links/#{@content_id}",
-            body: {
-              links: {
-                organisations: %w[591436ab-c2ae-416f-a3c5-1901d633fbfb],
-              },
-            },
-            headers: {
-              "Content-Type" => "application/json",
-            },
-          )
-          .will_respond_with(
-            status: 200,
-            body: {
-              links: {
-                organisations: %w[591436ab-c2ae-416f-a3c5-1901d633fbfb],
-              },
-            },
-          )
-      end
-
-      it "replaces the links and responds with the new links" do
-        response = @api_client.patch_links(
-          @content_id,
-          links: {
-            organisations: %w[591436ab-c2ae-416f-a3c5-1901d633fbfb],
-          },
-        )
-        assert_equal 200, response.code
-        assert_equal(
-          %w[591436ab-c2ae-416f-a3c5-1901d633fbfb],
-          response["links"]["organisations"],
-        )
-      end
-    end
-
-    describe "when setting links of a different type" do
-      before do
-        publishing_api
-          .given("organisation links exist for content_id #{@content_id}")
-          .upon_receiving("a patch topic links request")
-          .with(
-            method: :patch,
-            path: "/v2/links/#{@content_id}",
-            body: {
-              links: {
-                topics: %w[225df4a8-2945-4e9b-8799-df7424a90b69],
-              },
-            },
-            headers: {
-              "Content-Type" => "application/json",
-            },
-          )
-          .will_respond_with(
-            status: 200,
-            body: {
-              links: {
-                topics: %w[225df4a8-2945-4e9b-8799-df7424a90b69],
-                organisations: %w[20583132-1619-4c68-af24-77583172c070],
-              },
-            },
-          )
-      end
-
-      it "adds the new type of links and responds with the whole link set" do
-        response = @api_client.patch_links(
-          @content_id,
-          links: {
-            topics: %w[225df4a8-2945-4e9b-8799-df7424a90b69],
-          },
-        )
-
-        assert_equal 200, response.code
-        assert_equal(
-          {
-            "topics" => %w[225df4a8-2945-4e9b-8799-df7424a90b69],
-            "organisations" => %w[20583132-1619-4c68-af24-77583172c070],
-          },
-          response["links"],
-        )
-      end
-    end
-
-    describe "when deleting links of a specific type" do
-      before do
-        publishing_api
-          .given("organisation links exist for content_id #{@content_id}")
-          .upon_receiving("a patch blank organisation links request")
-          .with(
-            method: :patch,
-            path: "/v2/links/#{@content_id}",
-            body: {
-              links: {
-                organisations: [],
-              },
-            },
-            headers: {
-              "Content-Type" => "application/json",
-            },
-          )
-          .will_respond_with(
-            status: 200,
-            body: {
-              links: {},
-            },
-          )
-      end
-
-      it "responds with the links" do
-        response = @api_client.patch_links(
-          @content_id,
-          links: {
-            organisations: [],
-          },
-        )
-
-        assert_equal 200, response.code
-        assert_equal({}, response["links"])
-      end
-    end
-
-    describe "when there's no links entry" do
-      before do
-        publishing_api
-          .given("no links exist for content_id #{@content_id}")
-          .upon_receiving("a patch organisation links request")
-          .with(
-            method: :patch,
-            path: "/v2/links/#{@content_id}",
-            body: {
-              links: {
-                organisations: %w[591436ab-c2ae-416f-a3c5-1901d633fbfb],
-              },
-            },
-            headers: {
-              "Content-Type" => "application/json",
-            },
-          )
-          .will_respond_with(
-            status: 200,
-            body: {
-              links: {
-                organisations: %w[591436ab-c2ae-416f-a3c5-1901d633fbfb],
-              },
-            },
-          )
-      end
-
-      it "responds with the links" do
-        response = @api_client.patch_links(
-          @content_id,
-          links: {
-            organisations: %w[591436ab-c2ae-416f-a3c5-1901d633fbfb],
-          },
-        )
-
-        assert_equal 200, response.code
-        assert_equal(
-          {
-            "organisations" => %w[591436ab-c2ae-416f-a3c5-1901d633fbfb],
-          },
-          response["links"],
-        )
-      end
-    end
-
-    describe "optimistic locking" do
-      describe "if the linkset has not changed since it was requested" do
-        before do
-          publishing_api
-            .given("the linkset for #{@content_id} is at version 3")
-            .upon_receiving("a request to update the linkset at version 3")
-            .with(
-              method: :patch,
-              path: "/v2/links/#{@content_id}",
-              body: {
-                links: {
-                  organisations: %w[591436ab-c2ae-416f-a3c5-1901d633fbfb],
-                },
-                previous_version: 3,
-              },
-              headers: {
-                "Content-Type" => "application/json",
-              },
-            )
-            .will_respond_with(
-              status: 200,
-            )
-        end
-
-        it "responds with 200 OK" do
-          response = @api_client.patch_links(
-            @content_id,
+    it "replaces the links and responds with the new links when setting links of the same type" do
+      publishing_api
+        .given("organisation links exist for content_id #{@content_id}")
+        .upon_receiving("a patch organisation links request")
+        .with(
+          method: :patch,
+          path: "/v2/links/#{@content_id}",
+          body: {
             links: {
               organisations: %w[591436ab-c2ae-416f-a3c5-1901d633fbfb],
             },
-            previous_version: 3,
+          },
+          headers: {
+            "Content-Type" => "application/json",
+          },
+        )
+        .will_respond_with(
+          status: 200,
+          body: {
+            links: {
+              organisations: %w[591436ab-c2ae-416f-a3c5-1901d633fbfb],
+            },
+          },
+        )
+
+      @api_client.patch_links(
+        @content_id,
+        links: {
+          organisations: %w[591436ab-c2ae-416f-a3c5-1901d633fbfb],
+        },
+      )
+    end
+
+    it "adds the new type of links and responds with the whole link set when setting links of a different type" do
+      publishing_api
+        .given("organisation links exist for content_id #{@content_id}")
+        .upon_receiving("a patch topic links request")
+        .with(
+          method: :patch,
+          path: "/v2/links/#{@content_id}",
+          body: {
+            links: {
+              topics: %w[225df4a8-2945-4e9b-8799-df7424a90b69],
+            },
+          },
+          headers: {
+            "Content-Type" => "application/json",
+          },
+        )
+        .will_respond_with(
+          status: 200,
+          body: {
+            links: {
+              topics: %w[225df4a8-2945-4e9b-8799-df7424a90b69],
+              organisations: %w[20583132-1619-4c68-af24-77583172c070],
+            },
+          },
+        )
+
+      @api_client.patch_links(
+        @content_id,
+        links: {
+          topics: %w[225df4a8-2945-4e9b-8799-df7424a90b69],
+        },
+      )
+    end
+
+    it "responds with the links when deleting links of a specific type" do
+      publishing_api
+        .given("organisation links exist for content_id #{@content_id}")
+        .upon_receiving("a patch blank organisation links request")
+        .with(
+          method: :patch,
+          path: "/v2/links/#{@content_id}",
+          body: {
+            links: {
+              organisations: [],
+            },
+          },
+          headers: {
+            "Content-Type" => "application/json",
+          },
+        )
+        .will_respond_with(
+          status: 200,
+          body: {
+            links: {},
+          },
+        )
+
+      @api_client.patch_links(
+        @content_id,
+        links: {
+          organisations: [],
+        },
+      )
+    end
+
+    it "responds with the links when there's no links entry" do
+      publishing_api
+        .given("no links exist for content_id #{@content_id}")
+        .upon_receiving("a patch organisation links request")
+        .with(
+          method: :patch,
+          path: "/v2/links/#{@content_id}",
+          body: {
+            links: {
+              organisations: %w[591436ab-c2ae-416f-a3c5-1901d633fbfb],
+            },
+          },
+          headers: {
+            "Content-Type" => "application/json",
+          },
+        )
+        .will_respond_with(
+          status: 200,
+          body: {
+            links: {
+              organisations: %w[591436ab-c2ae-416f-a3c5-1901d633fbfb],
+            },
+          },
+        )
+
+      @api_client.patch_links(
+        @content_id,
+        links: {
+          organisations: %w[591436ab-c2ae-416f-a3c5-1901d633fbfb],
+        },
+      )
+    end
+
+    describe "optimistic locking" do
+      it "responds with 200 OK if the linkset has not changed since it was requested" do
+        publishing_api
+          .given("the linkset for #{@content_id} is at version 3")
+          .upon_receiving("a request to update the linkset at version 3")
+          .with(
+            method: :patch,
+            path: "/v2/links/#{@content_id}",
+            body: {
+              links: {
+                organisations: %w[591436ab-c2ae-416f-a3c5-1901d633fbfb],
+              },
+              previous_version: 3,
+            },
+            headers: {
+              "Content-Type" => "application/json",
+            },
+          )
+          .will_respond_with(
+            status: 200,
           )
 
-          assert_equal 200, response.code
-        end
+        @api_client.patch_links(
+          @content_id,
+          links: {
+            organisations: %w[591436ab-c2ae-416f-a3c5-1901d633fbfb],
+          },
+          previous_version: 3,
+        )
       end
 
-      describe "if the content item has changed in the meantime" do
-        before do
-          publishing_api
+      it "responds with 409 Conflict if the content item has changed in the meantime" do
+        publishing_api
             .given("the linkset for #{@content_id} is at version 3")
             .upon_receiving("a request to update the linkset at version 2")
             .with(
@@ -1487,474 +1253,394 @@ describe GdsApi::PublishingApi do
                 "Content-Type" => "application/json; charset=utf-8",
               },
             )
-        end
 
-        it "responds with 409 Conflict" do
-          error = assert_raises GdsApi::HTTPClientError do
-            @api_client.patch_links(
-              @content_id,
-              links: {
-                organisations: %w[591436ab-c2ae-416f-a3c5-1901d633fbfb],
-              },
-              previous_version: 2,
-            )
-          end
-
-          assert_equal 409, error.code
-          assert_equal "Conflict", error.error_details["error"]["message"]
+        assert_raises(GdsApi::HTTPConflict) do
+          @api_client.patch_links(
+            @content_id,
+            links: {
+              organisations: %w[591436ab-c2ae-416f-a3c5-1901d633fbfb],
+            },
+            previous_version: 2,
+          )
         end
       end
     end
-  end
 
-  describe "#get_linkables" do
-    let(:linkables) do
-      [
-        {
-          "title" => "Content Item A",
-          "internal_name" => "an internal name",
-          "content_id" => "aaaaaaaa-aaaa-1aaa-aaaa-aaaaaaaaaaaa",
-          "publication_state" => "draft",
-          "base_path" => "/a-base-path",
-        },
-        {
-          "title" => "Content Item B",
-          "internal_name" => "Content Item B",
-          "content_id" => "bbbbbbbb-bbbb-2bbb-bbbb-bbbbbbbbbbbb",
-          "publication_state" => "published",
-          "base_path" => "/another-base-path",
-        },
-      ]
-    end
-
-    it "returns the content items of a given document_type" do
-      publishing_api
-        .given("there is content with document_type 'topic'")
-        .upon_receiving("a get linkables request")
-        .with(
-          method: :get,
-          path: "/v2/linkables",
-          query: "document_type=topic",
-          headers: GdsApi::JsonClient.default_request_headers.merge(
-            "Authorization" => "Bearer #{@bearer_token}",
-          ),
-        )
-        .will_respond_with(
-          status: 200,
-          body: linkables,
-        )
-
-      response = @api_client.get_linkables(document_type: "topic")
-      assert_equal 200, response.code
-      assert_equal linkables, response.to_a
-    end
-  end
-
-  describe "#get_links_changes" do
-    let(:link_changes) do
-      { "link_changes" => [
-        {
-          "source" => { "title" => "Edition Title A1",
-                        "base_path" => "/base/path/a1",
-                        "content_id" => "aaaaaaaa-aaaa-1aaa-aaaa-aaaaaaaaaaaa" },
-          "target" => { "title" => "Edition Title B1",
-                        "base_path" => "/base/path/b1",
-                        "content_id" => "bbbbbbbb-bbbb-1bbb-bbbb-bbbbbbbbbbbb" },
-          "link_type" => "taxons",
-          "change" => "add",
-          "user_uid" => "11111111-1111-1111-1111-111111111111",
-          "created_at" => "2017-01-01T09:00:00.100Z",
-        },
-        {
-          "source" => { "title" => "Edition Title A2",
-                        "base_path" => "/base/path/a2",
-                        "content_id" => "aaaaaaaa-aaaa-2aaa-aaaa-aaaaaaaaaaaa" },
-          "target" => { "title" => "Edition Title B2",
-                        "base_path" => "/base/path/b2",
-                        "content_id" => "bbbbbbbb-bbbb-2bbb-bbbb-bbbbbbbbbbbb" },
-          "link_type" => "taxons",
-          "change" => "remove",
-          "user_uid" => "22222222-2222-2222-2222-222222222222",
-          "created_at" => "2017-01-01T09:00:00.100Z",
-        },
-      ] }
-    end
-
-    it "returns the changes for a single link_type" do
-      publishing_api
-        .given("there are two link changes with a link_type of 'taxons'")
-        .upon_receiving("a get links changes request for changes with a link_type of 'taxons'")
-        .with(
-          method: :get,
-          path: "/v2/links/changes",
-          query: "link_types%5B%5D=taxons",
-          headers: GdsApi::JsonClient.default_request_headers.merge(
-            "Authorization" => "Bearer #{@bearer_token}",
-          ),
-        )
-        .will_respond_with(
-          status: 200,
-          body: link_changes,
-        )
-
-      response = @api_client.get_links_changes(link_types: %w[taxons])
-      assert_equal 200, response.code
-      assert_equal link_changes, response.to_hash
-    end
-  end
-
-  describe "#get_paged_content_items" do
-    it "returns two content items" do
-      publishing_api
-        .given("there are four content items with document_type 'topic'")
-        .upon_receiving("get the first page request")
-        .with(
-          method: :get,
-          path: "/v2/content",
-          query: "document_type=topic&fields%5B%5D=title&fields%5B%5D=base_path&page=1&per_page=2",
-          headers: GdsApi::JsonClient.default_request_headers.merge(
-            "Authorization" => "Bearer #{@bearer_token}",
-          ),
-        )
-        .will_respond_with(
-          status: 200,
-          body: {
-            total: 4,
-            pages: 2,
-            current_page: 1,
-            links: [{ href: "http://example.org/v2/content?document_type=topic&fields%5B%5D=title&fields%5B%5D=base_path&per_page=2&page=2",
-                      rel: "next" },
-                    { href: "http://example.org/v2/content?document_type=topic&fields%5B%5D=title&fields%5B%5D=base_path&per_page=2&page=1",
-                      rel: "self" }],
-            results: [
-              { title: "title_1", base_path: "/path_1" },
-              { title: "title_2", base_path: "/path_2" },
-            ],
-          },
-        )
-      publishing_api
-        .given("there are four content items with document_type 'topic'")
-        .upon_receiving("get the second page request")
-        .with(
-          method: :get,
-          path: "/v2/content",
-          query: "document_type=topic&fields%5B%5D=title&fields%5B%5D=base_path&page=2&per_page=2",
-          headers: GdsApi::JsonClient.default_request_headers.merge(
-            "Authorization" => "Bearer #{@bearer_token}",
-          ),
-        )
-        .will_respond_with(
-          status: 200,
-          body: {
-            total: 4,
-            pages: 2,
-            current_page: 2,
-            links: [{ href: "http://example.org/v2/content?document_type=topic&fields%5B%5D=title&fields%5B%5D=base_path&per_page=2&page=1",
-                      rel: "previous" },
-                    { href: "http://example.org/v2/content?document_type=topic&fields%5B%5D=title&fields%5B%5D=base_path&per_page=2&page=2",
-                      rel: "self" }],
-            results: [
-              { title: "title_3", base_path: "/path_3" },
-              { title: "title_4", base_path: "/path_4" },
-            ],
-          },
-        )
-      assert_equal(
-        @api_client.get_content_items_enum(document_type: "topic", fields: %i[title base_path], per_page: 2).to_a,
+    describe "#get_linkables" do
+      let(:linkables) do
         [
-          { "title" => "title_1", "base_path" => "/path_1" },
-          { "title" => "title_2", "base_path" => "/path_2" },
-          { "title" => "title_3", "base_path" => "/path_3" },
-          { "title" => "title_4", "base_path" => "/path_4" },
-        ],
-      )
-    end
-  end
-
-  describe "#get_content_items" do
-    it "returns the content items of a certain document_type" do
-      publishing_api
-        .given("there is content with document_type 'topic'")
-        .upon_receiving("a get entries request")
-        .with(
-          method: :get,
-          path: "/v2/content",
-          query: "document_type=topic&fields%5B%5D=title&fields%5B%5D=base_path",
-          headers: GdsApi::JsonClient.default_request_headers.merge(
-            "Authorization" => "Bearer #{@bearer_token}",
-          ),
-        )
-        .will_respond_with(
-          status: 200,
-          body: {
-            total: 2,
-            pages: 1,
-            current_page: 1,
-            links: [{
-              href: "http://example.org/v2/content?document_type=topic&fields%5B%5D=title&fields%5B%5D=base_path&page=1",
-              rel: "self",
-            }],
-            results: [
-              { title: "Content Item A", base_path: "/a-base-path" },
-              { title: "Content Item B", base_path: "/another-base-path" },
-            ],
+          {
+            "title" => "Content Item A",
+            "internal_name" => "an internal name",
+            "content_id" => "aaaaaaaa-aaaa-1aaa-aaaa-aaaaaaaaaaaa",
+            "publication_state" => "draft",
+            "base_path" => "/a-base-path",
           },
-        )
-
-      response = @api_client.get_content_items(
-        document_type: "topic",
-        fields: %i[title base_path],
-      )
-
-      assert_equal 200, response.code
-
-      assert_equal [
-        ["total", 2],
-        ["pages", 1],
-        ["current_page", 1],
-        ["links", [{ "href" => "http://example.org/v2/content?document_type=topic&fields%5B%5D=title&fields%5B%5D=base_path&page=1", "rel" => "self" }]],
-        ["results", [{ "title" => "Content Item A", "base_path" => "/a-base-path" }, { "title" => "Content Item B", "base_path" => "/another-base-path" }]],
-      ],
-                   response.to_a
-    end
-
-    it "returns the content items in english locale by default" do
-      publishing_api
-        .given("a content item exists in multiple locales with content_id: #{@content_id}")
-        .upon_receiving("a get entries request")
-        .with(
-          method: :get,
-          path: "/v2/content",
-          query: "document_type=topic&fields%5B%5D=content_id&fields%5B%5D=locale",
-          headers: GdsApi::JsonClient.default_request_headers.merge(
-            "Authorization" => "Bearer #{@bearer_token}",
-          ),
-        )
-        .will_respond_with(
-          status: 200,
-          body: {
-            total: 1,
-            pages: 1,
-            current_page: 1,
-            links: [{
-              href: "http://example.org/v2/content?document_type=topic&fields%5B%5D=content_id&fields%5B%5D=locale&page=1",
-              rel: "self",
-            }],
-            results: [
-              { content_id: @content_id, locale: "en" },
-            ],
+          {
+            "title" => "Content Item B",
+            "internal_name" => "Content Item B",
+            "content_id" => "bbbbbbbb-bbbb-2bbb-bbbb-bbbbbbbbbbbb",
+            "publication_state" => "published",
+            "base_path" => "/another-base-path",
           },
-        )
+        ]
+      end
 
-      response = @api_client.get_content_items(
-        document_type: "topic",
-        fields: %i[content_id locale],
-      )
+      it "returns the content items of a given document_type" do
+        publishing_api
+          .given("there is content with document_type 'topic'")
+          .upon_receiving("a get linkables request")
+          .with(
+            method: :get,
+            path: "/v2/linkables",
+            query: "document_type=topic",
+            headers: GdsApi::JsonClient.default_request_headers.merge(
+              "Authorization" => "Bearer #{@bearer_token}",
+            ),
+          )
+          .will_respond_with(
+            status: 200,
+            body: linkables,
+          )
 
-      assert_equal 200, response.code
-
-      assert_equal [
-        ["total", 1],
-        ["pages", 1],
-        ["current_page", 1],
-        ["links", [{ "href" => "http://example.org/v2/content?document_type=topic&fields%5B%5D=content_id&fields%5B%5D=locale&page=1", "rel" => "self" }]],
-        ["results", [{ "content_id" => "bed722e6-db68-43e5-9079-063f623335a7", "locale" => "en" }]],
-      ],
-                   response.to_a
+        @api_client.get_linkables(document_type: "topic")
+      end
     end
 
-    it "returns the content items in a specific locale" do
-      publishing_api
-        .given("a content item exists in multiple locales with content_id: #{@content_id}")
-        .upon_receiving("a get entries request with a specific locale")
-        .with(
-          method: :get,
-          path: "/v2/content",
-          query: "document_type=topic&fields%5B%5D=content_id&fields%5B%5D=locale&locale=fr",
-          headers: GdsApi::JsonClient.default_request_headers.merge(
-            "Authorization" => "Bearer #{@bearer_token}",
-          ),
-        )
-        .will_respond_with(
-          status: 200,
-          body: {
-            total: 1,
-            pages: 1,
-            current_page: 1,
-            links: [{
-              href: "http://example.org/v2/content?document_type=topic&fields%5B%5D=content_id&fields%5B%5D=locale&locale=fr&page=1",
-              rel: "self",
-            }],
-            results: [
-              { content_id: @content_id, locale: "fr" },
-            ],
+    describe "#get_links_changes" do
+      let(:link_changes) do
+        { "link_changes" => [
+          {
+            "source" => { "title" => "Edition Title A1",
+                          "base_path" => "/base/path/a1",
+                          "content_id" => "aaaaaaaa-aaaa-1aaa-aaaa-aaaaaaaaaaaa" },
+            "target" => { "title" => "Edition Title B1",
+                          "base_path" => "/base/path/b1",
+                          "content_id" => "bbbbbbbb-bbbb-1bbb-bbbb-bbbbbbbbbbbb" },
+            "link_type" => "taxons",
+            "change" => "add",
+            "user_uid" => "11111111-1111-1111-1111-111111111111",
+            "created_at" => "2017-01-01T09:00:00.100Z",
           },
-        )
-
-      response = @api_client.get_content_items(
-        document_type: "topic",
-        fields: %i[content_id locale],
-        locale: "fr",
-      )
-
-      assert_equal 200, response.code
-      assert_equal [
-        ["total", 1],
-        ["pages", 1],
-        ["current_page", 1],
-        ["links", [{ "href" => "http://example.org/v2/content?document_type=topic&fields%5B%5D=content_id&fields%5B%5D=locale&locale=fr&page=1", "rel" => "self" }]],
-        ["results", [{ "content_id" => "bed722e6-db68-43e5-9079-063f623335a7", "locale" => "fr" }]],
-      ],
-                   response.to_a
-    end
-
-    it "returns the content items in all the available locales" do
-      publishing_api
-        .given("a content item exists in multiple locales with content_id: #{@content_id}")
-        .upon_receiving("a get entries request with an 'all' locale")
-        .with(
-          method: :get,
-          path: "/v2/content",
-          query: "document_type=topic&fields%5B%5D=content_id&fields%5B%5D=locale&locale=all",
-          headers: GdsApi::JsonClient.default_request_headers.merge(
-            "Authorization" => "Bearer #{@bearer_token}",
-          ),
-        )
-        .will_respond_with(
-          status: 200,
-          body: {
-            total: 3,
-            pages: 1,
-            current_page: 1,
-            links: [{
-              href: "http://example.org/v2/content?document_type=topic&fields%5B%5D=content_id&fields%5B%5D=locale&locale=all&page=1",
-              rel: "self",
-            }],
-            results: [
-              { content_id: @content_id, locale: "en" },
-              { content_id: @content_id, locale: "fr" },
-              { content_id: @content_id, locale: "ar" },
-            ],
+          {
+            "source" => { "title" => "Edition Title A2",
+                          "base_path" => "/base/path/a2",
+                          "content_id" => "aaaaaaaa-aaaa-2aaa-aaaa-aaaaaaaaaaaa" },
+            "target" => { "title" => "Edition Title B2",
+                          "base_path" => "/base/path/b2",
+                          "content_id" => "bbbbbbbb-bbbb-2bbb-bbbb-bbbbbbbbbbbb" },
+            "link_type" => "taxons",
+            "change" => "remove",
+            "user_uid" => "22222222-2222-2222-2222-222222222222",
+            "created_at" => "2017-01-01T09:00:00.100Z",
           },
-        )
+        ] }
+      end
 
-      response = @api_client.get_content_items(
-        document_type: "topic",
-        fields: %i[content_id locale],
-        locale: "all",
-      )
+      it "returns the changes for a single link_type" do
+        publishing_api
+          .given("there are two link changes with a link_type of 'taxons'")
+          .upon_receiving("a get links changes request for changes with a link_type of 'taxons'")
+          .with(
+            method: :get,
+            path: "/v2/links/changes",
+            query: "link_types%5B%5D=taxons",
+            headers: GdsApi::JsonClient.default_request_headers.merge(
+              "Authorization" => "Bearer #{@bearer_token}",
+            ),
+          )
+          .will_respond_with(
+            status: 200,
+            body: link_changes,
+          )
 
-      assert_equal 200, response.code
-      assert_equal [
-        ["total", 3],
-        ["pages", 1],
-        ["current_page", 1],
-        ["links",
-         [{ "href" => "http://example.org/v2/content?document_type=topic&fields%5B%5D=content_id&fields%5B%5D=locale&locale=all&page=1", "rel" => "self" }]],
-        ["results",
-         [{ "content_id" => "bed722e6-db68-43e5-9079-063f623335a7", "locale" => "en" },
-          { "content_id" => "bed722e6-db68-43e5-9079-063f623335a7", "locale" => "fr" },
-          { "content_id" => "bed722e6-db68-43e5-9079-063f623335a7", "locale" => "ar" }]],
-      ],
-                   response.to_a
+        @api_client.get_links_changes(link_types: %w[taxons])
+      end
     end
 
-    it "returns details hashes" do
-      publishing_api
-        .given("a content item exists with content_id: #{@content_id} and it has details")
-        .upon_receiving("a get entries request with details field")
-        .with(
-          method: :get,
-          path: "/v2/content",
-          query: "document_type=topic&fields%5B%5D=content_id&fields%5B%5D=details",
-          headers: GdsApi::JsonClient.default_request_headers.merge(
-            "Authorization" => "Bearer #{@bearer_token}",
-          ),
+    describe "#get_paged_content_items" do
+      it "returns two content items" do
+        publishing_api
+          .given("there are four content items with document_type 'topic'")
+          .upon_receiving("get the first page request")
+          .with(
+            method: :get,
+            path: "/v2/content",
+            query: "document_type=topic&fields%5B%5D=title&fields%5B%5D=base_path&page=1&per_page=2",
+            headers: GdsApi::JsonClient.default_request_headers.merge(
+              "Authorization" => "Bearer #{@bearer_token}",
+            ),
+          )
+          .will_respond_with(
+            status: 200,
+            body: {
+              total: 4,
+              pages: 2,
+              current_page: 1,
+              links: [{ href: "http://example.org/v2/content?document_type=topic&fields%5B%5D=title&fields%5B%5D=base_path&per_page=2&page=2",
+                        rel: "next" },
+                      { href: "http://example.org/v2/content?document_type=topic&fields%5B%5D=title&fields%5B%5D=base_path&per_page=2&page=1",
+                        rel: "self" }],
+              results: [
+                { title: "title_1", base_path: "/path_1" },
+                { title: "title_2", base_path: "/path_2" },
+              ],
+            },
+          )
+        publishing_api
+          .given("there are four content items with document_type 'topic'")
+          .upon_receiving("get the second page request")
+          .with(
+            method: :get,
+            path: "/v2/content",
+            query: "document_type=topic&fields%5B%5D=title&fields%5B%5D=base_path&page=2&per_page=2",
+            headers: GdsApi::JsonClient.default_request_headers.merge(
+              "Authorization" => "Bearer #{@bearer_token}",
+            ),
+          )
+          .will_respond_with(
+            status: 200,
+            body: {
+              total: 4,
+              pages: 2,
+              current_page: 2,
+              links: [{ href: "http://example.org/v2/content?document_type=topic&fields%5B%5D=title&fields%5B%5D=base_path&per_page=2&page=1",
+                        rel: "previous" },
+                      { href: "http://example.org/v2/content?document_type=topic&fields%5B%5D=title&fields%5B%5D=base_path&per_page=2&page=2",
+                        rel: "self" }],
+              results: [
+                { title: "title_3", base_path: "/path_3" },
+                { title: "title_4", base_path: "/path_4" },
+              ],
+            },
+          )
+        assert_equal(
+          @api_client.get_content_items_enum(document_type: "topic", fields: %i[title base_path], per_page: 2).to_a,
+          [
+            { "title" => "title_1", "base_path" => "/path_1" },
+            { "title" => "title_2", "base_path" => "/path_2" },
+            { "title" => "title_3", "base_path" => "/path_3" },
+            { "title" => "title_4", "base_path" => "/path_4" },
+          ],
         )
-        .will_respond_with(
-          status: 200,
-          body: {
-            total: 1,
-            pages: 1,
-            current_page: 1,
-            links: [{
-              href: "http://example.org/v2/content?document_type=topic&fields%5B%5D=content_id&fields%5B%5D=details&page=1",
-              rel: "self",
-            }],
-            results: [
-              { content_id: @content_id, details: { foo: :bar } },
-            ],
-          },
-        )
-
-      response = @api_client.get_content_items(
-        document_type: "topic",
-        fields: %i[content_id details],
-      )
-
-      assert_equal 200, response.code
-
-      assert_equal [
-        ["total", 1],
-        ["pages", 1],
-        ["current_page", 1],
-        ["links", [{ "href" => "http://example.org/v2/content?document_type=topic&fields%5B%5D=content_id&fields%5B%5D=details&page=1", "rel" => "self" }]],
-        ["results", [{ "content_id" => "bed722e6-db68-43e5-9079-063f623335a7", "details" => { "foo" => "bar" } }]],
-      ],
-                   response.to_a
+      end
     end
 
-    it "returns the items matching a query" do
-      publishing_api
-        .given("there is content with document_type 'topic'")
-        .upon_receiving("a get entries request with search_in and q parameters")
-        .with(
-          method: :get,
-          path: "/v2/content",
-          query: "document_type=topic&fields%5B%5D=content_id&q=an+internal+name&search_in%5B%5D=details.internal_name",
-          headers: GdsApi::JsonClient.default_request_headers.merge(
-            "Authorization" => "Bearer #{@bearer_token}",
-          ),
+    describe "#get_content_items" do
+      it "returns the content items of a certain document_type" do
+        publishing_api
+          .given("there is content with document_type 'topic'")
+          .upon_receiving("a get entries request")
+          .with(
+            method: :get,
+            path: "/v2/content",
+            query: "document_type=topic&fields%5B%5D=title&fields%5B%5D=base_path",
+            headers: GdsApi::JsonClient.default_request_headers.merge(
+              "Authorization" => "Bearer #{@bearer_token}",
+            ),
+          )
+          .will_respond_with(
+            status: 200,
+            body: {
+              total: 2,
+              pages: 1,
+              current_page: 1,
+              links: [{
+                href: "http://example.org/v2/content?document_type=topic&fields%5B%5D=title&fields%5B%5D=base_path&page=1",
+                rel: "self",
+              }],
+              results: [
+                { title: "Content Item A", base_path: "/a-base-path" },
+                { title: "Content Item B", base_path: "/another-base-path" },
+              ],
+            },
+          )
+
+        @api_client.get_content_items(
+          document_type: "topic",
+          fields: %i[title base_path],
         )
-        .will_respond_with(
-          status: 200,
-          body: {
-            total: 1,
-            pages: 1,
-            current_page: 1,
-            links: [{
-              href: "http://example.org/v2/content?document_type=topic&fields%5B%5D=content_id&q=an+internal+name&search_in%5B%5D=details.internal_name&page=1",
-              rel: "self",
-            }],
-            results: [
-              { content_id: "aaaaaaaa-aaaa-1aaa-aaaa-aaaaaaaaaaaa" },
-            ],
-          },
+      end
+
+      it "returns the content items in english locale by default" do
+        publishing_api
+          .given("a content item exists in multiple locales with content_id: #{@content_id}")
+          .upon_receiving("a get entries request")
+          .with(
+            method: :get,
+            path: "/v2/content",
+            query: "document_type=topic&fields%5B%5D=content_id&fields%5B%5D=locale",
+            headers: GdsApi::JsonClient.default_request_headers.merge(
+              "Authorization" => "Bearer #{@bearer_token}",
+            ),
+          )
+          .will_respond_with(
+            status: 200,
+            body: {
+              total: 1,
+              pages: 1,
+              current_page: 1,
+              links: [{
+                href: "http://example.org/v2/content?document_type=topic&fields%5B%5D=content_id&fields%5B%5D=locale&page=1",
+                rel: "self",
+              }],
+              results: [
+                { content_id: @content_id, locale: "en" },
+              ],
+            },
+          )
+
+        @api_client.get_content_items(
+          document_type: "topic",
+          fields: %i[content_id locale],
         )
+      end
 
-      response = @api_client.get_content_items(
-        document_type: "topic",
-        fields: [:content_id],
-        q: "an internal name",
-        search_in: ["details.internal_name"],
-      )
+      it "returns the content items in a specific locale" do
+        publishing_api
+          .given("a content item exists in multiple locales with content_id: #{@content_id}")
+          .upon_receiving("a get entries request with a specific locale")
+          .with(
+            method: :get,
+            path: "/v2/content",
+            query: "document_type=topic&fields%5B%5D=content_id&fields%5B%5D=locale&locale=fr",
+            headers: GdsApi::JsonClient.default_request_headers.merge(
+              "Authorization" => "Bearer #{@bearer_token}",
+            ),
+          )
+          .will_respond_with(
+            status: 200,
+            body: {
+              total: 1,
+              pages: 1,
+              current_page: 1,
+              links: [{
+                href: "http://example.org/v2/content?document_type=topic&fields%5B%5D=content_id&fields%5B%5D=locale&locale=fr&page=1",
+                rel: "self",
+              }],
+              results: [
+                { content_id: @content_id, locale: "fr" },
+              ],
+            },
+          )
 
-      assert_equal 200, response.code
+        @api_client.get_content_items(
+          document_type: "topic",
+          fields: %i[content_id locale],
+          locale: "fr",
+        )
+      end
 
-      assert_equal [
-        ["total", 1],
-        ["pages", 1],
-        ["current_page", 1],
-        ["links", [{ "href" => "http://example.org/v2/content?document_type=topic&fields%5B%5D=content_id&q=an+internal+name&search_in%5B%5D=details.internal_name&page=1", "rel" => "self" }]],
-        ["results", [{ "content_id" => "aaaaaaaa-aaaa-1aaa-aaaa-aaaaaaaaaaaa" }]],
-      ],
-                   response.to_a
+      it "returns the content items in all the available locales" do
+        publishing_api
+          .given("a content item exists in multiple locales with content_id: #{@content_id}")
+          .upon_receiving("a get entries request with an 'all' locale")
+          .with(
+            method: :get,
+            path: "/v2/content",
+            query: "document_type=topic&fields%5B%5D=content_id&fields%5B%5D=locale&locale=all",
+            headers: GdsApi::JsonClient.default_request_headers.merge(
+              "Authorization" => "Bearer #{@bearer_token}",
+            ),
+          )
+          .will_respond_with(
+            status: 200,
+            body: {
+              total: 3,
+              pages: 1,
+              current_page: 1,
+              links: [{
+                href: "http://example.org/v2/content?document_type=topic&fields%5B%5D=content_id&fields%5B%5D=locale&locale=all&page=1",
+                rel: "self",
+              }],
+              results: [
+                { content_id: @content_id, locale: "en" },
+                { content_id: @content_id, locale: "fr" },
+                { content_id: @content_id, locale: "ar" },
+              ],
+            },
+          )
+
+        @api_client.get_content_items(
+          document_type: "topic",
+          fields: %i[content_id locale],
+          locale: "all",
+        )
+      end
+
+      it "returns details hashes" do
+        publishing_api
+          .given("a content item exists with content_id: #{@content_id} and it has details")
+          .upon_receiving("a get entries request with details field")
+          .with(
+            method: :get,
+            path: "/v2/content",
+            query: "document_type=topic&fields%5B%5D=content_id&fields%5B%5D=details",
+            headers: GdsApi::JsonClient.default_request_headers.merge(
+              "Authorization" => "Bearer #{@bearer_token}",
+            ),
+          )
+          .will_respond_with(
+            status: 200,
+            body: {
+              total: 1,
+              pages: 1,
+              current_page: 1,
+              links: [{
+                href: "http://example.org/v2/content?document_type=topic&fields%5B%5D=content_id&fields%5B%5D=details&page=1",
+                rel: "self",
+              }],
+              results: [
+                { content_id: @content_id, details: { foo: :bar } },
+              ],
+            },
+          )
+
+        @api_client.get_content_items(
+          document_type: "topic",
+          fields: %i[content_id details],
+        )
+      end
+
+      it "returns the items matching a query" do
+        publishing_api
+          .given("there is content with document_type 'topic'")
+          .upon_receiving("a get entries request with search_in and q parameters")
+          .with(
+            method: :get,
+            path: "/v2/content",
+            query: "document_type=topic&fields%5B%5D=content_id&q=an+internal+name&search_in%5B%5D=details.internal_name",
+            headers: GdsApi::JsonClient.default_request_headers.merge(
+              "Authorization" => "Bearer #{@bearer_token}",
+            ),
+          )
+          .will_respond_with(
+            status: 200,
+            body: {
+              total: 1,
+              pages: 1,
+              current_page: 1,
+              links: [{
+                href: "http://example.org/v2/content?document_type=topic&fields%5B%5D=content_id&q=an+internal+name&search_in%5B%5D=details.internal_name&page=1",
+                rel: "self",
+              }],
+              results: [
+                { content_id: "aaaaaaaa-aaaa-1aaa-aaaa-aaaaaaaaaaaa" },
+              ],
+            },
+          )
+
+        @api_client.get_content_items(
+          document_type: "topic",
+          fields: [:content_id],
+          q: "an internal name",
+          search_in: ["details.internal_name"],
+        )
+      end
     end
-  end
 
-  describe "#discard_draft(content_id, options = {})" do
-    describe "when the content item exists" do
-      before do
+    describe "#discard_draft(content_id, options = {})" do
+      it "responds with 200 when the content item exists" do
         publishing_api
           .given("a content item exists with content_id: #{@content_id}")
           .upon_receiving("a request to discard draft content")
@@ -1969,16 +1655,11 @@ describe GdsApi::PublishingApi do
           .will_respond_with(
             status: 200,
           )
+
+        @api_client.discard_draft(@content_id)
       end
 
-      it "responds with 200" do
-        response = @api_client.discard_draft(@content_id)
-        assert_equal 200, response.code
-      end
-    end
-
-    describe "when the content item exists and is French" do
-      before do
+      it "responds with 200 when the content item exists and is French" do
         publishing_api
           .given("a French content item exists with content_id: #{@content_id}")
           .upon_receiving("a request to discard French draft content")
@@ -1995,16 +1676,11 @@ describe GdsApi::PublishingApi do
           .will_respond_with(
             status: 200,
           )
+
+        @api_client.discard_draft(@content_id, locale: "fr")
       end
 
-      it "responds with 200" do
-        response = @api_client.discard_draft(@content_id, locale: "fr")
-        assert_equal 200, response.code
-      end
-    end
-
-    describe "when there is no content with that content_id" do
-      before do
+      it "responds with a 404 when there is no content with that content_id" do
         publishing_api
           .given("no content exists")
           .upon_receiving("a request to discard draft content")
@@ -2019,62 +1695,55 @@ describe GdsApi::PublishingApi do
           .will_respond_with(
             status: 404,
           )
-      end
 
-      it "responds with a 404" do
-        error = assert_raises GdsApi::HTTPClientError do
+        assert_raises(GdsApi::HTTPNotFound) do
           @api_client.discard_draft(@content_id)
         end
-
-        assert_equal 404, error.code
       end
     end
-  end
 
-  describe "#get_links_by_content_id" do
-    it "returns the links for some content_ids" do
-      content_id_with_links = "bed722e6-db68-43e5-9079-063f623335a7"
-      content_id_no_links = "f40a63ce-ac0c-4102-84d1-f1835cb7daac"
+    describe "#get_links_by_content_id" do
+      it "returns the links for some content_ids" do
+        content_id_with_links = "bed722e6-db68-43e5-9079-063f623335a7"
+        content_id_no_links = "f40a63ce-ac0c-4102-84d1-f1835cb7daac"
 
-      response_hash = {
-        content_id_with_links => {
-          "links" => {
-            "taxons" => %w[20583132-1619-4c68-af24-77583172c070],
+        response_hash = {
+          content_id_with_links => {
+            "links" => {
+              "taxons" => %w[20583132-1619-4c68-af24-77583172c070],
+            },
+            "version" => 2,
           },
-          "version" => 2,
-        },
-        content_id_no_links => {
-          "links" => {},
-          "version" => 0,
-        },
-      }
-
-      publishing_api
-        .given("taxon links exist for content_id bed722e6-db68-43e5-9079-063f623335a7")
-        .upon_receiving("a bulk_links request")
-        .with(
-          method: :post,
-          path: "/v2/links/by-content-id",
-          body: {
-            content_ids: [content_id_with_links, content_id_no_links],
+          content_id_no_links => {
+            "links" => {},
+            "version" => 0,
           },
-          headers: {
-            "Content-Type" => "application/json",
-          },
-        )
-        .will_respond_with(
-          status: 200,
-          body: response_hash,
-        )
+        }
 
-      result = @api_client.get_links_for_content_ids([content_id_with_links, content_id_no_links])
-      assert_equal(response_hash, result)
+        publishing_api
+          .given("taxon links exist for content_id bed722e6-db68-43e5-9079-063f623335a7")
+          .upon_receiving("a bulk_links request")
+          .with(
+            method: :post,
+            path: "/v2/links/by-content-id",
+            body: {
+              content_ids: [content_id_with_links, content_id_no_links],
+            },
+            headers: {
+              "Content-Type" => "application/json",
+            },
+          )
+          .will_respond_with(
+            status: 200,
+            body: response_hash,
+          )
+
+        @api_client.get_links_for_content_ids([content_id_with_links, content_id_no_links])
+      end
     end
-  end
 
-  describe "#get_linked_items" do
-    describe "if the content item does not exist" do
-      before do
+    describe "#get_linked_items" do
+      it "404s if the content item does not exist" do
         publishing_api
           .given("no content exists")
           .upon_receiving("a request to return the items linked to it")
@@ -2098,9 +1767,7 @@ describe GdsApi::PublishingApi do
               "Content-Type" => "application/json; charset=utf-8",
             },
           )
-      end
 
-      it "404s" do
         assert_raises(GdsApi::HTTPNotFound) do
           @api_client.get_linked_items(
             @content_id,
@@ -2109,78 +1776,76 @@ describe GdsApi::PublishingApi do
           )
         end
       end
-    end
 
-    describe "there are two documents that link to the wanted document" do
-      before do
-        content_id2 = "08dfd5c3-d935-4e81-88fd-cfe65b78893d"
-        content_id3 = "e2961462-bc37-48e9-bb98-c981ef1a2d59"
+      describe "there are two documents that link to the wanted document" do
+        before do
+          content_id2 = "08dfd5c3-d935-4e81-88fd-cfe65b78893d"
+          content_id3 = "e2961462-bc37-48e9-bb98-c981ef1a2d59"
 
-        @linked_content_item = content_item_for_content_id("6cb2cf8c-670f-4de3-97d5-6ad9114581c7")
-        @linking_content_item1 = content_item_for_content_id(
-          content_id3,
-          "base_path" => "/item-b",
-          "links" => {
-            "topic" => [@linked_content_item["content_id1"]],
-          },
-        )
-        @linking_content_item2 = content_item_for_content_id(
-          content_id2,
-          "base_path" => "/item-a",
-          "links" => {
-            "topic" => [@linked_content_item["content_id1"]],
-          },
-        )
-
-        publishing_api
-          .given("there are two documents with a 'topic' link to another document")
-          .upon_receiving("a get linked request")
-          .with(
-            method: :get,
-            path: "/v2/linked/#{@linked_content_item['content_id']}",
-            query: "fields%5B%5D=content_id&fields%5B%5D=base_path&link_type=topic",
-            headers: GdsApi::JsonClient.default_request_headers.merge(
-              "Authorization" => "Bearer #{@bearer_token}",
-            ),
+          @linked_content_item = content_item_for_content_id("6cb2cf8c-670f-4de3-97d5-6ad9114581c7")
+          @linking_content_item1 = content_item_for_content_id(
+            content_id3,
+            "base_path" => "/item-b",
+            "links" => {
+              "topic" => [@linked_content_item["content_id1"]],
+            },
           )
-          .will_respond_with(
-            status: 200,
-            body: [
-              {
-                content_id: @linking_content_item1["content_id"],
-                base_path: @linking_content_item1["base_path"],
-              },
-              {
-                content_id: @linking_content_item2["content_id"],
-                base_path: @linking_content_item2["base_path"],
-              },
-            ],
+          @linking_content_item2 = content_item_for_content_id(
+            content_id2,
+            "base_path" => "/item-a",
+            "links" => {
+              "topic" => [@linked_content_item["content_id1"]],
+            },
           )
-      end
 
-      it "returns the requested fields of linking items" do
-        response = @api_client.get_linked_items(
-          @linked_content_item["content_id"],
-          link_type: "topic",
-          fields: %w[content_id base_path],
-        )
-        assert_equal 200, response.code
+          publishing_api
+            .given("there are two documents with a 'topic' link to another document")
+            .upon_receiving("a get linked request")
+            .with(
+              method: :get,
+              path: "/v2/linked/#{@linked_content_item['content_id']}",
+              query: "fields%5B%5D=content_id&fields%5B%5D=base_path&link_type=topic",
+              headers: GdsApi::JsonClient.default_request_headers.merge(
+                "Authorization" => "Bearer #{@bearer_token}",
+              ),
+            )
+            .will_respond_with(
+              status: 200,
+              body: [
+                {
+                  content_id: @linking_content_item1["content_id"],
+                  base_path: @linking_content_item1["base_path"],
+                },
+                {
+                  content_id: @linking_content_item2["content_id"],
+                  base_path: @linking_content_item2["base_path"],
+                },
+              ],
+            )
+        end
 
-        expected_documents = [
-          { "content_id" => @linking_content_item2["content_id"], "base_path" => "/item-a" },
-          { "content_id" => @linking_content_item1["content_id"], "base_path" => "/item-b" },
-        ]
+        it "returns the requested fields of linking items" do
+          response = @api_client.get_linked_items(
+            @linked_content_item["content_id"],
+            link_type: "topic",
+            fields: %w[content_id base_path],
+          )
+          assert_equal 200, response.code
 
-        expected_documents.each do |document|
-          assert_includes response.to_a, document
+          expected_documents = [
+            { "content_id" => @linking_content_item2["content_id"], "base_path" => "/item-a" },
+            { "content_id" => @linking_content_item1["content_id"], "base_path" => "/item-b" },
+          ]
+
+          expected_documents.each do |document|
+            assert_includes response.to_a, document
+          end
         end
       end
     end
-  end
 
-  describe "#get_editions" do
-    describe "there are editions available to paginate over" do
-      before do
+    describe "#get_editions" do
+      it "responds correctly when there are editions available to paginate over" do
         publishing_api
           .given("there are live content items with base_paths /foo and /bar")
           .upon_receiving("a get editions request")
@@ -2204,404 +1869,394 @@ describe GdsApi::PublishingApi do
               ],
             },
           )
-      end
 
-      it "will response correctly" do
-        response = @api_client.get_editions(fields: %w[content_id])
-        assert_equal response["results"].length, 2
+        @api_client.get_editions(fields: %w[content_id])
       end
     end
-  end
 
-  describe "#get_paged_editions" do
-    describe "there are multiple pages of editions" do
-      let(:content_id_1) { "bd50a6d9-f03d-4ccf-94aa-ad79579990a9" }
-      let(:content_id_2) { "989033fe-252a-4e69-976d-5c0059bca949" }
-      let(:content_id_3) { "271d4270-9186-4d60-b2ca-1d7dae7e0f73" }
-      let(:content_id_4) { "638af19c-27fc-4cc9-a914-4cca49028688" }
+    describe "#get_paged_editions" do
+      describe "there are multiple pages of editions" do
+        let(:content_id_1) { "bd50a6d9-f03d-4ccf-94aa-ad79579990a9" }
+        let(:content_id_2) { "989033fe-252a-4e69-976d-5c0059bca949" }
+        let(:content_id_3) { "271d4270-9186-4d60-b2ca-1d7dae7e0f73" }
+        let(:content_id_4) { "638af19c-27fc-4cc9-a914-4cca49028688" }
 
-      let(:first_page) do
-        {
-          request: {
-            method: :get,
-            path: "/v2/editions",
-            query: "fields%5B%5D=content_id&per_page=2",
-            headers: GdsApi::JsonClient.default_request_headers.merge(
-              "Authorization" => "Bearer #{@bearer_token}",
-            ),
-          },
-          response: {
-            status: 200,
-            body: {
-              results: [
-                { content_id: content_id_1 },
-                { content_id: content_id_2 },
-              ],
-              links: [
-                { href: "http://example.org#{second_page[:request][:path]}?#{second_page[:request][:query]}", rel: "next" },
-                { href: "http://example.org/v2/editions?fields%5B%5D=content_id&per_page=2", rel: "self" },
-              ],
+        let(:first_page) do
+          {
+            request: {
+              method: :get,
+              path: "/v2/editions",
+              query: "fields%5B%5D=content_id&per_page=2",
+              headers: GdsApi::JsonClient.default_request_headers.merge(
+                "Authorization" => "Bearer #{@bearer_token}",
+              ),
             },
-          },
-        }
-      end
-
-      let(:second_page) do
-        {
-          request: {
-            method: :get,
-            path: "/v2/editions",
-            query: "fields%5B%5D=content_id&per_page=2&after=2017-02-01T00%3A00%3A00.000000Z%2C2",
-            headers: GdsApi::JsonClient.default_request_headers.merge(
-              "Authorization" => "Bearer #{@bearer_token}",
-            ),
-          },
-          response: {
-            status: 200,
-            body: {
-              results: [
-                { content_id: content_id_3 },
-                { content_id: content_id_4 },
-              ],
-              links: [
-                { href: "http://example.org/v2/editions?fields%5B%5D=content_id&per_page=2&after=2017-02-01T00%3A00%3A00.000000Z%2C2", rel: "self" },
-                { href: "http://example.org/v2/editions?fields%5B%5D=content_id&per_page=2&before=2017-03-01T00%3A00%3A00.000000Z%2C3", rel: "previous" },
-              ],
+            response: {
+              status: 200,
+              body: {
+                results: [
+                  { content_id: content_id_1 },
+                  { content_id: content_id_2 },
+                ],
+                links: [
+                  { href: "http://example.org#{second_page[:request][:path]}?#{second_page[:request][:query]}", rel: "next" },
+                  { href: "http://example.org/v2/editions?fields%5B%5D=content_id&per_page=2", rel: "self" },
+                ],
+              },
             },
-          },
-        }
-      end
+          }
+        end
 
-      before do
-        publishing_api
-          .given("there are 4 live content items with fixed updated timestamps")
-          .upon_receiving("a get editions request for 2 per page")
-          .with(first_page[:request])
-          .will_respond_with(first_page[:response])
+        let(:second_page) do
+          {
+            request: {
+              method: :get,
+              path: "/v2/editions",
+              query: "fields%5B%5D=content_id&per_page=2&after=2017-02-01T00%3A00%3A00.000000Z%2C2",
+              headers: GdsApi::JsonClient.default_request_headers.merge(
+                "Authorization" => "Bearer #{@bearer_token}",
+              ),
+            },
+            response: {
+              status: 200,
+              body: {
+                results: [
+                  { content_id: content_id_3 },
+                  { content_id: content_id_4 },
+                ],
+                links: [
+                  { href: "http://example.org/v2/editions?fields%5B%5D=content_id&per_page=2&after=2017-02-01T00%3A00%3A00.000000Z%2C2", rel: "self" },
+                  { href: "http://example.org/v2/editions?fields%5B%5D=content_id&per_page=2&before=2017-03-01T00%3A00%3A00.000000Z%2C3", rel: "previous" },
+                ],
+              },
+            },
+          }
+        end
 
-        publishing_api
-          .given("there are 4 live content items with fixed updated timestamps")
-          .upon_receiving("a next page editions request")
-          .with(second_page[:request])
-          .will_respond_with(second_page[:response])
-      end
+        before do
+          publishing_api
+            .given("there are 4 live content items with fixed updated timestamps")
+            .upon_receiving("a get editions request for 2 per page")
+            .with(first_page[:request])
+            .will_respond_with(first_page[:response])
 
-      it "receives two pages of results" do
-        first_page_url = "#{publishing_api_host}#{first_page[:request][:path]}?#{first_page[:request][:query]}"
-        second_page_path = "#{second_page[:request][:path]}?#{second_page[:request][:query]}"
+          publishing_api
+            .given("there are 4 live content items with fixed updated timestamps")
+            .upon_receiving("a next page editions request")
+            .with(second_page[:request])
+            .will_respond_with(second_page[:response])
+        end
 
-        # Manually override JsonClient#get_json, because the Pact tests mean we return an invalid pagination
-        # URL, which we have to replace with our mocked publishing_api_host
-        @api_client
-          .expects(:get_json)
-          .with(first_page_url)
-          .returns(GdsApi::JsonClient.new.get_json(first_page_url, first_page[:request][:headers]))
+        it "receives two pages of results" do
+          first_page_url = "#{publishing_api_host}#{first_page[:request][:path]}?#{first_page[:request][:query]}"
+          second_page_path = "#{second_page[:request][:path]}?#{second_page[:request][:query]}"
 
-        @api_client
-          .expects(:get_json)
-          .with("http://example.org#{second_page_path}")
-          .returns(GdsApi::JsonClient.new.get_json("#{publishing_api_host}#{second_page_path}", second_page[:request][:headers]))
+          # Manually override JsonClient#get_json, because the Pact tests mean we return an invalid pagination
+          # URL, which we have to replace with our mocked publishing_api_host
+          @api_client
+            .expects(:get_json)
+            .with(first_page_url)
+            .returns(GdsApi::JsonClient.new.get_json(first_page_url, first_page[:request][:headers]))
 
-        response = @api_client.get_paged_editions(fields: %w[content_id], per_page: 2).to_a
+          @api_client
+            .expects(:get_json)
+            .with("http://example.org#{second_page_path}")
+            .returns(GdsApi::JsonClient.new.get_json("#{publishing_api_host}#{second_page_path}", second_page[:request][:headers]))
 
-        assert_equal 2, response.count
-        first_page_content_ids = response[0]["results"].map { |content_item| content_item["content_id"] }
-        second_page_content_ids = response[1]["results"].map { |content_item| content_item["content_id"] }
+          response = @api_client.get_paged_editions(fields: %w[content_id], per_page: 2).to_a
 
-        assert_equal [content_id_1, content_id_2], first_page_content_ids
-        assert_equal [content_id_3, content_id_4], second_page_content_ids
-      end
-    end
-  end
+          assert_equal 2, response.count
+          first_page_content_ids = response[0]["results"].map { |content_item| content_item["content_id"] }
+          second_page_content_ids = response[1]["results"].map { |content_item| content_item["content_id"] }
 
-  describe "content ID validation" do
-    %i[get_content get_links get_linked_items discard_draft].each do |method|
-      it "happens on #{method}" do
-        assert_raises ArgumentError do
-          @api_client.send(method, nil)
+          assert_equal [content_id_1, content_id_2], first_page_content_ids
+          assert_equal [content_id_3, content_id_4], second_page_content_ids
         end
       end
     end
 
-    it "happens on publish" do
-      assert_raises ArgumentError do
-        @api_client.publish(nil, "major")
+    describe "content ID validation" do
+      %i[get_content get_links get_linked_items discard_draft].each do |method|
+        it "happens on #{method}" do
+          assert_raises ArgumentError do
+            @api_client.send(method, nil)
+          end
+        end
+      end
+
+      it "happens on publish" do
+        assert_raises ArgumentError do
+          @api_client.publish(nil, "major")
+        end
+      end
+
+      it "happens on put_content" do
+        assert_raises ArgumentError do
+          @api_client.put_content(nil, {})
+        end
+      end
+
+      it "happens on patch_links" do
+        assert_raises ArgumentError do
+          @api_client.patch_links(nil, links: {})
+        end
       end
     end
 
-    it "happens on put_content" do
-      assert_raises ArgumentError do
-        @api_client.put_content(nil, {})
-      end
-    end
+    describe "#put_path" do
+      it "returns 200 if the path was successfully reserved" do
+        base_path = "/test-intent"
+        payload = {
+          publishing_app: "publisher",
+        }
 
-    it "happens on patch_links" do
-      assert_raises ArgumentError do
-        @api_client.patch_links(nil, links: {})
-      end
-    end
-  end
-
-  describe "#put_path" do
-    it "returns 200 if the path was successfully reserved" do
-      base_path = "/test-intent"
-      payload = {
-        publishing_app: "publisher",
-      }
-
-      publishing_api
-        .given("no content exists")
-        .upon_receiving("a request to put a path")
-        .with(
-          method: :put,
-          path: "/paths#{base_path}",
-          body: payload,
-          headers: {
-            "Content-Type" => "application/json",
-          },
-        )
-        .will_respond_with(
-          status: 200,
-          body: {},
-          headers: {
-            "Content-Type" => "application/json; charset=utf-8",
-          },
-        )
-
-      response = @api_client.put_path(base_path, payload)
-      assert_equal 200, response.code
-    end
-
-    it "returns 422 if the request is invalid" do
-      base_path = "/test-item"
-      payload = {
-        publishing_app: "whitehall",
-      }
-
-      publishing_api
-        .given("/test-item has been reserved by the Publisher application")
-        .upon_receiving("a request to change publishing app")
-        .with(
-          method: :put,
-          path: "/paths#{base_path}",
-          body: payload,
-          headers: {
-            "Content-Type" => "application/json",
-          },
-        )
-        .will_respond_with(
-          status: 422,
-          body: {
-            "error" => {
-              "code" => 422,
-              "message" => Pact.term(generate: "Unprocessable", matcher: /\S+/),
-              "fields" => {
-                "base_path" => Pact.each_like("has been reserved", min: 1),
-              },
+        publishing_api
+          .given("no content exists")
+          .upon_receiving("a request to put a path")
+          .with(
+            method: :put,
+            path: "/paths#{base_path}",
+            body: payload,
+            headers: {
+              "Content-Type" => "application/json",
             },
-          },
-        )
+          )
+          .will_respond_with(
+            status: 200,
+            body: {},
+            headers: {
+              "Content-Type" => "application/json; charset=utf-8",
+            },
+          )
 
-      error = assert_raises GdsApi::HTTPUnprocessableEntity do
         @api_client.put_path(base_path, payload)
       end
-      assert_equal "Unprocessable", error.error_details["error"]["message"]
-    end
 
-    it "returns 200 if an existing path was overridden" do
-      base_path = "/test-item"
-      payload = {
-        publishing_app: "whitehall",
-        override_existing: "true",
-      }
+      it "returns 422 if the request is invalid" do
+        base_path = "/test-item"
+        payload = {
+          publishing_app: "whitehall",
+        }
 
-      publishing_api
-        .given("/test-item has been reserved by the Publisher application")
-        .upon_receiving("a request to change publishing app with override_existing set")
-        .with(
-          method: :put,
-          path: "/paths#{base_path}",
-          body: payload,
-          headers: {
-            "Content-Type" => "application/json",
-          },
-        )
-        .will_respond_with(
-          status: 200,
-          body: {},
-          headers: {
-            "Content-Type" => "application/json; charset=utf-8",
-          },
-        )
+        publishing_api
+          .given("/test-item has been reserved by the Publisher application")
+          .upon_receiving("a request to change publishing app")
+          .with(
+            method: :put,
+            path: "/paths#{base_path}",
+            body: payload,
+            headers: {
+              "Content-Type" => "application/json",
+            },
+          )
+          .will_respond_with(
+            status: 422,
+            body: {
+              "error" => {
+                "code" => 422,
+                "message" => Pact.term(generate: "Unprocessable", matcher: /\S+/),
+                "fields" => {
+                  "base_path" => Pact.each_like("has been reserved", min: 1),
+                },
+              },
+            },
+          )
 
-      response = @api_client.put_path(base_path, payload)
-      assert_equal 200, response.code
-    end
-  end
+        assert_raises(GdsApi::HTTPUnprocessableEntity) do
+          @api_client.put_path(base_path, payload)
+        end
+      end
 
-  describe "#unreserve_path" do
-    it "responds with 200 OK if reservation is owned by the app" do
-      publishing_app = "publisher"
-      base_path = "/test-item"
+      it "returns 200 if an existing path was overridden" do
+        base_path = "/test-item"
+        payload = {
+          publishing_app: "whitehall",
+          override_existing: "true",
+        }
 
-      publishing_api
-        .given("/test-item has been reserved by the Publisher application")
-        .upon_receiving("a request to unreserve a path")
-        .with(
-          method: :delete,
-          path: "/paths#{base_path}",
-          body: { publishing_app: publishing_app },
-          headers: {
-            "Content-Type" => "application/json",
-          },
-        )
-        .will_respond_with(
-          status: 200,
-          body: {},
-          headers: {
-            "Content-Type" => "application/json; charset=utf-8",
-          },
-        )
+        publishing_api
+          .given("/test-item has been reserved by the Publisher application")
+          .upon_receiving("a request to change publishing app with override_existing set")
+          .with(
+            method: :put,
+            path: "/paths#{base_path}",
+            body: payload,
+            headers: {
+              "Content-Type" => "application/json",
+            },
+          )
+          .will_respond_with(
+            status: 200,
+            body: {},
+            headers: {
+              "Content-Type" => "application/json; charset=utf-8",
+            },
+          )
 
-      response = @api_client.unreserve_path(base_path, publishing_app)
-      assert_equal 200, response.code
-    end
-
-    it "raises an error if the reservation does not exist" do
-      publishing_app = "publisher"
-      base_path = "/test-item"
-
-      publishing_api
-        .given("no content exists")
-        .upon_receiving("a request to unreserve a non-existant path")
-        .with(
-          method: :delete,
-          path: "/paths#{base_path}",
-          body: { publishing_app: publishing_app },
-          headers: {
-            "Content-Type" => "application/json",
-          },
-        )
-        .will_respond_with(
-          status: 404,
-          body: {},
-          headers: {
-            "Content-Type" => "application/json; charset=utf-8",
-          },
-        )
-
-      assert_raises GdsApi::HTTPNotFound do
-        @api_client.unreserve_path(base_path, publishing_app)
+        @api_client.put_path(base_path, payload)
       end
     end
 
-    it "raises an error if the reservation is with another app" do
-      publishing_app = "whitehall"
-      base_path = "/test-item"
+    describe "#unreserve_path" do
+      it "responds with 200 OK if reservation is owned by the app" do
+        publishing_app = "publisher"
+        base_path = "/test-item"
 
-      publishing_api
-        .given("/test-item has been reserved by the Publisher application")
-        .upon_receiving("a request to unreserve a path owned by another app")
-        .with(
-          method: :delete,
-          path: "/paths#{base_path}",
-          body: { publishing_app: "whitehall" },
-          headers: {
-            "Content-Type" => "application/json",
-          },
-        )
-        .will_respond_with(
-          status: 422,
-          body: {},
-          headers: {
-            "Content-Type" => "application/json; charset=utf-8",
-          },
-        )
+        publishing_api
+          .given("/test-item has been reserved by the Publisher application")
+          .upon_receiving("a request to unreserve a path")
+          .with(
+            method: :delete,
+            path: "/paths#{base_path}",
+            body: { publishing_app: publishing_app },
+            headers: {
+              "Content-Type" => "application/json",
+            },
+          )
+          .will_respond_with(
+            status: 200,
+            body: {},
+            headers: {
+              "Content-Type" => "application/json; charset=utf-8",
+            },
+          )
 
-      assert_raises GdsApi::HTTPUnprocessableEntity do
         @api_client.unreserve_path(base_path, publishing_app)
       end
-    end
-  end
 
-  describe "#put_intent" do
-    it "responds with 200 OK if publish intent is valid" do
-      base_path = "/test-intent"
-      publish_intent = { publishing_app: "publisher",
-                         rendering_app: "frontend",
-                         publish_time: "2019-11-11t17:56:17+00:00" }
+      it "raises an error if the reservation does not exist" do
+        publishing_app = "publisher"
+        base_path = "/test-item"
 
-      publishing_api
-        .given("no content exists")
-        .upon_receiving("a request to create a publish intent")
-        .with(
-          method: :put,
-          path: "/publish-intent#{base_path}",
-          body: publish_intent,
-          headers: {
-            "Content-Type" => "application/json",
-          },
-        )
-        .will_respond_with(
-          status: 200,
-          body: {
-            "publishing_app" => "publisher",
-            "rendering_app" => "frontend",
-            "publish_time" => "2019-11-11t17:56:17+00:00",
-          },
-          headers: {
-            "Content-Type" => "application/json; charset=utf-8",
-          },
-        )
+        publishing_api
+          .given("no content exists")
+          .upon_receiving("a request to unreserve a non-existant path")
+          .with(
+            method: :delete,
+            path: "/paths#{base_path}",
+            body: { publishing_app: publishing_app },
+            headers: {
+              "Content-Type" => "application/json",
+            },
+          )
+          .will_respond_with(
+            status: 404,
+            body: {},
+            headers: {
+              "Content-Type" => "application/json; charset=utf-8",
+            },
+          )
 
-      response = @api_client.put_intent(base_path, publish_intent)
-      assert_equal 200, response.code
-    end
-  end
+        assert_raises(GdsApi::HTTPNotFound) do
+          @api_client.unreserve_path(base_path, publishing_app)
+        end
+      end
 
-  describe "#delete_intent" do
-    it "returns 200 OK if intent existed and was deleted" do
-      base_path = "/test-intent"
+      it "raises an error if the reservation is with another app" do
+        publishing_app = "whitehall"
+        base_path = "/test-item"
 
-      publishing_api
-        .given("a publish intent exists at /test-intent")
-        .upon_receiving("a request to delete a publish intent")
-        .with(
-          method: :delete,
-          path: "/publish-intent#{base_path}",
-        )
-        .will_respond_with(
-          status: 200,
-          body: {},
-          headers: {
-            "Content-Type" => "application/json; charset=utf-8",
-          },
-        )
+        publishing_api
+          .given("/test-item has been reserved by the Publisher application")
+          .upon_receiving("a request to unreserve a path owned by another app")
+          .with(
+            method: :delete,
+            path: "/paths#{base_path}",
+            body: { publishing_app: "whitehall" },
+            headers: {
+              "Content-Type" => "application/json",
+            },
+          )
+          .will_respond_with(
+            status: 422,
+            body: {},
+            headers: {
+              "Content-Type" => "application/json; charset=utf-8",
+            },
+          )
 
-      response = @api_client.destroy_intent(base_path)
-      assert_equal 200, response.code
+        assert_raises(GdsApi::HTTPUnprocessableEntity) do
+          @api_client.unreserve_path(base_path, publishing_app)
+        end
+      end
     end
 
-    it "returns 404 Not found if the intent does not exist" do
-      base_path = "/test-intent"
+    describe "#put_intent" do
+      it "responds with 200 OK if publish intent is valid" do
+        base_path = "/test-intent"
+        publish_intent = { publishing_app: "publisher",
+                           rendering_app: "frontend",
+                           publish_time: "2019-11-11t17:56:17+00:00" }
 
-      publishing_api
-        .given("no content exists")
-        .upon_receiving("a request to delete a publish intent")
-        .with(
-          method: :delete,
-          path: "/publish-intent#{base_path}",
-        )
-        .will_respond_with(
-          status: 404,
-          body: {},
-          headers: {
-            "Content-Type" => "application/json; charset=utf-8",
-          },
-        )
+        publishing_api
+          .given("no content exists")
+          .upon_receiving("a request to create a publish intent")
+          .with(
+            method: :put,
+            path: "/publish-intent#{base_path}",
+            body: publish_intent,
+            headers: {
+              "Content-Type" => "application/json",
+            },
+          )
+          .will_respond_with(
+            status: 200,
+            body: {
+              "publishing_app" => "publisher",
+              "rendering_app" => "frontend",
+              "publish_time" => "2019-11-11t17:56:17+00:00",
+            },
+            headers: {
+              "Content-Type" => "application/json; charset=utf-8",
+            },
+          )
 
-      response = @api_client.destroy_intent(base_path)
-      assert_equal 404, response.code
+        @api_client.put_intent(base_path, publish_intent)
+      end
+    end
+
+    describe "#delete_intent" do
+      it "returns 200 OK if intent existed and was deleted" do
+        base_path = "/test-intent"
+
+        publishing_api
+          .given("a publish intent exists at /test-intent")
+          .upon_receiving("a request to delete a publish intent")
+          .with(
+            method: :delete,
+            path: "/publish-intent#{base_path}",
+          )
+          .will_respond_with(
+            status: 200,
+            body: {},
+            headers: {
+              "Content-Type" => "application/json; charset=utf-8",
+            },
+          )
+
+        @api_client.destroy_intent(base_path)
+      end
+
+      it "returns 404 Not found if the intent does not exist" do
+        base_path = "/test-intent"
+
+        publishing_api
+          .given("no content exists")
+          .upon_receiving("a request to delete a publish intent")
+          .with(
+            method: :delete,
+            path: "/publish-intent#{base_path}",
+          )
+          .will_respond_with(
+            status: 404,
+            body: {},
+            headers: {
+              "Content-Type" => "application/json; charset=utf-8",
+            },
+          )
+
+        @api_client.destroy_intent(base_path)
+      end
     end
   end
 end


### PR DESCRIPTION
Throughout our Pact tests, we've duplicated our intentions, both
in the `will_respond_with` declaration AND in manual assertions
afterwards (e.g. `assert_equal(reponse_hash, content_id)`).

We should let the Pact gem do the heavy lifting here, and declare
our expected behaviour in just one place. It is up to Pact to fail
the build if the response is not as we expected.

The result should be easier-to-read tests, as we've removed some
nesting in cases where we had `before` blocks which served just
one `it` block. We made a decision in Content Publisher to move
setup code as close as possible to the assertions, which this
commit is enabling: https://docs.publishing.service.gov.uk/apps/content-publisher/testing-strategy.html

The build still fails if we introduce an incorrect expectation, e.g. https://ci.integration.publishing.service.gov.uk/job/gds-api-adapters/job/dry-pact-tests-test/1/console (from commit https://github.com/alphagov/gds-api-adapters/commit/4c1da4011b10a011d644c7594c80bb0b9b6e7b0a)