### PR TITLE
Test api/attributes/names endpoint in account-api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Add optional `level_of_authentication` parameter to Account API `get_sign_in_url`.
 * Store response body in new `http_body` field of HTTP exceptions
 * Added Pact tests for the `LinkCheckerApi` adapters.
+* Add get_attributes_names method for [account-api's /api/attributes/names endpoint](https://github.com/alphagov/account-api/pull/58) + Pact tests.
 
 # 71.0.0
 

--- a/lib/gds_api/account_api.rb
+++ b/lib/gds_api/account_api.rb
@@ -85,6 +85,17 @@ class GdsApi::AccountApi < GdsApi::Base
     patch_json("#{endpoint}/api/attributes", { attributes: attributes }, auth_headers(govuk_account_session))
   end
 
+  # Look up the names of a user's attributes
+  #
+  # @param [String] attributes Names of the attributes to check
+  # @param [String] govuk_account_session Value of the session header
+  #
+  # @return [Hash] The attribute names (if present), and a new session header
+  def get_attributes_names(attributes:, govuk_account_session:)
+    querystring = nested_query_string({ attributes: attributes }.compact)
+    get_json("#{endpoint}/api/attributes/names?#{querystring}", auth_headers(govuk_account_session))
+  end
+
 private
 
   def nested_query_string(params)

--- a/lib/gds_api/test_helpers/account_api.rb
+++ b/lib/gds_api/test_helpers/account_api.rb
@@ -95,6 +95,18 @@ module GdsApi
             .to_return(status: 200, body: { govuk_account_session: new_govuk_account_session }.compact.to_json)
         end
       end
+
+      def stub_account_api_get_attributes_names(govuk_account_session: nil, attributes: [], new_govuk_account_session: nil)
+        querystring = Rack::Utils.build_nested_query({ attributes: attributes }.compact)
+        if govuk_account_session
+          stub_request(:get, "#{ACCOUNT_API_ENDPOINT}/api/attributes/names?#{querystring}")
+            .with(headers: { GdsApi::AccountApi::AUTH_HEADER_NAME => govuk_account_session })
+            .to_return(status: 200, body: { govuk_account_session: new_govuk_account_session, values: attributes }.compact.to_json)
+        else
+          stub_request(:get, "#{ACCOUNT_API_ENDPOINT}/api/attributes/names?#{querystring}")
+            .to_return(status: 200, body: { govuk_account_session: new_govuk_account_session, values: attributes }.compact.to_json)
+        end
+      end
     end
   end
 end

--- a/test/account_api/account_api_test.rb
+++ b/test/account_api/account_api_test.rb
@@ -77,4 +77,12 @@ describe GdsApi::AccountApi do
     stub_account_api_set_attributes(attributes: { foo: %w[bar] }, new_govuk_account_session: "new-session")
     assert_equal("new-session", api_client.set_attributes(govuk_account_session: "foo", attributes: { foo: %w[bar] }).to_hash["govuk_account_session"])
   end
+
+  it "returns the attribute names" do
+    queried_attribute_names = %w[foo]
+    stub_account_api_get_attributes_names(attributes: queried_attribute_names, new_govuk_account_session: "new-session")
+    returned_attribute_names = api_client.get_attributes_names(attributes: queried_attribute_names, govuk_account_session: "bar")["values"]
+
+    assert_equal queried_attribute_names, returned_attribute_names
+  end
 end


### PR DESCRIPTION
This endpoint allows querying if the user has a value stored for an
attribute, without returning the value.

It is very similar to /api/attributes, with the difference that it only
returns the name of the attribute instead of the name and the value.

See where this endpoint was introduced: https://github.com/alphagov/account-api/pull/58

Trello card: https://trello.com/c/e7JQlXx9/710-add-an-endpoint-to-account-api-to-check-if-an-attribute-is-defined