### PR TITLE
Add optional 'level_of_authentication' to 'get_sign_in_url'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 * Removed `LinkCheckerApi#upsert_resource_monitor` method as it’s not supported by Link Checker API itself.
+* Add optional `level_of_authentication` parameter to Account API `get_sign_in_url`.
 
 # 71.0.0
 

--- a/lib/gds_api/account_api.rb
+++ b/lib/gds_api/account_api.rb
@@ -12,10 +12,17 @@ class GdsApi::AccountApi < GdsApi::Base
   #
   # @param [String, nil] redirect_path path on GOV.UK to send the user to after authentication
   # @param [String, nil] state_id identifier originally returned by #create_registration_state
+  # @param [String, nil] level_of_authentication either "level1" (require MFA) or "level0" (do not require MFA)
   #
   # @return [Hash] An authentication URL and the OAuth state parameter (for CSRF protection)
-  def get_sign_in_url(redirect_path: nil, state_id: nil)
-    querystring = nested_query_string({ redirect_path: redirect_path, state_id: state_id }.compact)
+  def get_sign_in_url(redirect_path: nil, state_id: nil, level_of_authentication: nil)
+    querystring = nested_query_string(
+      {
+        redirect_path: redirect_path,
+        state_id: state_id,
+        level_of_authentication: level_of_authentication,
+      }.compact,
+    )
     get_json("#{endpoint}/api/oauth2/sign-in?#{querystring}")
   end
 

--- a/lib/gds_api/test_helpers/account_api.rb
+++ b/lib/gds_api/test_helpers/account_api.rb
@@ -5,8 +5,8 @@ module GdsApi
     module AccountApi
       ACCOUNT_API_ENDPOINT = Plek.find("account-api")
 
-      def stub_account_api_get_sign_in_url(redirect_path: nil, state_id: nil, auth_uri: "http://auth/provider", state: "state")
-        querystring = Rack::Utils.build_nested_query({ redirect_path: redirect_path, state_id: state_id }.compact)
+      def stub_account_api_get_sign_in_url(redirect_path: nil, state_id: nil, level_of_authentication: nil, auth_uri: "http://auth/provider", state: "state")
+        querystring = Rack::Utils.build_nested_query({ redirect_path: redirect_path, state_id: state_id, level_of_authentication: level_of_authentication }.compact)
         stub_request(:get, "#{ACCOUNT_API_ENDPOINT}/api/oauth2/sign-in?#{querystring}")
           .to_return(
             status: 200,


### PR DESCRIPTION
See also https://github.com/alphagov/account-api/pull/61

---

[Trello card](https://trello.com/c/qGMyYZ51/715-implement-requesting-a-specific-level-of-authentication-from-the-account-manager)