### PR TITLE
Add `update_user_by_subject_identifier` (for Account API)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # unreleased
 
+* Add `update_user_by_subject_identifier` (for Account API)
 * Update "save a page" helpers to use new routes.
 
 # 71.3.0

--- a/lib/gds_api/account_api.rb
+++ b/lib/gds_api/account_api.rb
@@ -54,6 +54,17 @@ class GdsApi::AccountApi < GdsApi::Base
     get_json("#{endpoint}/api/user", auth_headers(govuk_account_session))
   end
 
+  # Update the user record with privileged information from the auth service.  Only the auth service will call this.
+  #
+  # @param [String] subject_identifier The identifier of the user, shared between the auth service and GOV.UK.
+  # @param [String, nil] email The new email address
+  # @param [Boolean, nil] email_verified Whether the new email address is verified
+  #
+  # @return [Hash] The user's subject identifier and email attributes
+  def update_user_by_subject_identifier(subject_identifier:, email: nil, email_verified: nil)
+    patch_json("#{endpoint}/api/oidc-users/#{subject_identifier}", { email: email, email_verified: email_verified }.compact)
+  end
+
   # Check if a user has an email subscription for the Transition Checker
   #
   # @param [String] govuk_account_session Value of the session header

--- a/lib/gds_api/test_helpers/account_api.rb
+++ b/lib/gds_api/test_helpers/account_api.rb
@@ -69,6 +69,19 @@ module GdsApi
         )
       end
 
+      def stub_update_user_by_subject_identifier(subject_identifier:, email: nil, email_verified: nil, old_email: nil, old_email_verified: nil)
+        stub_account_api_request(
+          :patch,
+          "/api/oidc-users/#{subject_identifier}",
+          with: { body: hash_including({ email: email, email_verified: email_verified }.compact) },
+          response_body: {
+            sub: subject_identifier,
+            email: email || old_email,
+            email_verified: email_verified || old_email_verified,
+          },
+        )
+      end
+
       def stub_account_api_has_email_subscription(**options)
         stub_account_api_request(
           :get,

--- a/test/account_api/account_api_test.rb
+++ b/test/account_api/account_api_test.rb
@@ -51,6 +51,11 @@ describe GdsApi::AccountApi do
     assert_equal("yes_but_must_reauthenticate", api_client.get_user(govuk_account_session: session_id)["services"]["register_to_become_a_wizard"])
   end
 
+  it "updates the user's email attributes" do
+    stub_update_user_by_subject_identifier(subject_identifier: "sid", email_verified: true, old_email: "email@example.com")
+    assert_equal({ "sub" => "sid", "email" => "email@example.com", "email_verified" => true }, api_client.update_user_by_subject_identifier(subject_identifier: "sid", email_verified: true).to_hash)
+  end
+
   describe "a transition checker subscription exists" do
     before { stub_account_api_has_email_subscription(new_govuk_account_session: new_session_id) }
 

--- a/test/account_api_test.rb
+++ b/test/account_api_test.rb
@@ -155,6 +155,36 @@ describe GdsApi::AccountApi do
     end
   end
 
+  describe "updating a user from the auth provider" do
+    let(:subject_identifier) { "the-subject-identifier" }
+    let(:email) { "example.email.address@gov.uk" }
+    let(:email_verified) { true }
+
+    before do
+      account_api
+        .upon_receiving("a request to change the user's email attributes")
+        .with(
+          method: :patch,
+          path: "/api/oidc-users/#{subject_identifier}",
+          body: { email: email, email_verified: email_verified },
+          headers: GdsApi::JsonClient.default_request_with_json_body_headers,
+        )
+      .will_respond_with(
+        status: 200,
+        headers: { "Content-Type" => "application/json; charset=utf-8" },
+        body: {
+          sub: subject_identifier,
+          email: email,
+          email_verified: email_verified,
+        },
+      )
+    end
+
+    it "responds with 200 OK" do
+      api_client.update_user_by_subject_identifier(subject_identifier: subject_identifier, email: email, email_verified: email_verified)
+    end
+  end
+
   describe "checking for a transition checker email subscription" do
     describe "the user is logged in" do
       let(:given) { "there is a valid user session" }


### PR DESCRIPTION
See also https://github.com/alphagov/account-api/pull/106

---

[Trello card](https://trello.com/c/UD2IR18h/830-make-account-manager-tell-account-api-about-email-address-changes)