### PR TITLE
Permit bearer_token field to be JSON

### DIFF
--- a/test/json_client_test.rb
+++ b/test/json_client_test.rb
@@ -379,8 +379,21 @@ class JsonClientTest < MiniTest::Spec
     assert_equal 1, response["a"]
   end
 
-  def test_client_can_use_bearer_token
+  def test_client_can_use_bearer_token_string
     client = GdsApi::JsonClient.new(bearer_token: "SOME_BEARER_TOKEN")
+    expected_headers = GdsApi::JsonClient.default_request_with_json_body_headers
+      .merge("Authorization" => "Bearer SOME_BEARER_TOKEN")
+
+    stub_request(:put, "http://some.other.endpoint/some.json")
+      .with(headers: expected_headers)
+      .to_return(body: '{"a":2}', status: 200)
+
+    response = client.put_json("http://some.other.endpoint/some.json", {})
+    assert_equal 2, response["a"]
+  end
+
+  def test_client_can_use_bearer_token_json
+    client = GdsApi::JsonClient.new(bearer_token: JSON.generate(value: "SOME_BEARER_TOKEN"))
     expected_headers = GdsApi::JsonClient.default_request_with_json_body_headers
       .merge("Authorization" => "Bearer SOME_BEARER_TOKEN")
 

--- a/test/publishing_api_test.rb
+++ b/test/publishing_api_test.rb
@@ -30,11 +30,15 @@ describe GdsApi::PublishingApi do
     }.merge(attrs)
   end
 
-  before do
-    @bearer_token = "example-bearer-token"
+  before :each do
+    bearer_token = [
+      { given: "example-bearer-token", expected: "example-bearer-token" },
+      { given: JSON.generate(value: "example-bearer-token-from-json"), expected: "example-bearer-token-from-json" },
+    ].sample
+    @bearer_token = bearer_token.fetch(:expected)
     @api_client = GdsApi::PublishingApi.new(
       publishing_api_host,
-      bearer_token: @bearer_token,
+      bearer_token: bearer_token.fetch(:given),
     )
 
     @content_id = "bed722e6-db68-43e5-9079-063f623335a7"


### PR DESCRIPTION
This enables the bearer_token option for the JsonClient to be a JSON with the structure `'{"value": <string>}'`.

Trello: https://trello.com/c/6Uaayg1l/545-use-a-single-rotation-lambda-instead-of-duplicating-them-per-secret

### Motivation

We would like to store additional data with the secret body, to enable rotation of the bearer token with configuration for the rotation provided in the secret body.

E.g. the secret body may look like this:

```json
{ "api_user": "publisher@alphagov.co.uk", "value": "123", "application": "publishing-api" }
```

The `value` field would contain the bearer token string. The remaining fields would enable rotation by a Lambda.

This should not have an impact on the existing platform. I expect secrets stored in `govuk-secrets` to remain unchanged. This will only impact secrets stored in AWS SecretsManager for the new ECS-hosted platform.