### PR TITLE
Add `authenticate_subscriber_by_govuk_account` (for Email Alert API)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# unreleased
+
+* Add `authenticate_subscriber_by_govuk_account` (for Email Alert API)
+
 # 71.5.0
 
 * Add functions and test helpers for account-linked email subscriptions.

--- a/lib/gds_api/email_alert_api.rb
+++ b/lib/gds_api/email_alert_api.rb
@@ -176,6 +176,18 @@ class GdsApi::EmailAlertApi < GdsApi::Base
     )
   end
 
+  # Verify a GOV.UK Account-holder has a corresponding subscriber
+  #
+  # @param [string] govuk_account_session The request's session identifier
+  #
+  # @return [Hash] subscriber
+  def authenticate_subscriber_by_govuk_account(govuk_account_session:)
+    post_json(
+      "#{endpoint}/subscribers/govuk-account",
+      govuk_account_session: govuk_account_session,
+    )
+  end
+
   # Verify a subscriber has control of a provided email
   #
   # @param [string]       address       Address to send verification email to

--- a/lib/gds_api/test_helpers/email_alert_api.rb
+++ b/lib/gds_api/test_helpers/email_alert_api.rb
@@ -283,6 +283,51 @@ module GdsApi
           .to_return(status: 404)
       end
 
+      def stub_email_alert_api_authenticate_subscriber_by_govuk_account(govuk_account_session, subscriber_id, address, new_govuk_account_session: nil)
+        stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscribers/govuk-account")
+          .with(
+            body: { govuk_account_session: govuk_account_session }.to_json,
+          ).to_return(
+            status: 200,
+            body: {
+              govuk_account_session: new_govuk_account_session,
+            }.compact.merge(get_subscriber_response(subscriber_id, address)).to_json,
+          )
+      end
+
+      def stub_email_alert_api_authenticate_subscriber_by_govuk_account_session_invalid(govuk_account_session)
+        stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscribers/govuk-account")
+          .with(
+            body: { govuk_account_session: govuk_account_session }.to_json,
+          ).to_return(
+            status: 401,
+          )
+      end
+
+      def stub_email_alert_api_authenticate_subscriber_by_govuk_account_email_unverified(govuk_account_session, new_govuk_account_session: nil)
+        stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscribers/govuk-account")
+          .with(
+            body: { govuk_account_session: govuk_account_session }.to_json,
+          ).to_return(
+            status: 403,
+            body: {
+              govuk_account_session: new_govuk_account_session,
+            }.compact.to_json,
+          )
+      end
+
+      def stub_email_alert_api_authenticate_subscriber_by_govuk_account_no_subscriber(govuk_account_session, new_govuk_account_session: nil)
+        stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscribers/govuk-account")
+          .with(
+            body: { govuk_account_session: govuk_account_session }.to_json,
+          ).to_return(
+            status: 404,
+            body: {
+              govuk_account_session: new_govuk_account_session,
+            }.compact.to_json,
+          )
+      end
+
       def assert_unsubscribed(uuid)
         assert_requested(:post, "#{EMAIL_ALERT_API_ENDPOINT}/unsubscribe/#{uuid}", times: 1)
       end

--- a/test/email_alert_api_test.rb
+++ b/test/email_alert_api_test.rb
@@ -629,6 +629,70 @@ describe GdsApi::EmailAlertApi do
     end
   end
 
+  describe "authenticate_subscriber_by_govuk_account" do
+    it "returns subscriber details" do
+      stub_email_alert_api_authenticate_subscriber_by_govuk_account("session-id", 42, "test@example.com")
+      api_response = api_client.authenticate_subscriber_by_govuk_account(govuk_account_session: "session-id")
+      assert_equal(200, api_response.code)
+      assert_equal(42, api_response.dig("subscriber", "id"))
+    end
+
+    it "includes a new govuk_account_session" do
+      stub_email_alert_api_authenticate_subscriber_by_govuk_account("session-id", 42, "test@example.com", new_govuk_account_session: "new-session-id")
+      api_response = api_client.authenticate_subscriber_by_govuk_account(govuk_account_session: "session-id")
+      assert_equal(200, api_response.code)
+      assert_equal("new-session-id", api_response["govuk_account_session"])
+    end
+
+    describe "when the session is invalid" do
+      it "returns a 401" do
+        stub_email_alert_api_authenticate_subscriber_by_govuk_account_session_invalid("session-id")
+
+        assert_raises GdsApi::HTTPUnauthorized do
+          api_client.authenticate_subscriber_by_govuk_account(govuk_account_session: "session-id")
+        end
+      end
+    end
+
+    describe "when the email address is not verified" do
+      it "returns a 403" do
+        stub_email_alert_api_authenticate_subscriber_by_govuk_account_email_unverified("session-id")
+
+        assert_raises GdsApi::HTTPForbidden do
+          api_client.authenticate_subscriber_by_govuk_account(govuk_account_session: "session-id")
+        end
+      end
+
+      it "includes a new govuk_account_session" do
+        stub_email_alert_api_authenticate_subscriber_by_govuk_account_email_unverified("session-id", new_govuk_account_session: "new-session-id")
+
+        error = assert_raises GdsApi::HTTPForbidden do
+          api_client.authenticate_subscriber_by_govuk_account(govuk_account_session: "session-id")
+        end
+        assert_equal("new-session-id", JSON.parse(error.http_body)["govuk_account_session"])
+      end
+    end
+
+    describe "when there is no subscriber" do
+      it "returns a 404" do
+        stub_email_alert_api_authenticate_subscriber_by_govuk_account_no_subscriber("session-id")
+
+        assert_raises GdsApi::HTTPNotFound do
+          api_client.authenticate_subscriber_by_govuk_account(govuk_account_session: "session-id")
+        end
+      end
+
+      it "includes a new govuk_account_session" do
+        stub_email_alert_api_authenticate_subscriber_by_govuk_account_no_subscriber("session-id", new_govuk_account_session: "new-session-id")
+
+        error = assert_raises GdsApi::HTTPNotFound do
+          api_client.authenticate_subscriber_by_govuk_account(govuk_account_session: "session-id")
+        end
+        assert_equal("new-session-id", JSON.parse(error.http_body)["govuk_account_session"])
+      end
+    end
+  end
+
   describe "send_subscription_verification_email" do
     it "returns 200" do
       stub_email_alert_api_sends_subscription_verification_email("test@example.com", "immediately", "topic")


### PR DESCRIPTION
This is a new endpoint to let a subscriber authenticate with
email-alert-api using their GOV.UK Account session, as an alternative
to the magic link journey.  It returns:

- 401 if the session identifier is invalid

- 403 if the account's email address is unverified

- 404 if there is no matching subscriber

- 200 and the subscriber details otherwise

See also https://github.com/alphagov/email-alert-api/pull/1638

---

[Trello card](https://trello.com/c/qPIGG5rp/872-backend-work-to-allow-logging-in-to-email-alert-api-with-an-account)