### PR TITLE
Add Account API Feature: Save a page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Add endpoints for authenticated "Save a page" API
+
 # 71.1.0
 
 * Removed `LinkCheckerApi#upsert_resource_monitor` method as it’s not supported by Link Checker API itself.

--- a/lib/gds_api/account_api.rb
+++ b/lib/gds_api/account_api.rb
@@ -96,6 +96,15 @@ class GdsApi::AccountApi < GdsApi::Base
     get_json("#{endpoint}/api/attributes/names?#{querystring}", auth_headers(govuk_account_session))
   end
 
+  # Look up all pages saved by a user in their Account
+  #
+  # @param [String] govuk_account_session Value of the session header
+  #
+  # @return [Hash] containing :saved_pages, an array of single saved page hashes  def get_saved_pages(govuk_account_session:)
+  def get_saved_pages(govuk_account_session:)
+    get_json("#{endpoint}/api/saved_pages", auth_headers(govuk_account_session))
+  end
+
 private
 
   def nested_query_string(params)

--- a/lib/gds_api/account_api.rb
+++ b/lib/gds_api/account_api.rb
@@ -125,6 +125,17 @@ class GdsApi::AccountApi < GdsApi::Base
     put_json("#{endpoint}/api/saved_pages/#{CGI.escape(page_path)}", {}, auth_headers(govuk_account_session))
   end
 
+  # Delete a single saved page entry from a users account
+  #
+  # @param [String] the path of a page to check
+  # @param [String] govuk_account_session Value of the session header
+  #
+  # @return [GdsApi::Response] A status code of 204 indicates the saved page has been successfully deleted.
+  #                            A status code of 404 indicates there is no saved page with this path.
+  def delete_saved_page(page_path:, govuk_account_session:)
+    delete_json("#{endpoint}/api/saved_pages/#{CGI.escape(page_path)}", {}, auth_headers(govuk_account_session))
+  end
+
 private
 
   def nested_query_string(params)

--- a/lib/gds_api/account_api.rb
+++ b/lib/gds_api/account_api.rb
@@ -105,6 +105,16 @@ class GdsApi::AccountApi < GdsApi::Base
     get_json("#{endpoint}/api/saved_pages", auth_headers(govuk_account_session))
   end
 
+  # Return a single page by unique URL
+  #
+  # @param [String] the path of a page to check
+  # @param [String] govuk_account_session Value of the session header
+  #
+  # @return [Hash] containing :saved_page, a hash of a single saved page value
+  def get_saved_page(page_path:, govuk_account_session:)
+    get_json("#{endpoint}/api/saved_pages/#{CGI.escape(page_path)}", auth_headers(govuk_account_session))
+  end
+
 private
 
   def nested_query_string(params)

--- a/lib/gds_api/account_api.rb
+++ b/lib/gds_api/account_api.rb
@@ -115,6 +115,16 @@ class GdsApi::AccountApi < GdsApi::Base
     get_json("#{endpoint}/api/saved_pages/#{CGI.escape(page_path)}", auth_headers(govuk_account_session))
   end
 
+  # Upsert a single saved page entry in a users account
+  #
+  # @param [String] the path of a page to check
+  # @param [String] govuk_account_session Value of the session header
+  #
+  # @return [Hash] A single saved page value (if sucessful)
+  def save_page(page_path:, govuk_account_session:)
+    put_json("#{endpoint}/api/saved_pages/#{CGI.escape(page_path)}", {}, auth_headers(govuk_account_session))
+  end
+
 private
 
   def nested_query_string(params)

--- a/lib/gds_api/test_helpers/account_api.rb
+++ b/lib/gds_api/test_helpers/account_api.rb
@@ -302,6 +302,36 @@ module GdsApi
           **option,
         }
       end
+
+      ####################################
+      # DELETE /api/saved-pages/:page_path
+      ####################################
+      def stub_account_api_delete_saved_page(page_path:, **options)
+        stub_account_api_request(
+          :delete,
+          "/api/saved_pages/#{CGI.escape(page_path)}",
+          response_status: 204,
+          **options,
+        )
+      end
+
+      def stub_account_api_delete_saved_page_does_not_exist(page_path:, **options)
+        stub_account_api_request(
+          :delete,
+          "/api/saved_pages/#{CGI.escape(page_path)}",
+          response_status: 404,
+          **options,
+        )
+      end
+
+      def stub_account_api_delete_saved_page_unauthorised(page_path:, **options)
+        stub_account_api_request(
+          :delete,
+          "/api/saved_pages/#{CGI.escape(page_path)}",
+          response_status: 401,
+          **options,
+        )
+      end
     end
   end
 end

--- a/lib/gds_api/test_helpers/account_api.rb
+++ b/lib/gds_api/test_helpers/account_api.rb
@@ -258,6 +258,50 @@ module GdsApi
           **options,
         )
       end
+
+      #################################
+      # PUT /api/saved_pages/:page_path
+      #################################
+      def stub_account_api_save_page(page_path:, **options)
+        stub_account_api_request(
+          :put,
+          "/api/saved_pages/#{CGI.escape(page_path)}",
+          response_body: { saved_page: { page_path: page_path } },
+          **options,
+        )
+      end
+
+      def stub_account_api_save_page_already_exists(page_path:, **options)
+        stub_account_api_save_page(page_path: page_path, **options)
+      end
+
+      def stub_account_api_save_page_cannot_save_page(page_path:, **options)
+        stub_account_api_request(
+          :put,
+          "/api/saved_pages/#{CGI.escape(page_path)}",
+          response_status: 422,
+          response_body: { **cannot_save_page_problem_detail({ page_path: page_path }) },
+          **options,
+        )
+      end
+
+      def stub_account_api_unauthorized_save_page(page_path:, **options)
+        stub_account_api_request(
+          :put,
+          "/api/saved_pages/#{CGI.escape(page_path)}",
+          response_status: 401,
+          **options,
+        )
+      end
+
+      def cannot_save_page_problem_detail(option = {})
+        {
+          title: "Cannot save page",
+          detail: "Cannot save page with path #{option['page_path']}, check it is not blank, and is a well formatted url path.",
+          type: "https://github.com/alphagov/account-api/blob/main/docs/api.md#cannot-save-page",
+          **option,
+        }
+      end
     end
   end
 end

--- a/lib/gds_api/test_helpers/account_api.rb
+++ b/lib/gds_api/test_helpers/account_api.rb
@@ -207,6 +207,27 @@ module GdsApi
           stub_request(method, "#{ACCOUNT_API_ENDPOINT}#{path}").with(**with).to_return(**to_return)
         end
       end
+
+      ######################
+      # GET /api/saved_pages
+      ######################
+      def stub_account_api_returning_saved_pages(saved_pages: [], **options)
+        stub_account_api_request(
+          :get,
+          "/api/saved_pages",
+          response_body: { saved_pages: saved_pages },
+          **options,
+        )
+      end
+
+      def stub_account_api_unauthorized_get_saved_pages(**options)
+        stub_account_api_request(
+          :get,
+          "/api/saved_pages",
+          response_status: 401,
+          **options,
+        )
+      end
     end
   end
 end

--- a/lib/gds_api/test_helpers/account_api.rb
+++ b/lib/gds_api/test_helpers/account_api.rb
@@ -228,6 +228,36 @@ module GdsApi
           **options,
         )
       end
+
+      #################################
+      # GET /api/saved_pages/:page_path
+      #################################
+      def stub_account_api_get_saved_page(page_path:, **options)
+        stub_account_api_request(
+          :get,
+          "/api/saved_pages/#{CGI.escape(page_path)}",
+          response_body: { saved_page: { page_path: page_path } },
+          **options,
+        )
+      end
+
+      def stub_account_api_does_not_have_saved_page(page_path:, **options)
+        stub_account_api_request(
+          :get,
+          "/api/saved_pages/#{CGI.escape(page_path)}",
+          response_status: 404,
+          **options,
+        )
+      end
+
+      def stub_account_api_unauthorized_get_saved_page(page_path:, **options)
+        stub_account_api_request(
+          :get,
+          "/api/saved_pages/#{CGI.escape(page_path)}",
+          response_status: 401,
+          **options,
+        )
+      end
     end
   end
 end

--- a/test/account_api/account_api_test.rb
+++ b/test/account_api/account_api_test.rb
@@ -189,4 +189,26 @@ describe GdsApi::AccountApi do
       end
     end
   end
+
+  describe "#get_saved_page" do
+    it "gets a single saved page by path and returns a saved page hash" do
+      stub_account_api_get_saved_page(page_path: "/foo", new_govuk_account_session: new_session_id)
+      assert_equal({ "page_path" => "/foo" }, api_client.get_saved_page(page_path: "/foo", govuk_account_session: new_session_id)["saved_page"])
+    end
+
+    it "it returns an empty array if there are no saved pages" do
+      stub_account_api_does_not_have_saved_page(page_path: "/bar", new_govuk_account_session: new_session_id)
+      assert_raises GdsApi::HTTPNotFound do
+        api_client.get_saved_page(page_path: "/bar", govuk_account_session: session_id)
+      end
+    end
+
+    it "throws a 401 if user is not logged in or their session is invalid" do
+      stub_account_api_unauthorized_get_saved_page(page_path: "/foo")
+
+      assert_raises GdsApi::HTTPUnauthorized do
+        api_client.get_saved_page(page_path: "/foo", govuk_account_session: session_id)
+      end
+    end
+  end
 end

--- a/test/account_api/account_api_test.rb
+++ b/test/account_api/account_api_test.rb
@@ -166,4 +166,27 @@ describe GdsApi::AccountApi do
       assert_equal("level1", JSON.parse(error.http_body)["needed_level_of_authentication"])
     end
   end
+
+  describe "#get_saved_pages" do
+    let(:saved_pages) { [{ "page_path" => "/foo" }, { "page_path" => "/bar" }] }
+
+    it "gets saved pages" do
+      stub_saved_pages = saved_pages
+      stub_account_api_returning_saved_pages(saved_pages: stub_saved_pages, new_govuk_account_session: new_session_id)
+      assert_equal(saved_pages, api_client.get_saved_pages(govuk_account_session: new_session_id)["saved_pages"])
+    end
+
+    it "it returns an empty array if there are no saved pages" do
+      stub_account_api_returning_saved_pages(saved_pages: [], new_govuk_account_session: new_session_id)
+      assert_equal([], api_client.get_saved_pages(govuk_account_session: new_session_id)["saved_pages"])
+    end
+
+    it "throws a 401 if user is not logged in or their session is invalid" do
+      stub_account_api_unauthorized_get_saved_pages
+
+      assert_raises GdsApi::HTTPUnauthorized do
+        api_client.get_saved_pages(govuk_account_session: new_session_id)
+      end
+    end
+  end
 end

--- a/test/account_api/account_api_test.rb
+++ b/test/account_api/account_api_test.rb
@@ -265,4 +265,25 @@ describe GdsApi::AccountApi do
       end
     end
   end
+
+  describe "#delete_saved_page" do
+    it "returns 204 if sucessfully deleted" do
+      stub_account_api_delete_saved_page(page_path: "/foo", new_govuk_account_session: new_session_id)
+      assert_equal(204, api_client.delete_saved_page(page_path: "/foo", govuk_account_session: session_id).code)
+    end
+
+    it "throws 404 if the saved page does not exist" do
+      stub_account_api_delete_saved_page_does_not_exist(page_path: "/foo", new_govuk_account_session: new_session_id)
+      assert_raises GdsApi::HTTPNotFound do
+        api_client.delete_saved_page(page_path: "/foo", govuk_account_session: session_id)
+      end
+    end
+
+    it "throws a 401 if user is not logged in or their session is invalid" do
+      stub_account_api_delete_saved_page_unauthorised(page_path: "/foo", new_govuk_account_session: new_session_id)
+      assert_raises GdsApi::HTTPUnauthorized do
+        api_client.delete_saved_page(page_path: "/foo", govuk_account_session: session_id)
+      end
+    end
+  end
 end


### PR DESCRIPTION
[Trello card](https://trello.com/c/OvsvoWsO/766-implement-an-api-to-save-a-page-unsave-a-page-check-if-a-page-is-saved-and-return-the-list-of-saved-pages)

Also relevant: [account-api#69](https://github.com/alphagov/account-api/pull/69)

## What

Add save page endpoints allowing an authenticated user to get an index of all their saved pages, as well ass add, delete or query a single saved page.