### PR TITLE
Use "main" as the default branch of frontend in pact tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ node("postgresql-9.6") {
       ),
       stringParam(
         name: 'FRONTEND_BRANCH',
-        defaultValue: 'master',
+        defaultValue: 'main',
         description: 'Branch of frontend to run pacts against'
       ),
       stringParam(


### PR DESCRIPTION
There is no master branch of frontend any more.