### PR TITLE
Add functions and test helpers for account-linked emails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# unreleased
+
+* Add functions and test helpers for account-linked email subscriptions.
+
 # 71.4.0
 
 * Add `update_user_by_subject_identifier` (for Account API)

--- a/lib/gds_api/account_api.rb
+++ b/lib/gds_api/account_api.rb
@@ -116,11 +116,40 @@ class GdsApi::AccountApi < GdsApi::Base
     get_json("#{endpoint}/api/attributes/names?#{querystring}", auth_headers(govuk_account_session))
   end
 
+  # Get the details of an account-linked email subscription.
+  #
+  # @param [String] name Name of the subscription
+  # @param [String] govuk_account_session Value of the session header
+  #
+  # @return [Hash] Details of the subscription, if it exists.
+  def get_email_subscription(name:, govuk_account_session:)
+    get_json("#{endpoint}/api/email-subscriptions/#{CGI.escape(name)}", auth_headers(govuk_account_session))
+  end
+
+  # Create or update an account-linked email subscription.
+  #
+  # @param [String] name Name of the subscription
+  # @param [String] topic_slug The email-alert-api topic slug to subscribe to
+  # @param [String] govuk_account_session Value of the session header
+  #
+  # @return [Hash] Details of the newly created subscription.
+  def put_email_subscription(name:, topic_slug:, govuk_account_session:)
+    put_json("#{endpoint}/api/email-subscriptions/#{CGI.escape(name)}", { topic_slug: topic_slug }, auth_headers(govuk_account_session))
+  end
+
+  # Unsubscribe and delete an account-linked email subscription.
+  #
+  # @param [String] name Name of the subscription
+  # @param [String] govuk_account_session Value of the session header
+  def delete_email_subscription(name:, govuk_account_session:)
+    delete_json("#{endpoint}/api/email-subscriptions/#{CGI.escape(name)}", {}, auth_headers(govuk_account_session))
+  end
+
   # Look up all pages saved by a user in their Account
   #
   # @param [String] govuk_account_session Value of the session header
   #
-  # @return [Hash] containing :saved_pages, an array of single saved page hashes  def get_saved_pages(govuk_account_session:)
+  # @return [Hash] containing :saved_pages, an array of single saved page hashes
   def get_saved_pages(govuk_account_session:)
     get_json("#{endpoint}/api/saved-pages", auth_headers(govuk_account_session))
   end

--- a/lib/gds_api/test_helpers/account_api.rb
+++ b/lib/gds_api/test_helpers/account_api.rb
@@ -69,6 +69,91 @@ module GdsApi
         )
       end
 
+      def stub_account_api_get_email_subscription(name:, topic_slug: "slug", email_alert_api_subscription_id: "12345", **options)
+        stub_account_api_request(
+          :get,
+          "/api/email-subscriptions/#{name}",
+          response_body: {
+            email_subscription: {
+              name: name,
+              topic_slug: topic_slug,
+              email_alert_api_subscription_id: email_alert_api_subscription_id,
+            },
+          },
+          **options,
+        )
+      end
+
+      def stub_account_api_get_email_subscription_does_not_exist(name:, **options)
+        stub_account_api_request(
+          :get,
+          "/api/email-subscriptions/#{name}",
+          response_status: 404,
+          **options,
+        )
+      end
+
+      def stub_account_api_get_email_subscription_unauthorized(name:, **options)
+        stub_account_api_request(
+          :get,
+          "/api/email-subscriptions/#{name}",
+          response_status: 401,
+          **options,
+        )
+      end
+
+      def stub_account_api_put_email_subscription(name:, topic_slug: nil, **options)
+        stub_account_api_request(
+          :put,
+          "/api/email-subscriptions/#{name}",
+          with: { body: hash_including({ topic_slug: topic_slug }.compact) },
+          response_body: {
+            email_subscription: {
+              name: name,
+              topic_slug: topic_slug || "slug",
+            },
+          },
+          **options,
+        )
+      end
+
+      def stub_account_api_unauthorized_put_email_subscription(name:, topic_slug: nil, **options)
+        stub_account_api_request(
+          :put,
+          "/api/email-subscriptions/#{name}",
+          with: { body: hash_including({ topic_slug: topic_slug }.compact) },
+          response_status: 401,
+          **options,
+        )
+      end
+
+      def stub_account_api_delete_email_subscription(name:, **options)
+        stub_account_api_request(
+          :delete,
+          "/api/email-subscriptions/#{name}",
+          response_status: 204,
+          **options,
+        )
+      end
+
+      def stub_account_api_delete_email_subscription_does_not_exist(name:, **options)
+        stub_account_api_request(
+          :delete,
+          "/api/email-subscriptions/#{name}",
+          response_status: 404,
+          **options,
+        )
+      end
+
+      def stub_account_api_unauthorized_delete_email_subscription(name:, **options)
+        stub_account_api_request(
+          :delete,
+          "/api/email-subscriptions/#{name}",
+          response_status: 401,
+          **options,
+        )
+      end
+
       def stub_update_user_by_subject_identifier(subject_identifier:, email: nil, email_verified: nil, old_email: nil, old_email_verified: nil)
         stub_account_api_request(
           :patch,

--- a/test/account_api/account_api_test.rb
+++ b/test/account_api/account_api_test.rb
@@ -112,6 +112,41 @@ describe GdsApi::AccountApi do
     assert_equal queried_attribute_names, returned_attribute_names
   end
 
+  describe "get_email_subscription" do
+    it "returns the subscription details if it exists" do
+      stub_account_api_get_email_subscription(name: "foo")
+      assert(!api_client.get_email_subscription(name: "foo", govuk_account_session: session_id)["email_subscription"].nil?)
+    end
+
+    it "throws a 404 if it does not exist" do
+      stub_account_api_get_email_subscription_does_not_exist(name: "foo")
+      assert_raises GdsApi::HTTPNotFound do
+        api_client.get_email_subscription(name: "foo", govuk_account_session: session_id)
+      end
+    end
+  end
+
+  describe "put_email_subscription" do
+    it "returns the new subscription details" do
+      stub_account_api_put_email_subscription(name: "foo", topic_slug: "slug")
+      assert(!api_client.put_email_subscription(name: "foo", topic_slug: "slug", govuk_account_session: session_id)["email_subscription"].nil?)
+    end
+  end
+
+  describe "delete_email_subscription" do
+    it "returns no content if it exists" do
+      stub_account_api_delete_email_subscription(name: "foo")
+      assert_equal(204, api_client.delete_email_subscription(name: "foo", govuk_account_session: session_id).code)
+    end
+
+    it "throws a 404 if it does not exist" do
+      stub_account_api_delete_email_subscription_does_not_exist(name: "foo")
+      assert_raises GdsApi::HTTPNotFound do
+        api_client.delete_email_subscription(name: "foo", govuk_account_session: session_id)
+      end
+    end
+  end
+
   describe "the user is not logged in or their session is invalid" do
     it "throws a 401 if the user checks their information" do
       stub_account_api_unauthorized_user_info
@@ -180,6 +215,27 @@ describe GdsApi::AccountApi do
       stub_account_api_delete_saved_page_unauthorised(page_path: "/foo")
       assert_raises GdsApi::HTTPUnauthorized do
         api_client.delete_saved_page(page_path: "/foo", govuk_account_session: session_id)
+      end
+    end
+
+    it "throws a 401 if the user gets an email subscription" do
+      stub_account_api_get_email_subscription_unauthorized(name: "foo")
+      assert_raises GdsApi::HTTPUnauthorized do
+        api_client.get_email_subscription(name: "foo", govuk_account_session: session_id)
+      end
+    end
+
+    it "throws a 401 if the user updates an email subscription" do
+      stub_account_api_unauthorized_put_email_subscription(name: "foo")
+      assert_raises GdsApi::HTTPUnauthorized do
+        api_client.put_email_subscription(name: "foo", topic_slug: "slug", govuk_account_session: session_id)
+      end
+    end
+
+    it "throws a 401 if the user deletes an email subscription" do
+      stub_account_api_unauthorized_delete_email_subscription(name: "foo")
+      assert_raises GdsApi::HTTPUnauthorized do
+        api_client.delete_email_subscription(name: "foo", govuk_account_session: session_id)
       end
     end
   end

--- a/test/account_api/account_api_test.rb
+++ b/test/account_api/account_api_test.rb
@@ -9,140 +9,237 @@ describe GdsApi::AccountApi do
   let(:session_id) { "session-id" }
   let(:new_session_id) { "new-session-id" }
 
-  it "gets a sign in URL" do
-    stub_account_api_get_sign_in_url(auth_uri: "https://www.example.com")
-    assert_equal("https://www.example.com", api_client.get_sign_in_url.to_hash["auth_uri"])
-  end
-
-  it "gives a session ID if the auth response validates" do
-    stub_account_api_validates_auth_response(code: "foo", state: "bar")
-    assert(!api_client.validate_auth_response(code: "foo", state: "bar")["govuk_account_session"].nil?)
-  end
-
-  it "throws a 401 if the auth response does not validate" do
-    stub_account_api_rejects_auth_response(code: "foo", state: "bar")
-
-    assert_raises GdsApi::HTTPUnauthorized do
-      api_client.validate_auth_response(code: "foo", state: "bar")
+  describe "#get_sign_in_url" do
+    it "gives an auth URI" do
+      stub_account_api_get_sign_in_url(auth_uri: "https://www.example.com")
+      assert_equal("https://www.example.com", api_client.get_sign_in_url.to_hash["auth_uri"])
     end
   end
 
-  it "gets a state ID" do
-    stub_account_api_create_registration_state(attributes: { foo: "bar" }, state_id: "state-id")
-    assert_equal("state-id", api_client.create_registration_state(attributes: { foo: "bar" }).to_hash["state_id"])
-  end
-
-  it "gets the user's information" do
-    stub_account_api_user_info(
-      level_of_authentication: "level90",
-      email: "user@gov.uk",
-      email_verified: false,
-      services: { register_to_become_a_wizard: "yes" },
-      new_govuk_account_session: new_session_id,
-    )
-    assert_equal("level90", api_client.get_user(govuk_account_session: session_id)["level_of_authentication"])
-    assert_equal("user@gov.uk", api_client.get_user(govuk_account_session: session_id)["email"])
-    assert_equal(false, api_client.get_user(govuk_account_session: session_id)["email_verified"])
-    assert_equal("yes", api_client.get_user(govuk_account_session: session_id)["services"]["register_to_become_a_wizard"])
-  end
-
-  it "stubs a single service" do
-    stub_account_api_user_info_service_state(service: "register_to_become_a_wizard", service_state: "yes_but_must_reauthenticate")
-    assert_equal("yes_but_must_reauthenticate", api_client.get_user(govuk_account_session: session_id)["services"]["register_to_become_a_wizard"])
-  end
-
-  it "updates the user's email attributes" do
-    stub_update_user_by_subject_identifier(subject_identifier: "sid", email_verified: true, old_email: "email@example.com")
-    assert_equal({ "sub" => "sid", "email" => "email@example.com", "email_verified" => true }, api_client.update_user_by_subject_identifier(subject_identifier: "sid", email_verified: true).to_hash)
-  end
-
-  describe "a transition checker subscription exists" do
-    before { stub_account_api_has_email_subscription(new_govuk_account_session: new_session_id) }
-
-    it "checks if the user has an email subscription" do
-      assert(api_client.check_for_email_subscription(govuk_account_session: session_id)["has_subscription"])
+  describe "#validate_auth_response" do
+    it "gives a session ID if the auth response validates" do
+      stub_account_api_validates_auth_response(code: "foo", state: "bar")
+      assert(!api_client.validate_auth_response(code: "foo", state: "bar")["govuk_account_session"].nil?)
     end
 
-    it "returns the new session value" do
-      assert_equal(new_session_id, api_client.check_for_email_subscription(govuk_account_session: session_id)["govuk_account_session"])
-    end
-  end
+    it "throws a 401 if the auth response does not validate" do
+      stub_account_api_rejects_auth_response(code: "foo", state: "bar")
 
-  describe "a transition checker subscription does not exist" do
-    before { stub_account_api_does_not_have_email_subscription(new_govuk_account_session: new_session_id) }
-
-    it "checks if the user has an email subscription" do
-      assert(api_client.check_for_email_subscription(govuk_account_session: session_id)["has_subscription"] == false)
-    end
-
-    it "returns the new session value" do
-      assert_equal(new_session_id, api_client.check_for_email_subscription(govuk_account_session: session_id)["govuk_account_session"])
-    end
-  end
-
-  it "returns a new session when setting the email subscription" do
-    stub_account_api_set_email_subscription(new_govuk_account_session: new_session_id)
-    assert_equal(new_session_id, api_client.set_email_subscription(govuk_account_session: session_id, slug: "slug").to_hash["govuk_account_session"])
-  end
-
-  describe "attributes exist" do
-    before { stub_account_api_has_attributes(attributes: attributes.keys, values: attributes, new_govuk_account_session: new_session_id) }
-
-    let(:attributes) { { "foo" => { "bar" => %w[baz] } } }
-
-    it "returns the attribute values" do
-      assert(api_client.get_attributes(attributes: attributes.keys, govuk_account_session: session_id)["values"] == attributes)
-    end
-
-    it "returns the new session value" do
-      assert_equal(new_session_id, api_client.get_attributes(attributes: attributes.keys, govuk_account_session: session_id)["govuk_account_session"])
-    end
-  end
-
-  it "returns a new session when setting attributes" do
-    stub_account_api_set_attributes(attributes: { foo: %w[bar] }, new_govuk_account_session: new_session_id)
-    assert_equal(new_session_id, api_client.set_attributes(govuk_account_session: session_id, attributes: { foo: %w[bar] }).to_hash["govuk_account_session"])
-  end
-
-  it "returns the attribute names" do
-    queried_attribute_names = %w[foo]
-    stub_account_api_get_attributes_names(attributes: queried_attribute_names, new_govuk_account_session: new_session_id)
-    returned_attribute_names = api_client.get_attributes_names(attributes: queried_attribute_names, govuk_account_session: session_id)["values"]
-
-    assert_equal queried_attribute_names, returned_attribute_names
-  end
-
-  describe "get_email_subscription" do
-    it "returns the subscription details if it exists" do
-      stub_account_api_get_email_subscription(name: "foo")
-      assert(!api_client.get_email_subscription(name: "foo", govuk_account_session: session_id)["email_subscription"].nil?)
-    end
-
-    it "throws a 404 if it does not exist" do
-      stub_account_api_get_email_subscription_does_not_exist(name: "foo")
-      assert_raises GdsApi::HTTPNotFound do
-        api_client.get_email_subscription(name: "foo", govuk_account_session: session_id)
+      assert_raises GdsApi::HTTPUnauthorized do
+        api_client.validate_auth_response(code: "foo", state: "bar")
       end
     end
   end
 
-  describe "put_email_subscription" do
-    it "returns the new subscription details" do
-      stub_account_api_put_email_subscription(name: "foo", topic_slug: "slug")
-      assert(!api_client.put_email_subscription(name: "foo", topic_slug: "slug", govuk_account_session: session_id)["email_subscription"].nil?)
+  describe "#create_registration_state" do
+    it "returns gives a state ID" do
+      stub_account_api_create_registration_state(attributes: { foo: "bar" }, state_id: "state-id")
+      assert_equal("state-id", api_client.create_registration_state(attributes: { foo: "bar" }).to_hash["state_id"])
     end
   end
 
-  describe "delete_email_subscription" do
-    it "returns no content if it exists" do
-      stub_account_api_delete_email_subscription(name: "foo")
-      assert_equal(204, api_client.delete_email_subscription(name: "foo", govuk_account_session: session_id).code)
+  describe "#get_user" do
+    it "gets the user's information" do
+      stub_account_api_user_info(
+        level_of_authentication: "level90",
+        email: "user@gov.uk",
+        email_verified: false,
+        services: { register_to_become_a_wizard: "yes" },
+        new_govuk_account_session: new_session_id,
+      )
+      assert_equal("level90", api_client.get_user(govuk_account_session: session_id)["level_of_authentication"])
+      assert_equal("user@gov.uk", api_client.get_user(govuk_account_session: session_id)["email"])
+      assert_equal(false, api_client.get_user(govuk_account_session: session_id)["email_verified"])
+      assert_equal("yes", api_client.get_user(govuk_account_session: session_id)["services"]["register_to_become_a_wizard"])
     end
 
-    it "throws a 404 if it does not exist" do
-      stub_account_api_delete_email_subscription_does_not_exist(name: "foo")
-      assert_raises GdsApi::HTTPNotFound do
-        api_client.delete_email_subscription(name: "foo", govuk_account_session: session_id)
+    it "stubs a single service" do
+      stub_account_api_user_info_service_state(service: "register_to_become_a_wizard", service_state: "yes_but_must_reauthenticate")
+      assert_equal("yes_but_must_reauthenticate", api_client.get_user(govuk_account_session: session_id)["services"]["register_to_become_a_wizard"])
+    end
+  end
+
+  describe "#update_user_by_subject_identifier" do
+    it "updates the user's email attributes" do
+      stub_update_user_by_subject_identifier(subject_identifier: "sid", email_verified: true, old_email: "email@example.com")
+      assert_equal({ "sub" => "sid", "email" => "email@example.com", "email_verified" => true }, api_client.update_user_by_subject_identifier(subject_identifier: "sid", email_verified: true).to_hash)
+    end
+  end
+
+  describe "email subscriptions" do
+    describe "#get_email_subscription" do
+      it "returns the subscription details if it exists" do
+        stub_account_api_get_email_subscription(name: "foo")
+        assert(!api_client.get_email_subscription(name: "foo", govuk_account_session: session_id)["email_subscription"].nil?)
+      end
+
+      it "throws a 404 if it does not exist" do
+        stub_account_api_get_email_subscription_does_not_exist(name: "foo")
+        assert_raises GdsApi::HTTPNotFound do
+          api_client.get_email_subscription(name: "foo", govuk_account_session: session_id)
+        end
+      end
+    end
+
+    describe "#put_email_subscription" do
+      it "returns the new subscription details" do
+        stub_account_api_put_email_subscription(name: "foo", topic_slug: "slug")
+        assert(!api_client.put_email_subscription(name: "foo", topic_slug: "slug", govuk_account_session: session_id)["email_subscription"].nil?)
+      end
+    end
+
+    describe "#delete_email_subscription" do
+      it "returns no content if it exists" do
+        stub_account_api_delete_email_subscription(name: "foo")
+        assert_equal(204, api_client.delete_email_subscription(name: "foo", govuk_account_session: session_id).code)
+      end
+
+      it "throws a 404 if it does not exist" do
+        stub_account_api_delete_email_subscription_does_not_exist(name: "foo")
+        assert_raises GdsApi::HTTPNotFound do
+          api_client.delete_email_subscription(name: "foo", govuk_account_session: session_id)
+        end
+      end
+    end
+  end
+
+  describe "legacy transition checker email subscriptions" do
+    describe "#check_for_email_subscription" do
+      describe "a transition checker subscription exists" do
+        before { stub_account_api_has_email_subscription(new_govuk_account_session: new_session_id) }
+
+        it "checks if the user has an email subscription" do
+          assert(api_client.check_for_email_subscription(govuk_account_session: session_id)["has_subscription"])
+        end
+
+        it "returns the new session value" do
+          assert_equal(new_session_id, api_client.check_for_email_subscription(govuk_account_session: session_id)["govuk_account_session"])
+        end
+      end
+
+      describe "a transition checker subscription does not exist" do
+        before { stub_account_api_does_not_have_email_subscription(new_govuk_account_session: new_session_id) }
+
+        it "checks if the user has an email subscription" do
+          assert(api_client.check_for_email_subscription(govuk_account_session: session_id)["has_subscription"] == false)
+        end
+
+        it "returns the new session value" do
+          assert_equal(new_session_id, api_client.check_for_email_subscription(govuk_account_session: session_id)["govuk_account_session"])
+        end
+      end
+    end
+
+    describe "#set_email_subscription" do
+      it "returns a new session when setting the email subscription" do
+        stub_account_api_set_email_subscription(new_govuk_account_session: new_session_id)
+        assert_equal(new_session_id, api_client.set_email_subscription(govuk_account_session: session_id, slug: "slug").to_hash["govuk_account_session"])
+      end
+    end
+  end
+
+  describe "attributes" do
+    describe "#get_attributes" do
+      describe "attributes exist" do
+        before { stub_account_api_has_attributes(attributes: attributes.keys, values: attributes, new_govuk_account_session: new_session_id) }
+
+        let(:attributes) { { "foo" => { "bar" => %w[baz] } } }
+
+        it "returns the attribute values" do
+          assert(api_client.get_attributes(attributes: attributes.keys, govuk_account_session: session_id)["values"] == attributes)
+        end
+
+        it "returns the new session value" do
+          assert_equal(new_session_id, api_client.get_attributes(attributes: attributes.keys, govuk_account_session: session_id)["govuk_account_session"])
+        end
+      end
+    end
+
+    describe "#set_attributes" do
+      it "returns a new session when setting attributes" do
+        stub_account_api_set_attributes(attributes: { foo: %w[bar] }, new_govuk_account_session: new_session_id)
+        assert_equal(new_session_id, api_client.set_attributes(govuk_account_session: session_id, attributes: { foo: %w[bar] }).to_hash["govuk_account_session"])
+      end
+    end
+
+    describe "#get_attributes_names" do
+      it "returns the attribute names" do
+        queried_attribute_names = %w[foo]
+        stub_account_api_get_attributes_names(attributes: queried_attribute_names, new_govuk_account_session: new_session_id)
+        returned_attribute_names = api_client.get_attributes_names(attributes: queried_attribute_names, govuk_account_session: session_id)["values"]
+
+        assert_equal queried_attribute_names, returned_attribute_names
+      end
+    end
+  end
+
+  describe "saved pages" do
+    describe "#get_saved_pages" do
+      let(:saved_pages) { [{ "page_path" => "/foo" }, { "page_path" => "/bar" }] }
+
+      it "gets saved pages" do
+        stub_saved_pages = saved_pages
+        stub_account_api_returning_saved_pages(saved_pages: stub_saved_pages, new_govuk_account_session: new_session_id)
+        assert_equal(saved_pages, api_client.get_saved_pages(govuk_account_session: new_session_id)["saved_pages"])
+      end
+
+      it "it returns an empty array if there are no saved pages" do
+        stub_account_api_returning_saved_pages(saved_pages: [], new_govuk_account_session: new_session_id)
+        assert_equal([], api_client.get_saved_pages(govuk_account_session: new_session_id)["saved_pages"])
+      end
+    end
+
+    describe "#get_saved_page" do
+      it "gets a single saved page by path and returns a saved page hash" do
+        stub_account_api_get_saved_page(page_path: "/foo", content_id: "content-id", title: "title", new_govuk_account_session: new_session_id)
+        assert_equal({ "page_path" => "/foo", "content_id" => "content-id", "title" => "title" }, api_client.get_saved_page(page_path: "/foo", govuk_account_session: session_id)["saved_page"])
+      end
+
+      it "throws a 404 if the saved page does not exist" do
+        stub_account_api_does_not_have_saved_page(page_path: "/bar", new_govuk_account_session: new_session_id)
+        assert_raises GdsApi::HTTPNotFound do
+          api_client.get_saved_page(page_path: "/bar", govuk_account_session: session_id)
+        end
+      end
+    end
+
+    describe "#save_page" do
+      describe "if the saved page does not exist in the user's account" do
+        before { stub_account_api_save_page(page_path: "/foo", content_id: "content-id", title: "title", new_govuk_account_session: new_session_id) }
+
+        it "responds sucessfully" do
+          assert_equal(200, api_client.save_page(page_path: "/foo", govuk_account_session: session_id).code)
+        end
+
+        it "returns the created value" do
+          assert_equal({ "page_path" => "/foo", "content_id" => "content-id", "title" => "title" }, api_client.save_page(page_path: "/foo", govuk_account_session: session_id)["saved_page"])
+        end
+      end
+
+      it "returns success if the page already exists" do
+        stub_account_api_save_page_already_exists(page_path: "/existing", new_govuk_account_session: new_session_id)
+        assert_equal(200, api_client.save_page(page_path: "/existing", govuk_account_session: session_id).code)
+      end
+
+      it "responds 422 Unprocessable Entity if the page cannot be saved" do
+        stub_account_api_save_page_cannot_save_page(page_path: "/invalid", new_govuk_account_session: new_session_id)
+        assert_raises GdsApi::HTTPUnprocessableEntity do
+          api_client.save_page(page_path: "/invalid", govuk_account_session: session_id)
+        end
+      end
+    end
+
+    describe "#delete_saved_page" do
+      it "returns 204 if sucessfully deleted" do
+        stub_account_api_delete_saved_page(page_path: "/foo", new_govuk_account_session: new_session_id)
+        assert_equal(204, api_client.delete_saved_page(page_path: "/foo", govuk_account_session: session_id).code)
+      end
+
+      it "throws 404 if the saved page does not exist" do
+        stub_account_api_delete_saved_page_does_not_exist(page_path: "/foo", new_govuk_account_session: new_session_id)
+        assert_raises GdsApi::HTTPNotFound do
+          api_client.delete_saved_page(page_path: "/foo", govuk_account_session: session_id)
+        end
       end
     end
   end
@@ -279,75 +376,6 @@ describe GdsApi::AccountApi do
         api_client.get_attributes_names(attributes: %w[foo bar baz], govuk_account_session: session_id)
       end
       assert_equal("level1", JSON.parse(error.http_body)["needed_level_of_authentication"])
-    end
-  end
-
-  describe "#get_saved_pages" do
-    let(:saved_pages) { [{ "page_path" => "/foo" }, { "page_path" => "/bar" }] }
-
-    it "gets saved pages" do
-      stub_saved_pages = saved_pages
-      stub_account_api_returning_saved_pages(saved_pages: stub_saved_pages, new_govuk_account_session: new_session_id)
-      assert_equal(saved_pages, api_client.get_saved_pages(govuk_account_session: new_session_id)["saved_pages"])
-    end
-
-    it "it returns an empty array if there are no saved pages" do
-      stub_account_api_returning_saved_pages(saved_pages: [], new_govuk_account_session: new_session_id)
-      assert_equal([], api_client.get_saved_pages(govuk_account_session: new_session_id)["saved_pages"])
-    end
-  end
-
-  describe "#get_saved_page" do
-    it "gets a single saved page by path and returns a saved page hash" do
-      stub_account_api_get_saved_page(page_path: "/foo", content_id: "content-id", title: "title", new_govuk_account_session: new_session_id)
-      assert_equal({ "page_path" => "/foo", "content_id" => "content-id", "title" => "title" }, api_client.get_saved_page(page_path: "/foo", govuk_account_session: session_id)["saved_page"])
-    end
-
-    it "throws a 404 if the saved page does not exist" do
-      stub_account_api_does_not_have_saved_page(page_path: "/bar", new_govuk_account_session: new_session_id)
-      assert_raises GdsApi::HTTPNotFound do
-        api_client.get_saved_page(page_path: "/bar", govuk_account_session: session_id)
-      end
-    end
-  end
-
-  describe "#save_page" do
-    describe "if the saved page does not exist in the user's account" do
-      before { stub_account_api_save_page(page_path: "/foo", content_id: "content-id", title: "title", new_govuk_account_session: new_session_id) }
-
-      it "responds sucessfully" do
-        assert_equal(200, api_client.save_page(page_path: "/foo", govuk_account_session: session_id).code)
-      end
-
-      it "returns the created value" do
-        assert_equal({ "page_path" => "/foo", "content_id" => "content-id", "title" => "title" }, api_client.save_page(page_path: "/foo", govuk_account_session: session_id)["saved_page"])
-      end
-    end
-
-    it "returns success if the page already exists" do
-      stub_account_api_save_page_already_exists(page_path: "/existing", new_govuk_account_session: new_session_id)
-      assert_equal(200, api_client.save_page(page_path: "/existing", govuk_account_session: session_id).code)
-    end
-
-    it "responds 422 Unprocessable Entity if the page cannot be saved" do
-      stub_account_api_save_page_cannot_save_page(page_path: "/invalid", new_govuk_account_session: new_session_id)
-      assert_raises GdsApi::HTTPUnprocessableEntity do
-        api_client.save_page(page_path: "/invalid", govuk_account_session: session_id)
-      end
-    end
-  end
-
-  describe "#delete_saved_page" do
-    it "returns 204 if sucessfully deleted" do
-      stub_account_api_delete_saved_page(page_path: "/foo", new_govuk_account_session: new_session_id)
-      assert_equal(204, api_client.delete_saved_page(page_path: "/foo", govuk_account_session: session_id).code)
-    end
-
-    it "throws 404 if the saved page does not exist" do
-      stub_account_api_delete_saved_page_does_not_exist(page_path: "/foo", new_govuk_account_session: new_session_id)
-      assert_raises GdsApi::HTTPNotFound do
-        api_client.delete_saved_page(page_path: "/foo", govuk_account_session: session_id)
-      end
     end
   end
 end

--- a/test/account_api_test.rb
+++ b/test/account_api_test.rb
@@ -6,483 +6,367 @@ describe GdsApi::AccountApi do
 
   let(:api_client) { GdsApi::AccountApi.new(account_api_host) }
 
-  let(:authenticated_headers) { { "GOVUK-Account-Session" => govuk_account_session } }
-  let(:govuk_account_session) { "logged-in-user-session" }
+  let(:govuk_account_session) { nil }
 
-  describe "getting a sign-in URL" do
+  let(:headers) { GdsApi::JsonClient.default_request_headers.merge({ "GOVUK-Account-Session" => govuk_account_session }.compact) }
+  let(:headers_with_json_body) { GdsApi::JsonClient.default_request_with_json_body_headers.merge({ "GOVUK-Account-Session" => govuk_account_session }.compact) }
+
+  let(:json_response_headers) { { "Content-Type" => "application/json; charset=utf-8" } }
+
+  let(:response_body_with_session_identifier) { { govuk_account_session: Pact.like("user-session-id") } }
+
+  describe "#get_sign_in_url" do
+    let(:path) { "/api/oauth2/sign-in" }
+
     it "responds with 200 OK, an authentication URI, and a state for CSRF protection" do
+      response_body = {
+        auth_uri: Pact.like("http://authentication-provider/some/oauth/url"),
+        state: Pact.like("value-to-use-for-csrf-prevention"),
+      }
+
       account_api
         .upon_receiving("a sign-in request")
-        .with(
-          method: :get,
-          path: "/api/oauth2/sign-in",
-          headers: GdsApi::JsonClient.default_request_headers,
-        )
-        .will_respond_with(
-          status: 200,
-          headers: { "Content-Type" => "application/json; charset=utf-8" },
-          body: {
-            auth_uri: Pact.like("http://authentication-provider/some/oauth/url"),
-            state: Pact.like("value-to-use-for-csrf-prevention"),
-          },
-        )
+        .with(method: :get, path: path, headers: headers)
+        .will_respond_with(status: 200, headers: json_response_headers, body: response_body)
 
       api_client.get_sign_in_url
     end
   end
 
-  describe "validating an OAuth response" do
-    it "responds with 200 OK and a govuk_account_session" do
+  describe "#validate_auth_response" do
+    let(:path) { "/api/oauth2/callback" }
+    let(:params) { { code: "code", state: "state" } }
+
+    it "responds with 200 OK and a govuk_account_session if the parameters are valid" do
       account_api
         .given("there is a valid OAuth response")
         .upon_receiving("a validation request")
-        .with(
-          method: :post,
-          path: "/api/oauth2/callback",
-          body: {
-            code: "code",
-            state: "state",
-          },
-          headers: GdsApi::JsonClient.default_request_with_json_body_headers,
-        )
-        .will_respond_with(
-          status: 200,
-          headers: { "Content-Type" => "application/json; charset=utf-8" },
-          body: {
-            govuk_account_session: Pact.like("user-session-id"),
-          },
-        )
+        .with(method: :post, path: path, headers: headers_with_json_body, body: params)
+        .will_respond_with(status: 200, headers: json_response_headers, body: response_body_with_session_identifier)
 
-      api_client.validate_auth_response(code: "code", state: "state")
+      api_client.validate_auth_response(**params)
     end
-  end
 
-  describe "validating an OAuth response with a redirect path" do
-    let(:redirect_path) { "/some-arbitrary-path" }
+    it "responds with 200 OK and includes the redirect_path in the response, if given" do
+      redirect_path = "/some-arbitrary-path"
+      response_body = response_body_with_session_identifier.merge(redirect_path: redirect_path)
 
-    it "responds with a redirect_path" do
       account_api
-        .given("there is a valid OAuth response, with the redirect path '/some-arbitrary-path'")
+        .given("there is a valid OAuth response, with the redirect path '#{redirect_path}'")
         .upon_receiving("a validation request")
-        .with(
-          method: :post,
-          path: "/api/oauth2/callback",
-          body: {
-            code: "code",
-            state: "state",
-          },
-          headers: GdsApi::JsonClient.default_request_with_json_body_headers,
-        )
-        .will_respond_with(
-          status: 200,
-          headers: { "Content-Type" => "application/json; charset=utf-8" },
-          body: {
-            govuk_account_session: Pact.like("user-session-id"),
-            redirect_path: Pact.like(redirect_path),
-          },
-        )
+        .with(method: :post, path: path, headers: headers_with_json_body, body: params)
+        .will_respond_with(status: 200, headers: json_response_headers, body: response_body)
 
-      api_client.validate_auth_response(code: "code", state: "state")
+      api_client.validate_auth_response(**params)
     end
   end
 
-  describe "creating a registration state" do
-    let(:attributes) { { foo: "bar" } }
+  describe "#create_registration_state" do
+    let(:path) { "/api/oauth2/state" }
 
     it "responds with 200 OK and a state_id" do
+      attributes = { foo: "bar" }
+      response_body = { state_id: Pact.like("reference-to-pass-to-get_sign_in_url") }
+
       account_api
         .upon_receiving("a create-state request")
-        .with(
-          method: :post,
-          path: "/api/oauth2/state",
-          body: { attributes: attributes },
-          headers: GdsApi::JsonClient.default_request_with_json_body_headers,
-        )
-        .will_respond_with(
-          status: 200,
-          headers: { "Content-Type" => "application/json; charset=utf-8" },
-          body: {
-            state_id: Pact.like("reference-to-pass-to-get_sign_in_url"),
-          },
-        )
+        .with(method: :post, path: path, headers: headers_with_json_body, body: { attributes: attributes })
+        .will_respond_with(status: 200, headers: json_response_headers, body: response_body)
 
       api_client.create_registration_state(attributes: attributes)
     end
   end
 
-  describe "getting user information" do
-    describe "the user is logged in" do
-      let(:given) { "there is a valid user session" }
-      let(:saved_pages_service) { "no" }
+  describe "#update_user_by_subject_identifier" do
+    let(:subject_identifier) { "the-subject-identifier" }
+    let(:path) { "/api/oidc-users/#{subject_identifier}" }
 
-      before do
+    before do
+      email_attributes = {
+        email: "example.email.address@gov.uk",
+        email_verified: true,
+      }
+      response_body = email_attributes.merge(sub: subject_identifier)
+
+      account_api
+        .upon_receiving("a request to change the user's email attributes")
+        .with(method: :patch, path: path, headers: headers_with_json_body, body: email_attributes)
+        .will_respond_with(status: 200, headers: json_response_headers, body: response_body)
+
+      api_client.update_user_by_subject_identifier(
+        subject_identifier: subject_identifier,
+        email: email_attributes[:email],
+        email_verified: email_attributes[:email_verified],
+      )
+    end
+  end
+
+  describe "the user is logged in" do
+    let(:govuk_account_session) { "logged-in-user-session" }
+
+    describe "#get_user" do
+      let(:path) { "/api/user" }
+
+      it "responds with 200 OK" do
+        user_details = response_body_with_session_identifier.merge(
+          level_of_authentication: Pact.like("level0"),
+          email: Pact.like("user@example.com"),
+          email_verified: Pact.like(true),
+          services: {
+            transition_checker: "no",
+            saved_pages: "no",
+          },
+        )
+
         account_api
-          .given(given)
+          .given("there is a valid user session")
           .upon_receiving("a get-user request")
-          .with(
-            method: :get,
-            path: "/api/user",
-            headers: GdsApi::JsonClient.default_request_headers.merge(authenticated_headers),
-          )
-          .will_respond_with(
-            status: 200,
-            headers: { "Content-Type" => "application/json; charset=utf-8" },
-            body: {
-              govuk_account_session: Pact.like("user-session-id"),
-              level_of_authentication: Pact.like("level0"),
-              email: Pact.like("user@example.com"),
-              email_verified: Pact.like(true),
-              services: {
-                transition_checker: "no",
-                saved_pages: saved_pages_service,
-              },
-            },
-          )
-      end
+          .with(method: :get, path: path, headers: headers)
+          .will_respond_with(status: 200, headers: json_response_headers, body: user_details)
 
-      it "responds with a 200 OK" do
         api_client.get_user(govuk_account_session: govuk_account_session)
       end
 
-      describe "a user has saved pages" do
-        let(:given) { "there is a valid user session, with /guidance/some-govuk-guidance saved" }
-        let(:saved_pages_service) { "yes" }
+      it "includes 'saved_pages: yes' if the user has saved pages" do
+        account_api
+          .given("there is a valid user session, with /guidance/some-govuk-guidance saved")
+          .upon_receiving("a get-user request")
+          .with(method: :get, path: path, headers: headers)
+          .will_respond_with(status: 200, headers: json_response_headers, body: { services: { saved_pages: "yes" } })
 
-        it "responds with 200 OK" do
-          api_client.get_user(govuk_account_session: govuk_account_session)
-        end
+        api_client.get_user(govuk_account_session: govuk_account_session)
       end
     end
-  end
 
-  describe "updating a user from the auth provider" do
-    let(:subject_identifier) { "the-subject-identifier" }
-    let(:email) { "example.email.address@gov.uk" }
-    let(:email_verified) { true }
+    describe "email subscriptions" do
+      let(:subscription_name) { "wizard-news" }
+      let(:path) { "/api/email-subscriptions/#{subscription_name}" }
 
-    before do
-      account_api
-        .upon_receiving("a request to change the user's email attributes")
-        .with(
-          method: :patch,
-          path: "/api/oidc-users/#{subject_identifier}",
-          body: { email: email, email_verified: email_verified },
-          headers: GdsApi::JsonClient.default_request_with_json_body_headers,
-        )
-      .will_respond_with(
-        status: 200,
-        headers: { "Content-Type" => "application/json; charset=utf-8" },
-        body: {
-          sub: subject_identifier,
-          email: email,
-          email_verified: email_verified,
-        },
-      )
-    end
+      describe "#get_email_subscription" do
+        it "responds with 200 OK if there is a subscription" do
+          subscription_json = {
+            name: subscription_name,
+            topic_slug: Pact.like("wizard-news-topic-slug"),
+          }
 
-    it "responds with 200 OK" do
-      api_client.update_user_by_subject_identifier(subject_identifier: subject_identifier, email: email, email_verified: email_verified)
-    end
-  end
+          account_api
+            .given("there is a valid user session, with a '#{subscription_name}' email subscription")
+            .upon_receiving("a show-subscription request for '#{subscription_name}'")
+            .with(method: :get, path: path, headers: headers)
+            .will_respond_with(status: 200, headers: json_response_headers, body: { email_subscription: subscription_json })
 
-  describe "email subscriptions" do
-    let(:subscription_name) { "wizard-news" }
-    let(:path) { "/api/email-subscriptions/#{subscription_name}" }
-
-    let(:headers) { GdsApi::JsonClient.default_request_headers.merge(authenticated_headers) }
-    let(:headers_with_json_body) { GdsApi::JsonClient.default_request_with_json_body_headers.merge(authenticated_headers) }
-
-    let(:json_response_headers) { { "Content-Type" => "application/json; charset=utf-8" } }
-
-    describe "#get_email_subscription" do
-      it "responds with 200 OK if there is a subscription" do
-        subscription_json = {
-          name: subscription_name,
-          topic_slug: Pact.like("wizard-news-topic-slug"),
-        }
-
-        account_api
-          .given("there is a valid user session, with a '#{subscription_name}' email subscription")
-          .upon_receiving("a show-subscription request for '#{subscription_name}'")
-          .with(method: :get, path: path, headers: headers)
-          .will_respond_with(status: 200, headers: json_response_headers, body: { email_subscription: subscription_json })
-
-        api_client.get_email_subscription(name: subscription_name, govuk_account_session: govuk_account_session)
-      end
-
-      it "responds with 404 Not Found if there is not a subscription" do
-        account_api
-          .given("there is a valid user session")
-          .upon_receiving("a show-subscription request for '#{subscription_name}'")
-          .with(method: :get, path: path, headers: headers)
-          .will_respond_with(status: 404)
-
-        assert_raises GdsApi::HTTPNotFound do
           api_client.get_email_subscription(name: subscription_name, govuk_account_session: govuk_account_session)
         end
-      end
-    end
 
-    describe "#put_email_subscription" do
-      let(:topic_slug) { "wizard-news-topic-slug" }
-      let(:subscription_json) { { name: subscription_name, topic_slug: topic_slug } }
+        it "responds with 404 Not Found if there is not a subscription" do
+          account_api
+            .given("there is a valid user session")
+            .upon_receiving("a show-subscription request for '#{subscription_name}'")
+            .with(method: :get, path: path, headers: headers)
+            .will_respond_with(status: 404)
 
-      it "responds with 200 OK" do
-        account_api
-          .given("there is a valid user session")
-          .upon_receiving("a put-subscription request for '#{subscription_name}'")
-          .with(method: :put, path: path, headers: headers_with_json_body, body: { topic_slug: topic_slug })
-          .will_respond_with(status: 200, headers: json_response_headers, body: { email_subscription: subscription_json })
-
-        api_client.put_email_subscription(name: subscription_name, topic_slug: topic_slug, govuk_account_session: govuk_account_session)
+          assert_raises GdsApi::HTTPNotFound do
+            api_client.get_email_subscription(name: subscription_name, govuk_account_session: govuk_account_session)
+          end
+        end
       end
 
-      it "responds with 200 OK and updates an existing subscription" do
-        account_api
-          .given("there is a valid user session, with a '#{subscription_name}' email subscription")
-          .upon_receiving("a put-subscription request for '#{subscription_name}'")
-          .with(method: :put, path: path, headers: headers_with_json_body, body: { topic_slug: topic_slug })
-          .will_respond_with(status: 200, headers: json_response_headers, body: { email_subscription: subscription_json })
+      describe "#put_email_subscription" do
+        let(:topic_slug) { "wizard-news-topic-slug" }
+        let(:subscription_json) { { name: subscription_name, topic_slug: topic_slug } }
 
-        api_client.put_email_subscription(name: subscription_name, topic_slug: topic_slug, govuk_account_session: govuk_account_session)
+        it "responds with 200 OK" do
+          response_body = response_body_with_session_identifier.merge(email_subscription: subscription_json)
+
+          account_api
+            .given("there is a valid user session")
+            .upon_receiving("a put-subscription request for '#{subscription_name}'")
+            .with(method: :put, path: path, headers: headers_with_json_body, body: { topic_slug: topic_slug })
+            .will_respond_with(status: 200, headers: json_response_headers, body: response_body)
+
+          api_client.put_email_subscription(name: subscription_name, topic_slug: topic_slug, govuk_account_session: govuk_account_session)
+        end
+
+        it "responds with 200 OK and updates an existing subscription" do
+          response_body = response_body_with_session_identifier.merge(email_subscription: subscription_json)
+
+          account_api
+            .given("there is a valid user session, with a '#{subscription_name}' email subscription")
+            .upon_receiving("a put-subscription request for '#{subscription_name}'")
+            .with(method: :put, path: path, headers: headers_with_json_body, body: { topic_slug: topic_slug })
+            .will_respond_with(status: 200, headers: json_response_headers, body: response_body)
+
+          api_client.put_email_subscription(name: subscription_name, topic_slug: topic_slug, govuk_account_session: govuk_account_session)
+        end
       end
-    end
 
-    describe "#delete_email_subscription" do
-      it "responds with 204 No Content if there is a subscription" do
-        account_api
-          .given("there is a valid user session, with a '#{subscription_name}' email subscription")
-          .upon_receiving("a delete-subscription request for '#{subscription_name}'")
-          .with(method: :delete, path: path, headers: headers)
-          .will_respond_with(status: 204)
+      describe "#delete_email_subscription" do
+        it "responds with 204 No Content if there is a subscription" do
+          account_api
+            .given("there is a valid user session, with a '#{subscription_name}' email subscription")
+            .upon_receiving("a delete-subscription request for '#{subscription_name}'")
+            .with(method: :delete, path: path, headers: headers)
+            .will_respond_with(status: 204)
 
-        api_client.delete_email_subscription(name: subscription_name, govuk_account_session: govuk_account_session)
-      end
-
-      it "responds with 404 Not Found if there is not a subscription" do
-        account_api
-          .given("there is a valid user session")
-          .upon_receiving("a delete-subscription request for '#{subscription_name}'")
-          .with(method: :delete, path: path, headers: headers)
-          .will_respond_with(status: 404)
-
-        assert_raises GdsApi::HTTPNotFound do
           api_client.delete_email_subscription(name: subscription_name, govuk_account_session: govuk_account_session)
+        end
+
+        it "responds with 404 Not Found if there is not a subscription" do
+          account_api
+            .given("there is a valid user session")
+            .upon_receiving("a delete-subscription request for '#{subscription_name}'")
+            .with(method: :delete, path: path, headers: headers)
+            .will_respond_with(status: 404)
+
+          assert_raises GdsApi::HTTPNotFound do
+            api_client.delete_email_subscription(name: subscription_name, govuk_account_session: govuk_account_session)
+          end
         end
       end
     end
-  end
 
-  describe "checking for a transition checker email subscription" do
-    describe "the user is logged in" do
-      let(:given) { "there is a valid user session" }
-      let(:has_subscription) { false }
+    describe "legacy transition checker email subscriptions" do
+      let(:path) { "/api/transition-checker-email-subscription" }
 
-      before do
-        account_api
-          .given(given)
-          .upon_receiving("a has-subscription request")
-          .with(
-            method: :get,
-            path: "/api/transition-checker-email-subscription",
-            headers: GdsApi::JsonClient.default_request_headers.merge(authenticated_headers),
-          )
-          .will_respond_with(
-            status: 200,
-            headers: { "Content-Type" => "application/json; charset=utf-8" },
-            body: {
-              govuk_account_session: Pact.like("user-session-id"),
-              has_subscription: has_subscription,
-            },
-          )
-      end
+      describe "#check_for_email_subscription" do
+        it "responds with 200 OK and 'has_subscription: false' if one does not exist" do
+          response_body = response_body_with_session_identifier.merge(has_subscription: false)
 
-      it "responds with 200 OK, a new govuk_account_session, and says that the subscription does not exist" do
-        api_client.check_for_email_subscription(govuk_account_session: govuk_account_session)
-      end
+          account_api
+            .given("there is a valid user session")
+            .upon_receiving("a has-subscription request")
+            .with(method: :get, path: path, headers: headers)
+            .will_respond_with(status: 200, headers: json_response_headers, body: response_body)
 
-      describe "a subscription exists" do
-        let(:given) { "there is a valid user session, with a transition checker email subscription" }
-        let(:has_subscription) { true }
+          api_client.check_for_email_subscription(govuk_account_session: govuk_account_session)
+        end
 
-        it "says that the subscription exists" do
+        it "responds with 200 OK and 'has_subscription: true' if one exists" do
+          response_body = response_body_with_session_identifier.merge(has_subscription: true)
+
+          account_api
+            .given("there is a valid user session, with a transition checker email subscription")
+            .upon_receiving("a has-subscription request")
+            .with(method: :get, path: path, headers: headers)
+            .will_respond_with(status: 200, headers: json_response_headers, body: response_body)
+
           api_client.check_for_email_subscription(govuk_account_session: govuk_account_session)
         end
       end
-    end
-  end
 
-  describe "setting the transition checker email subscription" do
-    describe "the user is logged in" do
-      it "responds with 200 OK and a new govuk_account_session" do
-        account_api
-          .given("there is a valid user session")
-          .upon_receiving("a set-subscription request")
-          .with(
-            method: :post,
-            path: "/api/transition-checker-email-subscription",
-            body: { slug: "brexit-emails-123" },
-            headers: GdsApi::JsonClient.default_request_with_json_body_headers.merge(authenticated_headers),
-          )
-          .will_respond_with(
-            status: 200,
-            headers: { "Content-Type" => "application/json; charset=utf-8" },
-            body: {
-              govuk_account_session: Pact.like("user-session-id"),
-            },
-          )
+      describe "#set_email_subscription" do
+        it "responds with 200 OK" do
+          slug = "brexit-emails-123"
 
-        api_client.set_email_subscription(govuk_account_session: govuk_account_session, slug: "brexit-emails-123")
-      end
-    end
-  end
+          account_api
+            .given("there is a valid user session")
+            .upon_receiving("a set-subscription request")
+            .with(method: :post, path: path, headers: headers_with_json_body, body: { slug: slug })
+            .will_respond_with(status: 200, headers: json_response_headers, body: response_body_with_session_identifier)
 
-  describe "fetching attribute values" do
-    describe "the user is logged in" do
-      let(:given) { "there is a valid user session" }
-      let(:attributes) { {} }
-
-      before do
-        account_api
-          .given(given)
-          .upon_receiving("a get-attributes request")
-          .with(
-            method: :get,
-            path: "/api/attributes",
-            query: { "attributes[]" => %w[foo] },
-            headers: GdsApi::JsonClient.default_request_headers.merge(authenticated_headers),
-          )
-          .will_respond_with(
-            status: 200,
-            headers: { "Content-Type" => "application/json; charset=utf-8" },
-            body: {
-              govuk_account_session: Pact.like("user-session-id"),
-              values: attributes,
-            },
-          )
-      end
-
-      it "responds with 200 OK, a new govuk_account_session, and no attributes" do
-        api_client.get_attributes(govuk_account_session: govuk_account_session, attributes: %w[foo])
-      end
-
-      describe "attributes exist" do
-        let(:given) { "there is a valid user session, with an attribute called 'foo'" }
-        let(:attributes) { { foo: { bar: "baz" } } }
-
-        it "responds with the attribute values" do
-          api_client.get_attributes(govuk_account_session: govuk_account_session, attributes: %w[foo])
+          api_client.set_email_subscription(govuk_account_session: govuk_account_session, slug: slug)
         end
       end
     end
-  end
 
-  describe "setting attribute values" do
-    let(:attributes) { { foo: [1, 2, 3], bar: { nested: "json" } } }
+    describe "attributes" do
+      let(:path) { "/api/attributes" }
 
-    describe "the user is logged in" do
-      it "responds with 200 OK and a new govuk_account_session" do
-        account_api
-          .given("there is a valid user session")
-          .upon_receiving("a set-attributes request")
-          .with(
-            method: :patch,
-            path: "/api/attributes",
-            body: { attributes: attributes },
-            headers: GdsApi::JsonClient.default_request_with_json_body_headers.merge(authenticated_headers),
-          )
-          .will_respond_with(
-            status: 200,
-            headers: { "Content-Type" => "application/json; charset=utf-8" },
-            body: {
-              govuk_account_session: Pact.like("user-session-id"),
-            },
-          )
+      describe "#get_attributes" do
+        let(:attribute_name) { "test_attribute_1" }
 
-        api_client.set_attributes(govuk_account_session: govuk_account_session, attributes: attributes)
+        it "responds with 200 OK and no attributes, if none exist" do
+          response_body = response_body_with_session_identifier.merge(values: {})
+
+          account_api
+            .given("there is a valid user session")
+            .upon_receiving("a get-attributes request")
+            .with(method: :get, path: path, headers: headers, query: { "attributes[]" => [attribute_name] })
+            .will_respond_with(status: 200, headers: json_response_headers, body: response_body)
+
+          api_client.get_attributes(govuk_account_session: govuk_account_session, attributes: [attribute_name])
+        end
+
+        it "responds with 200 OK and the attributes, if some exist" do
+          response_body = response_body_with_session_identifier.merge(values: { attribute_name => { bar: "baz" } })
+
+          account_api
+            .given("there is a valid user session, with an attribute called '#{attribute_name}'")
+            .upon_receiving("a get-attributes request")
+            .with(method: :get, path: path, headers: headers, query: { "attributes[]" => [attribute_name] })
+            .will_respond_with(status: 200, headers: json_response_headers, body: response_body)
+
+          api_client.get_attributes(govuk_account_session: govuk_account_session, attributes: [attribute_name])
+        end
+      end
+
+      describe "#set_attributes" do
+        let(:attributes) { { test_attribute_1: [1, 2, 3], test_attribute_2: { nested: "json" } } }
+
+        it "responds with 200 OK" do
+          account_api
+            .given("there is a valid user session")
+            .upon_receiving("a set-attributes request")
+            .with(method: :patch, path: path, headers: headers_with_json_body, body: { attributes: attributes })
+            .will_respond_with(status: 200, headers: json_response_headers, body: response_body_with_session_identifier)
+
+          api_client.set_attributes(govuk_account_session: govuk_account_session, attributes: attributes)
+        end
       end
     end
-  end
 
-  describe "fetching attribute names" do
-    describe "the user is logged in" do
-      before do
+    describe "#get_attributes_names" do
+      let(:path) { "/api/attributes/names" }
+      let(:attribute_name) { "test_attribute_1" }
+
+      it "responds with 200 OK and no attributes, if none exist" do
+        response_body = response_body_with_session_identifier.merge(values: [])
+
         account_api
-          .given(given)
+          .given("there is a valid user session")
           .upon_receiving("a get-attributes-names request")
-          .with(
-            method: :get,
-            path: "/api/attributes/names",
-            query: { "attributes[]" => queried_attribute_names },
-            headers: GdsApi::JsonClient.default_request_headers.merge(authenticated_headers),
-          )
-          .will_respond_with(
-            status: 200,
-            headers: { "Content-Type" => "application/json; charset=utf-8" },
-            body: {
-              govuk_account_session: Pact.like("user-session-id"),
-              values: returned_attribute_names,
-            },
-          )
+          .with(method: :get, path: path, headers: headers, query: { "attributes[]" => [attribute_name] })
+          .will_respond_with(status: 200, headers: json_response_headers, body: response_body)
+
+        api_client.get_attributes_names(govuk_account_session: govuk_account_session, attributes: [attribute_name])
       end
 
-      let(:queried_attribute_names) { %w[foo] }
-      let(:response) { api_client.get_attributes_names(govuk_account_session: govuk_account_session, attributes: queried_attribute_names) }
+      it "responds with 200 OK and the attribute names, if they exist" do
+        response_body = response_body_with_session_identifier.merge(values: [attribute_name])
 
-      describe "attributes do not exist" do
-        let(:given) { "there is a valid user session" }
-        let(:returned_attribute_names) { [] }
+        account_api
+          .given("there is a valid user session, with an attribute called '#{attribute_name}'")
+          .upon_receiving("a get-attributes-names request")
+          .with(method: :get, path: path, headers: headers, query: { "attributes[]" => [attribute_name] })
+          .will_respond_with(status: 200, headers: json_response_headers, body: response_body)
 
-        it "responds with 200 OK, a new govuk_account_session, and no attributes" do
-          assert response["govuk_account_session"].present?
-          assert_equal returned_attribute_names, response["values"]
-          assert_equal 200, response.code
-        end
-      end
-
-      describe "attributes exist" do
-        let(:given) { "there is a valid user session, with an attribute called 'foo'" }
-        let(:returned_attribute_names) { %w[foo] }
-
-        it "responds with the attribute values" do
-          assert_equal returned_attribute_names, response["values"]
-        end
+        api_client.get_attributes_names(govuk_account_session: govuk_account_session, attributes: [attribute_name])
       end
     end
   end
 
-  describe "#get_saved_pages" do
-    describe "the user is logged in" do
-      let(:given) { "there is a valid user session" }
-      let(:saved_pages) { [] }
+  describe "saved pages" do
+    let(:saved_page_path) { "/guidance/some-govuk-guidance" }
+    let(:path) { "/api/saved-pages/#{CGI.escape(saved_page_path)}" }
 
-      before do
+    describe "#get_saved_pages" do
+      let(:path) { "/api/saved-pages" }
+
+      it "responds with 200 OK and returns an empty list of saved pages, if none exist" do
+        response_body = response_body_with_session_identifier.merge(saved_pages: [])
+
         account_api
-          .given(given)
+          .given("there is a valid user session")
           .upon_receiving("a GET saved_pages request")
-          .with(
-            method: :get,
-            path: "/api/saved-pages",
-            headers: GdsApi::JsonClient.default_request_headers.merge(authenticated_headers),
-          )
-          .will_respond_with(
-            status: 200,
-            headers: { "Content-Type" => "application/json; charset=utf-8" },
-            body: {
-              govuk_account_session: Pact.like("user-session-id"),
-              saved_pages: saved_pages,
-            },
-          )
-      end
+          .with(method: :get, path: path, headers: headers)
+          .will_respond_with(status: 200, headers: json_response_headers, body: response_body)
 
-      it "responds with 200 OK, a new govuk_account_session, and returns an empty array of saved pages" do
         api_client.get_saved_pages(govuk_account_session: govuk_account_session)
       end
 
-      describe "a user has saved pages" do
-        let(:given) { "there is a valid user session, with saved pages" }
-        let(:saved_pages) do
-          [
+      it "responds with 200 OK and a list of saved pages, if some exist" do
+        response_body = response_body_with_session_identifier.merge(
+          saved_pages: [
             {
               page_path: "/page-path/1",
               content_id: Pact.like("7b7b77b0-257a-467d-84c9-c5167781d05c"),
@@ -493,102 +377,68 @@ describe GdsApi::AccountApi do
               content_id: Pact.like("7b7b77b0-257a-467d-84c9-c5167781d05c"),
               title: Pact.like("Page #1"),
             },
-          ]
-        end
+          ],
+        )
 
-        it "responds with 200 OK, a new govuk_account_session, and returns an array of saved pages" do
-          api_client.get_saved_pages(govuk_account_session: govuk_account_session)
-        end
+        account_api
+          .given("there is a valid user session, with saved pages")
+          .upon_receiving("a GET saved_pages request")
+          .with(method: :get, path: path, headers: headers)
+          .will_respond_with(status: 200, headers: json_response_headers, body: response_body)
+
+        api_client.get_saved_pages(govuk_account_session: govuk_account_session)
       end
     end
-  end
 
-  describe "#get_saved_page" do
-    describe "the user is logged in" do
-      let(:given) { "there is a valid user session, with #{page_path} saved" }
-      let(:page_path) { "/guidance/some-govuk-guidance" }
-      let(:status) { 200 }
+    describe "#get_saved_page" do
+      it "responds with 200 OK and the saved page, if it exists" do
+        response_body = response_body_with_session_identifier.merge(
+          saved_page: {
+            page_path: saved_page_path,
+            content_id: Pact.like("6e0e144a-9e59-4ac8-af3b-d87e8ff30a47"),
+            title: Pact.like("Some GOV.UK Guidance"),
+          },
+        )
 
-      before do
         account_api
-          .given(given)
+          .given("there is a valid user session, with '#{saved_page_path}' saved")
           .upon_receiving("a GET saved-page/:page_path request")
-          .with(
-            method: :get,
-            path: "/api/saved-pages/#{CGI.escape(page_path)}",
-            headers: GdsApi::JsonClient.default_request_headers.merge(authenticated_headers),
-          )
-          .will_respond_with(
-            status: 200,
-            headers: { "Content-Type" => "application/json; charset=utf-8" },
-            body: {
-              govuk_account_session: Pact.like("user-session-id"),
-              saved_page: {
-                page_path: page_path,
-                content_id: Pact.like("6e0e144a-9e59-4ac8-af3b-d87e8ff30a47"),
-                title: Pact.like("Some GOV.UK Guidance"),
-              },
-            },
-          )
-      end
+          .with(method: :get, path: path, headers: headers)
+          .will_respond_with(status: 200, headers: json_response_headers, body: response_body)
 
-      describe "a user has saved pages" do
-        it "responds with 200 OK, a new govuk_account_session, and the saved page" do
-          api_client.get_saved_page(page_path: page_path, govuk_account_session: govuk_account_session)
-        end
+        api_client.get_saved_page(page_path: saved_page_path, govuk_account_session: govuk_account_session)
       end
     end
-  end
 
-  describe "#save_page" do
-    describe "the user is logged in" do
-      let(:given) { "there is a valid user session" }
-      let(:page_path) { "/guidance/some-govuk-guidance" }
+    describe "#save_page" do
+      it "responds with 200 OK and the saved page" do
+        response_body = response_body_with_session_identifier.merge(
+          saved_page: {
+            page_path: saved_page_path,
+            content_id: Pact.like("6e0e144a-9e59-4ac8-af3b-d87e8ff30a47"),
+            title: Pact.like("Some GOV.UK Guidance"),
+          },
+        )
 
-      before do
         account_api
-          .given(given)
+          .given("there is a valid user session")
           .upon_receiving("a PUT saved-page/:page_path request")
-          .with(
-            method: :put,
-            path: "/api/saved-pages/#{CGI.escape(page_path)}",
-            headers: GdsApi::JsonClient.default_request_headers.merge(authenticated_headers),
-          )
-          .will_respond_with(
-            status: 200,
-            headers: { "Content-Type" => "application/json; charset=utf-8" },
-            body: {
-              govuk_account_session: Pact.like("user-session-id"),
-              saved_page: { page_path: page_path },
-            },
-          )
-      end
+          .with(method: :put, path: path, headers: headers)
+          .will_respond_with(status: 200, headers: json_response_headers, body: response_body)
 
-      it "responds with 200 OK, the page data and a new govuk_account_session if the saved page does not exist" do
-        api_client.save_page(page_path: page_path, govuk_account_session: govuk_account_session)
+        api_client.save_page(page_path: saved_page_path, govuk_account_session: govuk_account_session)
       end
     end
-  end
 
-  describe "#delete_page" do
-    describe "the user is logged in" do
-      let(:given) { "there is a valid user session, with #{page_path} saved" }
-      let(:page_path) { "/guidance/some-govuk-guidance" }
-
-      before do
+    describe "#delete_saved_page" do
+      it "responds with 204 No Content if there is a saved page" do
         account_api
-          .given(given)
+          .given("there is a valid user session, with '#{saved_page_path}' saved")
           .upon_receiving("a DELETE saved-page/:page_path request")
-          .with(
-            method: :delete,
-            path: "/api/saved-pages/#{CGI.escape(page_path)}",
-            headers: GdsApi::JsonClient.default_request_headers.merge(authenticated_headers),
-          )
+          .with(method: :delete, path: path, headers: headers)
           .will_respond_with(status: 204)
-      end
 
-      it "responds with 204 NO CONTENT and a new govuk_account_session if the saved page exists" do
-        api_client.delete_saved_page(page_path: page_path, govuk_account_session: govuk_account_session)
+        api_client.delete_saved_page(page_path: saved_page_path, govuk_account_session: govuk_account_session)
       end
     end
   end

--- a/test/account_api_test.rb
+++ b/test/account_api_test.rb
@@ -185,6 +185,94 @@ describe GdsApi::AccountApi do
     end
   end
 
+  describe "email subscriptions" do
+    let(:subscription_name) { "wizard-news" }
+    let(:path) { "/api/email-subscriptions/#{subscription_name}" }
+
+    let(:headers) { GdsApi::JsonClient.default_request_headers.merge(authenticated_headers) }
+    let(:headers_with_json_body) { GdsApi::JsonClient.default_request_with_json_body_headers.merge(authenticated_headers) }
+
+    let(:json_response_headers) { { "Content-Type" => "application/json; charset=utf-8" } }
+
+    describe "#get_email_subscription" do
+      it "responds with 200 OK if there is a subscription" do
+        subscription_json = {
+          name: subscription_name,
+          topic_slug: Pact.like("wizard-news-topic-slug"),
+        }
+
+        account_api
+          .given("there is a valid user session, with a '#{subscription_name}' email subscription")
+          .upon_receiving("a show-subscription request for '#{subscription_name}'")
+          .with(method: :get, path: path, headers: headers)
+          .will_respond_with(status: 200, headers: json_response_headers, body: { email_subscription: subscription_json })
+
+        api_client.get_email_subscription(name: subscription_name, govuk_account_session: govuk_account_session)
+      end
+
+      it "responds with 404 Not Found if there is not a subscription" do
+        account_api
+          .given("there is a valid user session")
+          .upon_receiving("a show-subscription request for '#{subscription_name}'")
+          .with(method: :get, path: path, headers: headers)
+          .will_respond_with(status: 404)
+
+        assert_raises GdsApi::HTTPNotFound do
+          api_client.get_email_subscription(name: subscription_name, govuk_account_session: govuk_account_session)
+        end
+      end
+    end
+
+    describe "#put_email_subscription" do
+      let(:topic_slug) { "wizard-news-topic-slug" }
+      let(:subscription_json) { { name: subscription_name, topic_slug: topic_slug } }
+
+      it "responds with 200 OK" do
+        account_api
+          .given("there is a valid user session")
+          .upon_receiving("a put-subscription request for '#{subscription_name}'")
+          .with(method: :put, path: path, headers: headers_with_json_body, body: { topic_slug: topic_slug })
+          .will_respond_with(status: 200, headers: json_response_headers, body: { email_subscription: subscription_json })
+
+        api_client.put_email_subscription(name: subscription_name, topic_slug: topic_slug, govuk_account_session: govuk_account_session)
+      end
+
+      it "responds with 200 OK and updates an existing subscription" do
+        account_api
+          .given("there is a valid user session, with a '#{subscription_name}' email subscription")
+          .upon_receiving("a put-subscription request for '#{subscription_name}'")
+          .with(method: :put, path: path, headers: headers_with_json_body, body: { topic_slug: topic_slug })
+          .will_respond_with(status: 200, headers: json_response_headers, body: { email_subscription: subscription_json })
+
+        api_client.put_email_subscription(name: subscription_name, topic_slug: topic_slug, govuk_account_session: govuk_account_session)
+      end
+    end
+
+    describe "#delete_email_subscription" do
+      it "responds with 204 No Content if there is a subscription" do
+        account_api
+          .given("there is a valid user session, with a '#{subscription_name}' email subscription")
+          .upon_receiving("a delete-subscription request for '#{subscription_name}'")
+          .with(method: :delete, path: path, headers: headers)
+          .will_respond_with(status: 204)
+
+        api_client.delete_email_subscription(name: subscription_name, govuk_account_session: govuk_account_session)
+      end
+
+      it "responds with 404 Not Found if there is not a subscription" do
+        account_api
+          .given("there is a valid user session")
+          .upon_receiving("a delete-subscription request for '#{subscription_name}'")
+          .with(method: :delete, path: path, headers: headers)
+          .will_respond_with(status: 404)
+
+        assert_raises GdsApi::HTTPNotFound do
+          api_client.delete_email_subscription(name: subscription_name, govuk_account_session: govuk_account_session)
+        end
+      end
+    end
+  end
+
   describe "checking for a transition checker email subscription" do
     describe "the user is logged in" do
       let(:given) { "there is a valid user session" }


### PR DESCRIPTION
This PR also does some refactoring of the existing tests, probably easiest to review commit by commit.

See also https://github.com/alphagov/account-api/pull/111

---

[Trello card](https://trello.com/c/yzVmdrzw/829-add-rest-api-for-email-subscriptions-to-account-api)