### PR TITLE
Add methods to lookup local authority links by GSS Code

### DIFF
--- a/lib/gds_api/local_links_manager.rb
+++ b/lib/gds_api/local_links_manager.rb
@@ -10,4 +10,14 @@ class GdsApi::LocalLinksManager < GdsApi::Base
     url = "#{endpoint}/api/local-authority?authority_slug=#{authority_slug}"
     get_json(url)
   end
+
+  def local_link_by_gss(gss, lgsl, lgil)
+    url = "#{endpoint}/api/link?gss=#{gss}&lgsl=#{lgsl}&lgil=#{lgil}"
+    get_json(url)
+  end
+
+  def local_authority_by_gss(gss)
+    url = "#{endpoint}/api/local-authority?gss=#{gss}"
+    get_json(url)
+  end
 end

--- a/lib/gds_api/test_helpers/local_links_manager.rb
+++ b/lib/gds_api/test_helpers/local_links_manager.rb
@@ -5,8 +5,8 @@ module GdsApi
     module LocalLinksManager
       LOCAL_LINKS_MANAGER_ENDPOINT = Plek.current.find("local-links-manager")
 
-      def stub_local_links_manager_has_a_link(authority_slug:, lgsl:, lgil:, url:, country_name: "England", status: "ok")
-        response = {
+      def local_authority_example_link_response
+        {
           "local_authority" => {
             "name" => authority_slug.capitalize,
             "snac" => "00AG",
@@ -21,14 +21,22 @@ module GdsApi
             "status" => status,
           },
         }
-
-        stub_request(:get, "#{LOCAL_LINKS_MANAGER_ENDPOINT}/api/link")
-          .with(query: { authority_slug: authority_slug, lgsl: lgsl, lgil: lgil })
-          .to_return(body: response.to_json, status: 200)
       end
 
-      def stub_local_links_manager_has_no_link(authority_slug:, lgsl:, lgil:, country_name: "England")
-        response = {
+      def stub_local_links_manager_has_a_link_with_slug_with_slug(authority_slug:, lgsl:, lgil:, url:, country_name: "England", status: "ok")
+        stub_request(:get, "#{LOCAL_LINKS_MANAGER_ENDPOINT}/api/link")
+          .with(query: { authority_slug: authority_slug, lgsl: lgsl, lgil: lgil })
+          .to_return(body: local_authority_example_link_response.to_json, status: 200)
+      end
+
+      def stub_local_links_manager_has_a_link_with_gss(gss:, lgsl:, lgil:, url:, country_name: "England", status: "ok")
+        stub_request(:get, "#{LOCAL_LINKS_MANAGER_ENDPOINT}/api/link")
+          .with(query: { gss: gss, lgsl: lgsl, lgil: lgil })
+          .to_return(body: local_authority_example_link_response.to_json, status: 200)
+      end
+
+      def local_authority_example_no_link_response
+        {
           "local_authority" => {
             "name" => authority_slug.capitalize,
             "snac" => "00AG",
@@ -37,14 +45,22 @@ module GdsApi
             "country_name" => country_name,
           },
         }
-
-        stub_request(:get, "#{LOCAL_LINKS_MANAGER_ENDPOINT}/api/link")
-          .with(query: { authority_slug: authority_slug, lgsl: lgsl, lgil: lgil })
-          .to_return(body: response.to_json, status: 200)
       end
 
-      def stub_local_links_manager_has_no_link_and_no_homepage_url(authority_slug:, lgsl:, lgil:, country_name: "England")
-        response = {
+      def stub_local_links_manager_has_no_link_with_slug(authority_slug:, lgsl:, lgil:, country_name: "England")
+        stub_request(:get, "#{LOCAL_LINKS_MANAGER_ENDPOINT}/api/link")
+          .with(query: { authority_slug: authority_slug, lgsl: lgsl, lgil: lgil })
+          .to_return(body: local_authority_example_no_link_response.to_json, status: 200)
+      end
+
+      def stub_local_links_manager_has_no_link_with_gss(gss:, lgsl:, lgil:, country_name: "England")
+        stub_request(:get, "#{LOCAL_LINKS_MANAGER_ENDPOINT}/api/link")
+          .with(query: { gss: gss, lgsl: lgsl, lgil: lgil })
+          .to_return(body: local_authority_example_no_link_response.to_json, status: 200)
+      end
+
+      def local_authority_example_no_link_and_ho_homepage_url_response
+        {
           "local_authority" => {
             "name" => authority_slug.capitalize,
             "snac" => "00AG",
@@ -53,10 +69,18 @@ module GdsApi
             "country_name" => country_name,
           },
         }
+      end
 
+      def stub_local_links_manager_has_no_link_and_no_homepage_url_with_slug(authority_slug:, lgsl:, lgil:, country_name: "England")
         stub_request(:get, "#{LOCAL_LINKS_MANAGER_ENDPOINT}/api/link")
           .with(query: { authority_slug: authority_slug, lgsl: lgsl, lgil: lgil })
-          .to_return(body: response.to_json, status: 200)
+          .to_return(body: local_authority_example_no_link_and_ho_homepage_url_response.to_json, status: 200)
+      end
+
+      def stub_local_links_manager_has_no_link_and_no_homepage_url_with_gss(gss:, lgsl:, lgil:, country_name: "England")
+        stub_request(:get, "#{LOCAL_LINKS_MANAGER_ENDPOINT}/api/link")
+          .with(query: { gss: gss, lgsl: lgsl, lgil: lgil })
+          .to_return(body: local_authority_example_no_link_and_ho_homepage_url_response.to_json, status: 200)
       end
 
       def stub_local_links_manager_request_with_missing_parameters(authority_slug, lgsl, lgil)

--- a/test/local_links_manager_api_test.rb
+++ b/test/local_links_manager_api_test.rb
@@ -13,7 +13,7 @@ describe GdsApi::LocalLinksManager do
   describe "#link" do
     describe "when making a request" do
       it "returns the local authority and local interaction details if link present" do
-        stub_local_links_manager_has_a_link(
+        stub_local_links_manager_has_a_link_with_slug(
           authority_slug: "blackburn",
           lgsl: 2,
           lgil: 4,
@@ -43,7 +43,7 @@ describe GdsApi::LocalLinksManager do
       end
 
       it "returns the local authority details only if no link present" do
-        stub_local_links_manager_has_no_link(
+        stub_local_links_manager_has_no_link_with_slug(
           authority_slug: "blackburn",
           lgsl: 2,
           lgil: 4,
@@ -65,7 +65,7 @@ describe GdsApi::LocalLinksManager do
       end
 
       it "returns the local authority without a homepage url if no homepage link present" do
-        stub_local_links_manager_has_no_link_and_no_homepage_url(
+        stub_local_links_manager_has_no_link_and_no_homepage_url_with_slug(
           authority_slug: "blackburn",
           lgsl: 2,
           lgil: 4,


### PR DESCRIPTION
We currently assign each local authority a slug. API requests have the GET parameter `authority_slug`.

This allows the use of an alternative data source (e.g. the Ordnance Survey Names API) that provides us with the GSS Code.

[Trello card](https://trello.com/c/2x6Eh2b3)