### PR TITLE
Store response body in new `http_body` field of HTTP exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Removed `LinkCheckerApi#upsert_resource_monitor` method as it’s not supported by Link Checker API itself.
 * Add optional `level_of_authentication` parameter to Account API `get_sign_in_url`.
+* Store response body in new `http_body` field of HTTP exceptions
 
 # 71.0.0
 

--- a/lib/gds_api/exceptions.rb
+++ b/lib/gds_api/exceptions.rb
@@ -23,12 +23,13 @@ module GdsApi
 
   # Superclass for all 4XX and 5XX errors
   class HTTPErrorResponse < BaseError
-    attr_accessor :code, :error_details
+    attr_accessor :code, :error_details, :http_body
 
-    def initialize(code, message = nil, error_details = nil)
+    def initialize(code, message = nil, error_details = nil, http_body = nil)
       super(message)
       @code = code
       @error_details = error_details
+      @http_body = http_body
     end
   end
 
@@ -72,7 +73,7 @@ module GdsApi
     def build_specific_http_error(error, url, details = nil)
       message = "URL: #{url}\nResponse body:\n#{error.http_body}"
       code = error.http_code
-      error_class_for_code(code).new(code, message, details)
+      error_class_for_code(code).new(code, message, details, error.http_body)
     end
 
     def error_class_for_code(code)

--- a/test/json_client_test.rb
+++ b/test/json_client_test.rb
@@ -85,6 +85,13 @@ class JsonClientTest < MiniTest::Spec
     assert_equal GdsApi::Response, @client.get_json(url).class
   end
 
+  def test_should_include_body_for_http_error
+    url = "http://some.endpoint/some.json"
+    stub_request(:get, url).to_return(body: "response body goes here", status: 404)
+    error = assert_raises(GdsApi::HTTPErrorResponse) { @client.get_json(url) }
+    assert_equal "response body goes here", error.http_body
+  end
+
   def test_get_bang_should_raise_http_not_found_if_404_returned_from_endpoint
     url = "http://some.endpoint/some.json"
     stub_request(:get, url).to_return(body: "{}", status: 404)


### PR DESCRIPTION
We don't currently make the response body easily available - it can
only be extracted from the `message` field, by splitting it at the
"Response body:\n" bit, which is a bit unpleasant.  Better for it to
be directly available without manipulating strings.

This is useful for the accounts work, as the account-api is going to
start returning 403 errors when a user doesn't have a sufficiently
high level-of-authentication to access an attribute, and it'll return
the required level-of-authentication in the response body.

An alternative implementation would be to return a 200 response with a
body like:

    { "error": "level of authentication too low", ... }

But this is (1) error prone (you need to remember to check for an
"error" field), and (2) confusing (an error response should have an
error code).  Returning a 403 response, which throws an exception from
gds-api-adapters and so is *guaranteed* to interrupt the normal flow
of control, is much better.

This is a non-breaking change, as the new parameter is the last of
`HTTPErrorResponse` and defaults to `nil`, so anyone constructing
these exceptions in their own code won't have to change things.

---

[Trello card](https://trello.com/c/G2uYUDuz/716-check-the-level-of-authentication-when-using-attributes-in-the-account-api)