### PR TITLE
Change Publishing API branch to main

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ node("postgresql-9.6") {
     extraParameters: [
       stringParam(
         name: 'PUBLISHING_API_BRANCH',
-        defaultValue: 'master',
+        defaultValue: 'main',
         description: 'Branch of publishing-api to run pacts against'
       ),
       stringParam(


### PR DESCRIPTION
Like #1054, the default branch for Publishing API has been changed from `master` to `main`.