### PR TITLE
Add 401 and 403 test helpers for Account API methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Store response body in new `http_body` field of HTTP exceptions
 * Added Pact tests for the `LinkCheckerApi` adapters.
 * Add get_attributes_names method for [account-api's /api/attributes/names endpoint](https://github.com/alphagov/account-api/pull/58) + Pact tests.
+* Add 401 and 403 test helpers for Account API methods
 
 # 71.0.0
 

--- a/lib/gds_api/test_helpers/account_api.rb
+++ b/lib/gds_api/test_helpers/account_api.rb
@@ -56,11 +56,51 @@ module GdsApi
         )
       end
 
-      def stub_account_api_set_email_subscription(slug: "slug", **options)
+      def stub_account_api_unauthorized_get_email_subscription(**options)
+        stub_account_api_request(
+          :get,
+          "/api/transition-checker-email-subscription",
+          response_status: 401,
+          **options,
+        )
+      end
+
+      def stub_account_api_forbidden_get_email_subscription(needed_level_of_authentication: "level1", **options)
+        stub_account_api_request(
+          :get,
+          "/api/transition-checker-email-subscription",
+          response_status: 403,
+          response_body: { needed_level_of_authentication: needed_level_of_authentication },
+          **options,
+        )
+      end
+
+      def stub_account_api_set_email_subscription(slug: nil, **options)
         stub_account_api_request(
           :post,
           "/api/transition-checker-email-subscription",
           with: { body: hash_including({ slug: slug }.compact) },
+          **options,
+        )
+      end
+
+      def stub_account_api_unauthorized_set_email_subscription(slug: nil, **options)
+        stub_account_api_request(
+          :post,
+          "/api/transition-checker-email-subscription",
+          with: { body: hash_including({ slug: slug }.compact) },
+          response_status: 401,
+          **options,
+        )
+      end
+
+      def stub_account_api_forbidden_set_email_subscription(slug: nil, needed_level_of_authentication: "level1", **options)
+        stub_account_api_request(
+          :post,
+          "/api/transition-checker-email-subscription",
+          with: { body: hash_including({ slug: slug }.compact) },
+          response_status: 403,
+          response_body: { needed_level_of_authentication: needed_level_of_authentication },
           **options,
         )
       end
@@ -75,11 +115,53 @@ module GdsApi
         )
       end
 
+      def stub_account_api_unauthorized_has_attributes(attributes: [], **options)
+        querystring = Rack::Utils.build_nested_query({ attributes: attributes }.compact)
+        stub_account_api_request(
+          :get,
+          "/api/attributes?#{querystring}",
+          response_status: 401,
+          **options,
+        )
+      end
+
+      def stub_account_api_forbidden_has_attributes(attributes: [], needed_level_of_authentication: "level1", **options)
+        querystring = Rack::Utils.build_nested_query({ attributes: attributes }.compact)
+        stub_account_api_request(
+          :get,
+          "/api/attributes?#{querystring}",
+          response_status: 403,
+          response_body: { needed_level_of_authentication: needed_level_of_authentication },
+          **options,
+        )
+      end
+
       def stub_account_api_set_attributes(attributes: nil, **options)
         stub_account_api_request(
           :patch,
           "/api/attributes",
           with: { body: hash_including({ attributes: attributes }.compact) },
+          **options,
+        )
+      end
+
+      def stub_account_api_unauthorized_set_attributes(attributes: nil, **options)
+        stub_account_api_request(
+          :patch,
+          "/api/attributes",
+          with: { body: hash_including({ attributes: attributes }.compact) },
+          response_status: 401,
+          **options,
+        )
+      end
+
+      def stub_account_api_forbidden_set_attributes(attributes: nil, needed_level_of_authentication: "level1", **options)
+        stub_account_api_request(
+          :patch,
+          "/api/attributes",
+          with: { body: hash_including({ attributes: attributes }.compact) },
+          response_status: 403,
+          response_body: { needed_level_of_authentication: needed_level_of_authentication },
           **options,
         )
       end
@@ -94,8 +176,30 @@ module GdsApi
         )
       end
 
+      def stub_account_api_unauthorized_get_attributes_names(attributes: [], **options)
+        querystring = Rack::Utils.build_nested_query({ attributes: attributes }.compact)
+        stub_account_api_request(
+          :get,
+          "/api/attributes/names?#{querystring}",
+          response_status: 401,
+          **options,
+        )
+      end
+
+      def stub_account_api_forbidden_get_attributes_names(attributes: [], needed_level_of_authentication: "level1", **options)
+        querystring = Rack::Utils.build_nested_query({ attributes: attributes }.compact)
+        stub_account_api_request(
+          :get,
+          "/api/attributes/names?#{querystring}",
+          response_status: 403,
+          response_body: { needed_level_of_authentication: needed_level_of_authentication },
+          **options,
+        )
+      end
+
       def stub_account_api_request(method, path, with: {}, response_status: 200, response_body: {}, govuk_account_session: nil, new_govuk_account_session: nil)
         with.merge!(headers: { GdsApi::AccountApi::AUTH_HEADER_NAME => govuk_account_session }) if govuk_account_session
+        new_govuk_account_session = nil if response_status >= 400
         to_return = { status: response_status, body: response_body.merge(govuk_account_session: new_govuk_account_session).compact.to_json }
         if with.empty?
           stub_request(method, "#{ACCOUNT_API_ENDPOINT}#{path}").to_return(**to_return)

--- a/lib/gds_api/test_helpers/account_api.rb
+++ b/lib/gds_api/test_helpers/account_api.rb
@@ -38,73 +38,69 @@ module GdsApi
           )
       end
 
-      def stub_account_api_has_email_subscription(govuk_account_session: nil, new_govuk_account_session: nil)
-        if govuk_account_session
-          stub_request(:get, "#{ACCOUNT_API_ENDPOINT}/api/transition-checker-email-subscription")
-            .with(headers: { GdsApi::AccountApi::AUTH_HEADER_NAME => govuk_account_session })
-            .to_return(status: 200, body: { govuk_account_session: new_govuk_account_session, has_subscription: true }.compact.to_json)
-        else
-          stub_request(:get, "#{ACCOUNT_API_ENDPOINT}/api/transition-checker-email-subscription")
-            .to_return(status: 200, body: { govuk_account_session: new_govuk_account_session, has_subscription: true }.compact.to_json)
-        end
+      def stub_account_api_has_email_subscription(**options)
+        stub_account_api_request(
+          :get,
+          "/api/transition-checker-email-subscription",
+          response_body: { has_subscription: true },
+          **options,
+        )
       end
 
-      def stub_account_api_does_not_have_email_subscription(govuk_account_session: nil, new_govuk_account_session: nil)
-        if govuk_account_session
-          stub_request(:get, "#{ACCOUNT_API_ENDPOINT}/api/transition-checker-email-subscription")
-            .with(headers: { GdsApi::AccountApi::AUTH_HEADER_NAME => govuk_account_session })
-            .to_return(status: 200, body: { govuk_account_session: new_govuk_account_session, has_subscription: false }.compact.to_json)
-        else
-          stub_request(:get, "#{ACCOUNT_API_ENDPOINT}/api/transition-checker-email-subscription")
-            .to_return(status: 200, body: { govuk_account_session: new_govuk_account_session, has_subscription: false }.compact.to_json)
-        end
+      def stub_account_api_does_not_have_email_subscription(**options)
+        stub_account_api_request(
+          :get,
+          "/api/transition-checker-email-subscription",
+          response_body: { has_subscription: false },
+          **options,
+        )
       end
 
-      def stub_account_api_set_email_subscription(govuk_account_session: nil, slug: "slug", new_govuk_account_session: nil)
-        if govuk_account_session
-          stub_request(:post, "#{ACCOUNT_API_ENDPOINT}/api/transition-checker-email-subscription")
-            .with(body: hash_including({ slug: slug }.compact), headers: { GdsApi::AccountApi::AUTH_HEADER_NAME => govuk_account_session })
-            .to_return(status: 200, body: { govuk_account_session: new_govuk_account_session }.compact.to_json)
-        else
-          stub_request(:post, "#{ACCOUNT_API_ENDPOINT}/api/transition-checker-email-subscription")
-            .with(body: hash_including({ slug: slug }.compact))
-            .to_return(status: 200, body: { govuk_account_session: new_govuk_account_session }.compact.to_json)
-        end
+      def stub_account_api_set_email_subscription(slug: "slug", **options)
+        stub_account_api_request(
+          :post,
+          "/api/transition-checker-email-subscription",
+          with: { body: hash_including({ slug: slug }.compact) },
+          **options,
+        )
       end
 
-      def stub_account_api_has_attributes(govuk_account_session: nil, attributes: [], values: {}, new_govuk_account_session: nil)
+      def stub_account_api_has_attributes(attributes: [], values: {}, **options)
         querystring = Rack::Utils.build_nested_query({ attributes: attributes }.compact)
-        if govuk_account_session
-          stub_request(:get, "#{ACCOUNT_API_ENDPOINT}/api/attributes?#{querystring}")
-            .with(headers: { GdsApi::AccountApi::AUTH_HEADER_NAME => govuk_account_session })
-            .to_return(status: 200, body: { govuk_account_session: new_govuk_account_session, values: values }.compact.to_json)
-        else
-          stub_request(:get, "#{ACCOUNT_API_ENDPOINT}/api/attributes?#{querystring}")
-            .to_return(status: 200, body: { govuk_account_session: new_govuk_account_session, values: values }.compact.to_json)
-        end
+        stub_account_api_request(
+          :get,
+          "/api/attributes?#{querystring}",
+          response_body: { values: values },
+          **options,
+        )
       end
 
-      def stub_account_api_set_attributes(govuk_account_session: nil, attributes: nil, new_govuk_account_session: nil)
-        if govuk_account_session
-          stub_request(:patch, "#{ACCOUNT_API_ENDPOINT}/api/attributes")
-            .with(body: hash_including({ attributes: attributes }.compact), headers: { GdsApi::AccountApi::AUTH_HEADER_NAME => govuk_account_session })
-            .to_return(status: 200, body: { govuk_account_session: new_govuk_account_session }.compact.to_json)
-        else
-          stub_request(:patch, "#{ACCOUNT_API_ENDPOINT}/api/attributes")
-            .with(body: hash_including({ attributes: attributes }.compact))
-            .to_return(status: 200, body: { govuk_account_session: new_govuk_account_session }.compact.to_json)
-        end
+      def stub_account_api_set_attributes(attributes: nil, **options)
+        stub_account_api_request(
+          :patch,
+          "/api/attributes",
+          with: { body: hash_including({ attributes: attributes }.compact) },
+          **options,
+        )
       end
 
-      def stub_account_api_get_attributes_names(govuk_account_session: nil, attributes: [], new_govuk_account_session: nil)
+      def stub_account_api_get_attributes_names(attributes: [], **options)
         querystring = Rack::Utils.build_nested_query({ attributes: attributes }.compact)
-        if govuk_account_session
-          stub_request(:get, "#{ACCOUNT_API_ENDPOINT}/api/attributes/names?#{querystring}")
-            .with(headers: { GdsApi::AccountApi::AUTH_HEADER_NAME => govuk_account_session })
-            .to_return(status: 200, body: { govuk_account_session: new_govuk_account_session, values: attributes }.compact.to_json)
+        stub_account_api_request(
+          :get,
+          "/api/attributes/names?#{querystring}",
+          response_body: { values: attributes },
+          **options,
+        )
+      end
+
+      def stub_account_api_request(method, path, with: {}, response_status: 200, response_body: {}, govuk_account_session: nil, new_govuk_account_session: nil)
+        with.merge!(headers: { GdsApi::AccountApi::AUTH_HEADER_NAME => govuk_account_session }) if govuk_account_session
+        to_return = { status: response_status, body: response_body.merge(govuk_account_session: new_govuk_account_session).compact.to_json }
+        if with.empty?
+          stub_request(method, "#{ACCOUNT_API_ENDPOINT}#{path}").to_return(**to_return)
         else
-          stub_request(:get, "#{ACCOUNT_API_ENDPOINT}/api/attributes/names?#{querystring}")
-            .to_return(status: 200, body: { govuk_account_session: new_govuk_account_session, values: attributes }.compact.to_json)
+          stub_request(method, "#{ACCOUNT_API_ENDPOINT}#{path}").with(**with).to_return(**to_return)
         end
       end
     end


### PR DESCRIPTION
We don't currently expose an easy way to create error cases in tests, but those will be useful as we roll out levels of authentication and want to test that apps do the right thing in the failure cases.