### PR TITLE
Bump version 71.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 71.2.0
 
 * Add endpoints for authenticated "Save a page" API
 

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = "71.1.0".freeze
+  VERSION = "71.2.0".freeze
 end


### PR DESCRIPTION
[Trello](https://trello.com/c/OvsvoWsO/766-implement-an-api-to-save-a-page-unsave-a-page-check-if-a-page-is-saved-and-return-the-list-of-saved-pages)

Releases the GOV.UK Account API saved page API wrappers.

- [See Save a Page feature work here](https://github.com/alphagov/account-api/pull/69)
- [See GDS API adaptors work here]( https://github.com/alphagov/gds-api-adapters/pull/1067)
- Part of the Spring/Summer 2021 GOV.UK Accounts team work