### PR TITLE
Add `has_unconfirmed_email` to `update_user_by_subject_identifier` and to `get_user` test helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # unreleased
 
 * Add functions and test helpers for account-linked email subscriptions.
+* Add `has_unconfirmed_email` option to `update_user_by_subject_identifier`.
 
 # 71.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Add functions and test helpers for account-linked email subscriptions.
 * Add `has_unconfirmed_email` option to `update_user_by_subject_identifier`.
+* Add `has_unconfirmed_email` option to `get_user` test helper.
 
 # 71.4.0
 

--- a/lib/gds_api/account_api.rb
+++ b/lib/gds_api/account_api.rb
@@ -57,12 +57,19 @@ class GdsApi::AccountApi < GdsApi::Base
   # Update the user record with privileged information from the auth service.  Only the auth service will call this.
   #
   # @param [String] subject_identifier The identifier of the user, shared between the auth service and GOV.UK.
-  # @param [String, nil] email The new email address
-  # @param [Boolean, nil] email_verified Whether the new email address is verified
+  # @param [String, nil] email The user's current
+  # @param [Boolean, nil] email_verified Whether the user's current email address is verified
+  # @param [Boolean, nil] has_unconfirmed_email Whether the user has a new, pending, email address
   #
   # @return [Hash] The user's subject identifier and email attributes
-  def update_user_by_subject_identifier(subject_identifier:, email: nil, email_verified: nil)
-    patch_json("#{endpoint}/api/oidc-users/#{subject_identifier}", { email: email, email_verified: email_verified }.compact)
+  def update_user_by_subject_identifier(subject_identifier:, email: nil, email_verified: nil, has_unconfirmed_email: nil)
+    params = {
+      email: email,
+      email_verified: email_verified,
+      has_unconfirmed_email: has_unconfirmed_email,
+    }.compact
+
+    patch_json("#{endpoint}/api/oidc-users/#{subject_identifier}", params)
   end
 
   # Check if a user has an email subscription for the Transition Checker

--- a/lib/gds_api/test_helpers/account_api.rb
+++ b/lib/gds_api/test_helpers/account_api.rb
@@ -95,15 +95,16 @@ module GdsApi
       ###########################################
       # PATCH /api/oidc-users/:subject_identifier
       ###########################################
-      def stub_update_user_by_subject_identifier(subject_identifier:, email: nil, email_verified: nil, old_email: nil, old_email_verified: nil)
+      def stub_update_user_by_subject_identifier(subject_identifier:, email: nil, email_verified: nil, has_unconfirmed_email: nil, old_email: nil, old_email_verified: nil, old_has_unconfirmed_email: nil)
         stub_account_api_request(
           :patch,
           "/api/oidc-users/#{subject_identifier}",
-          with: { body: hash_including({ email: email, email_verified: email_verified }.compact) },
+          with: { body: hash_including({ email: email, email_verified: email_verified, has_unconfirmed_email: has_unconfirmed_email }.compact) },
           response_body: {
             sub: subject_identifier,
             email: email || old_email,
             email_verified: email_verified || old_email_verified,
+            has_unconfirmed_email: has_unconfirmed_email || old_has_unconfirmed_email,
           },
         )
       end

--- a/lib/gds_api/test_helpers/account_api.rb
+++ b/lib/gds_api/test_helpers/account_api.rb
@@ -61,7 +61,7 @@ module GdsApi
       ###############
       # GET /api/user
       ###############
-      def stub_account_api_user_info(level_of_authentication: "level0", email: "email@example.com", email_verified: true, services: {}, **options)
+      def stub_account_api_user_info(level_of_authentication: "level0", email: "email@example.com", email_verified: true, has_unconfirmed_email: false, services: {}, **options)
         stub_account_api_request(
           :get,
           "/api/user",
@@ -69,6 +69,7 @@ module GdsApi
             level_of_authentication: level_of_authentication,
             email: email,
             email_verified: email_verified,
+            has_unconfirmed_email: has_unconfirmed_email,
             services: services,
           },
           **options,

--- a/test/account_api_test.rb
+++ b/test/account_api_test.rb
@@ -123,6 +123,7 @@ describe GdsApi::AccountApi do
           level_of_authentication: Pact.like("level0"),
           email: Pact.like("user@example.com"),
           email_verified: Pact.like(true),
+          has_unconfirmed_email: Pact.like(true),
           services: {
             transition_checker: "no",
             saved_pages: "no",

--- a/test/account_api_test.rb
+++ b/test/account_api_test.rb
@@ -96,6 +96,7 @@ describe GdsApi::AccountApi do
       email_attributes = {
         email: "example.email.address@gov.uk",
         email_verified: true,
+        has_unconfirmed_email: false,
       }
       response_body = email_attributes.merge(sub: subject_identifier)
 
@@ -106,8 +107,7 @@ describe GdsApi::AccountApi do
 
       api_client.update_user_by_subject_identifier(
         subject_identifier: subject_identifier,
-        email: email_attributes[:email],
-        email_verified: email_attributes[:email_verified],
+        **email_attributes,
       )
     end
   end


### PR DESCRIPTION
See also https://github.com/alphagov/account-api/pull/117

---

[Trello card](https://trello.com/c/nvi8bZct/856-add-hasunconfirmedemail-attribute)