### PR TITLE
Add `content_id` and `title` fields to "save a page" test helpers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# unreleased
+
+* Add `content_id` and `title` fields to "save a page" test helpers.
+
 # 71.2.0
 
 * Add endpoints for authenticated "Save a page" API

--- a/lib/gds_api/test_helpers/account_api.rb
+++ b/lib/gds_api/test_helpers/account_api.rb
@@ -232,11 +232,17 @@ module GdsApi
       #################################
       # GET /api/saved_pages/:page_path
       #################################
-      def stub_account_api_get_saved_page(page_path:, **options)
+      def stub_account_api_get_saved_page(page_path:, content_id: "46163ed2-1777-4ee6-bdd4-6a2007e49d8f", title: "Ministry of Magic", **options)
         stub_account_api_request(
           :get,
           "/api/saved_pages/#{CGI.escape(page_path)}",
-          response_body: { saved_page: { page_path: page_path } },
+          response_body: {
+            saved_page: {
+              page_path: page_path,
+              content_id: content_id,
+              title: title,
+            },
+          },
           **options,
         )
       end
@@ -262,11 +268,17 @@ module GdsApi
       #################################
       # PUT /api/saved_pages/:page_path
       #################################
-      def stub_account_api_save_page(page_path:, **options)
+      def stub_account_api_save_page(page_path:, content_id: "c840bfa2-011a-42cc-ac7a-a6da990aff0b", title: "Ministry of Magic", **options)
         stub_account_api_request(
           :put,
           "/api/saved_pages/#{CGI.escape(page_path)}",
-          response_body: { saved_page: { page_path: page_path } },
+          response_body: {
+            saved_page: {
+              page_path: page_path,
+              content_id: content_id,
+              title: title,
+            },
+          },
           **options,
         )
       end
@@ -280,7 +292,7 @@ module GdsApi
           :put,
           "/api/saved_pages/#{CGI.escape(page_path)}",
           response_status: 422,
-          response_body: { **cannot_save_page_problem_detail({ page_path: page_path }) },
+          response_body: cannot_save_page_problem_detail({ page_path: page_path }),
           **options,
         )
       end

--- a/test/account_api/account_api_test.rb
+++ b/test/account_api/account_api_test.rb
@@ -192,8 +192,8 @@ describe GdsApi::AccountApi do
 
   describe "#get_saved_page" do
     it "gets a single saved page by path and returns a saved page hash" do
-      stub_account_api_get_saved_page(page_path: "/foo", new_govuk_account_session: new_session_id)
-      assert_equal({ "page_path" => "/foo" }, api_client.get_saved_page(page_path: "/foo", govuk_account_session: new_session_id)["saved_page"])
+      stub_account_api_get_saved_page(page_path: "/foo", content_id: "content-id", title: "title", new_govuk_account_session: new_session_id)
+      assert_equal({ "page_path" => "/foo", "content_id" => "content-id", "title" => "title" }, api_client.get_saved_page(page_path: "/foo", govuk_account_session: session_id)["saved_page"])
     end
 
     it "it returns an empty array if there are no saved pages" do
@@ -214,21 +214,20 @@ describe GdsApi::AccountApi do
 
   describe "#save_page" do
     describe "if the saved page does not exist in the user's account" do
-      before { stub_account_api_save_page(page_path: "/foo", new_govuk_account_session: new_session_id) }
+      before { stub_account_api_save_page(page_path: "/foo", content_id: "content-id", title: "title", new_govuk_account_session: new_session_id) }
 
       it "responds sucessfully" do
         assert_equal(200, api_client.save_page(page_path: "/foo", govuk_account_session: session_id).code)
       end
 
       it "returns the created value" do
-        assert_equal({ "page_path" => "/foo" }, api_client.save_page(page_path: "/foo", govuk_account_session: session_id)["saved_page"])
+        assert_equal({ "page_path" => "/foo", "content_id" => "content-id", "title" => "title" }, api_client.save_page(page_path: "/foo", govuk_account_session: session_id)["saved_page"])
       end
     end
 
-    it "silently upserts and returns 200 if the page already exists" do
+    it "returns success if the page already exists" do
       stub_account_api_save_page_already_exists(page_path: "/existing", new_govuk_account_session: new_session_id)
       assert_equal(200, api_client.save_page(page_path: "/existing", govuk_account_session: session_id).code)
-      assert_equal({ "page_path" => "/existing" }, api_client.save_page(page_path: "/existing", govuk_account_session: session_id)["saved_page"])
     end
 
     it "responds 401 Unauthorized if user is not logged in or their session is invalid" do
@@ -238,30 +237,10 @@ describe GdsApi::AccountApi do
       end
     end
 
-    it "responds 422 Unprocessable Entity if the page path includes a fragment identifier" do
-      invalid_page_path = "/foo#bar"
-
-      stub_account_api_save_page_cannot_save_page(page_path: invalid_page_path, new_govuk_account_session: new_session_id)
+    it "responds 422 Unprocessable Entity if the page cannot be saved" do
+      stub_account_api_save_page_cannot_save_page(page_path: "/invalid", new_govuk_account_session: new_session_id)
       assert_raises GdsApi::HTTPUnprocessableEntity do
-        api_client.save_page(page_path: invalid_page_path, govuk_account_session: session_id)
-      end
-    end
-
-    it "responds 422 Unprocessable Entity if the page path includes query parameter" do
-      invalid_page_path = "/foo?bar"
-
-      stub_account_api_save_page_cannot_save_page(page_path: invalid_page_path, new_govuk_account_session: new_session_id)
-      assert_raises GdsApi::HTTPUnprocessableEntity do
-        api_client.save_page(page_path: invalid_page_path, govuk_account_session: session_id)
-      end
-    end
-
-    it "responds 422 Unprocessable Entity if the page path includes a domain" do
-      invalid_page_path = "gov.uk/foo"
-
-      stub_account_api_save_page_cannot_save_page(page_path: invalid_page_path, new_govuk_account_session: new_session_id)
-      assert_raises GdsApi::HTTPUnprocessableEntity do
-        api_client.save_page(page_path: invalid_page_path, govuk_account_session: session_id)
+        api_client.save_page(page_path: "/invalid", govuk_account_session: session_id)
       end
     end
   end

--- a/test/account_api_test.rb
+++ b/test/account_api_test.rb
@@ -318,7 +318,20 @@ describe GdsApi::AccountApi do
 
       describe "a user has saved pages" do
         let(:given) { "there is a valid user session, with saved pages" }
-        let(:saved_pages) { [{ page_path: "/page-path/1" }, { page_path: "/page-path/2" }] }
+        let(:saved_pages) do
+          [
+            {
+              page_path: "/page-path/1",
+              content_id: Pact.like("7b7b77b0-257a-467d-84c9-c5167781d05c"),
+              title: Pact.like("Page #1"),
+            },
+            {
+              page_path: "/page-path/2",
+              content_id: Pact.like("7b7b77b0-257a-467d-84c9-c5167781d05c"),
+              title: Pact.like("Page #1"),
+            },
+          ]
+        end
 
         it "responds with 200 OK, a new govuk_account_session, and returns an array of saved pages" do
           api_client.get_saved_pages(govuk_account_session: govuk_account_session)
@@ -347,7 +360,11 @@ describe GdsApi::AccountApi do
             headers: { "Content-Type" => "application/json; charset=utf-8" },
             body: {
               govuk_account_session: Pact.like("user-session-id"),
-              saved_page: { page_path: page_path },
+              saved_page: {
+                page_path: page_path,
+                content_id: Pact.like("6e0e144a-9e59-4ac8-af3b-d87e8ff30a47"),
+                title: Pact.like("Some GOV.UK Guidance"),
+              },
             },
           )
       end


### PR DESCRIPTION
I also removed some of the 422 response tests, as they were all
testing the same thing: a path stubbed to be invalid is invalid.  The
actual validation logic is not in this repo.

---

[Trello card](https://trello.com/c/8EadgviV/772-get-account-api-consuming-publishing-messages-from-rabbitmq)