### PR TITLE
Add GOV.UK Account ID test helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# unreleased
+
+* Add `id` to Account API user info test helper.
+* Add `govuk_account_id` to Email Alert API subscriber test helpers.
+
 # 71.6.0
 
 * Add `authenticate_subscriber_by_govuk_account` (for Email Alert API)

--- a/lib/gds_api/test_helpers/account_api.rb
+++ b/lib/gds_api/test_helpers/account_api.rb
@@ -61,11 +61,12 @@ module GdsApi
       ###############
       # GET /api/user
       ###############
-      def stub_account_api_user_info(level_of_authentication: "level0", email: "email@example.com", email_verified: true, has_unconfirmed_email: false, services: {}, **options)
+      def stub_account_api_user_info(id: "user-id", level_of_authentication: "level0", email: "email@example.com", email_verified: true, has_unconfirmed_email: false, services: {}, **options)
         stub_account_api_request(
           :get,
           "/api/user",
           response_body: {
+            id: id,
             level_of_authentication: level_of_authentication,
             email: email,
             email_verified: email_verified,

--- a/lib/gds_api/test_helpers/email_alert_api.rb
+++ b/lib/gds_api/test_helpers/email_alert_api.rb
@@ -6,11 +6,11 @@ module GdsApi
     module EmailAlertApi
       EMAIL_ALERT_API_ENDPOINT = Plek.find("email-alert-api")
 
-      def stub_email_alert_api_has_updated_subscriber(id, new_address)
+      def stub_email_alert_api_has_updated_subscriber(id, new_address, govuk_account_id: nil)
         stub_request(:patch, "#{EMAIL_ALERT_API_ENDPOINT}/subscribers/#{id}")
           .to_return(
             status: 200,
-            body: get_subscriber_response(id, new_address).to_json,
+            body: get_subscriber_response(id, new_address, govuk_account_id).to_json,
           )
       end
 
@@ -265,11 +265,11 @@ module GdsApi
           ).to_return(status: 422)
       end
 
-      def stub_email_alert_api_sends_subscriber_verification_email(subscriber_id, address)
+      def stub_email_alert_api_sends_subscriber_verification_email(subscriber_id, address, govuk_account_id: nil)
         stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscribers/auth-token")
           .to_return(
             status: 201,
-            body: get_subscriber_response(subscriber_id, address).to_json,
+            body: get_subscriber_response(subscriber_id, address, govuk_account_id).to_json,
           )
       end
 
@@ -283,7 +283,7 @@ module GdsApi
           .to_return(status: 404)
       end
 
-      def stub_email_alert_api_authenticate_subscriber_by_govuk_account(govuk_account_session, subscriber_id, address, new_govuk_account_session: nil)
+      def stub_email_alert_api_authenticate_subscriber_by_govuk_account(govuk_account_session, subscriber_id, address, govuk_account_id: "user-id", new_govuk_account_session: nil)
         stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscribers/govuk-account")
           .with(
             body: { govuk_account_session: govuk_account_session }.to_json,
@@ -291,7 +291,7 @@ module GdsApi
             status: 200,
             body: {
               govuk_account_session: new_govuk_account_session,
-            }.compact.merge(get_subscriber_response(subscriber_id, address)).to_json,
+            }.compact.merge(get_subscriber_response(subscriber_id, address, govuk_account_id)).to_json,
           )
       end
 
@@ -359,11 +359,12 @@ module GdsApi
 
     private
 
-      def get_subscriber_response(id, address)
+      def get_subscriber_response(id, address, govuk_account_id)
         {
           "subscriber" => {
             "id" => id,
             "address" => address,
+            "govuk_account_id" => govuk_account_id,
           },
         }
       end

--- a/test/account_api_test.rb
+++ b/test/account_api_test.rb
@@ -120,6 +120,7 @@ describe GdsApi::AccountApi do
 
       it "responds with 200 OK" do
         user_details = response_body_with_session_identifier.merge(
+          id: Pact.like("user-id"),
           level_of_authentication: Pact.like("level0"),
           email: Pact.like("user@example.com"),
           email_verified: Pact.like(true),


### PR DESCRIPTION
We're now returning this from the Account API's user-info endpoint,
and from Email Alert API's subscriber-info endpoints for subscribers
which have been linked to an account.

---

[Trello card](https://trello.com/c/Vzd8so2T/874-implement-designs-for-managing-your-email-notifications-via-the-account)