### PR TITLE
Add link_subscriber_to_govuk_account / find_subscriber_by_govuk_account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Add `id` to Account API user info test helper.
 * Add `govuk_account_id` to Email Alert API subscriber test helpers.
+* Add `link_subscriber_to_govuk_account` (for Email Alert API)
+* Add `find_subscriber_by_govuk_account` (for Email Alert API)
 
 # 71.6.0
 

--- a/lib/gds_api/email_alert_api.rb
+++ b/lib/gds_api/email_alert_api.rb
@@ -188,6 +188,32 @@ class GdsApi::EmailAlertApi < GdsApi::Base
     )
   end
 
+  # Mark a subscriber as "linked" to its corresponding GOV.UK Account.
+  # In practice "linking" will mean that email-alert-frontend and
+  # account-api will treat the subscriber specially (eg, only allowing
+  # address changes via the account).
+  #
+  # @param [string] govuk_account_session The request's session identifier
+  #
+  # @return [Hash] subscriber
+  def link_subscriber_to_govuk_account(govuk_account_session:)
+    post_json(
+      "#{endpoint}/subscribers/govuk-account/link",
+      govuk_account_session: govuk_account_session,
+    )
+  end
+
+  # Find a subscriber which has been "linked" to a GOV.UK Account.
+  #
+  # @param [String] govuk_account_id An ID for the account.
+  #
+  # @return [Hash] subscriber
+  def find_subscriber_by_govuk_account(govuk_account_id:)
+    get_json(
+      "#{endpoint}/subscribers/govuk-account/#{govuk_account_id}",
+    )
+  end
+
   # Verify a subscriber has control of a provided email
   #
   # @param [string]       address       Address to send verification email to

--- a/lib/gds_api/test_helpers/email_alert_api.rb
+++ b/lib/gds_api/test_helpers/email_alert_api.rb
@@ -328,6 +328,52 @@ module GdsApi
           )
       end
 
+      def stub_email_alert_api_link_subscriber_to_govuk_account(govuk_account_session, subscriber_id, address, govuk_account_id: "user-id", new_govuk_account_session: nil)
+        stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscribers/govuk-account/link")
+          .with(
+            body: { govuk_account_session: govuk_account_session }.to_json,
+          ).to_return(
+            status: 200,
+            body: {
+              govuk_account_session: new_govuk_account_session,
+            }.compact.merge(get_subscriber_response(subscriber_id, address, govuk_account_id)).to_json,
+          )
+      end
+
+      def stub_email_alert_api_link_subscriber_to_govuk_account_session_invalid(govuk_account_session)
+        stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscribers/govuk-account/link")
+          .with(
+            body: { govuk_account_session: govuk_account_session }.to_json,
+          ).to_return(
+            status: 401,
+          )
+      end
+
+      def stub_email_alert_api_link_subscriber_to_govuk_account_email_unverified(govuk_account_session, new_govuk_account_session: nil)
+        stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscribers/govuk-account/link")
+          .with(
+            body: { govuk_account_session: govuk_account_session }.to_json,
+          ).to_return(
+            status: 403,
+            body: {
+              govuk_account_session: new_govuk_account_session,
+            }.compact.to_json,
+          )
+      end
+
+      def stub_email_alert_api_find_subscriber_by_govuk_account(govuk_account_id, subscriber_id, address)
+        stub_request(:get, "#{EMAIL_ALERT_API_ENDPOINT}/subscribers/govuk-account/#{govuk_account_id}")
+          .to_return(
+            status: 200,
+            body: get_subscriber_response(subscriber_id, address, govuk_account_id).to_json,
+          )
+      end
+
+      def stub_email_alert_api_find_subscriber_by_govuk_account_no_subscriber(govuk_account_id)
+        stub_request(:get, "#{EMAIL_ALERT_API_ENDPOINT}/subscribers/govuk-account/#{govuk_account_id}")
+          .to_return(status: 404)
+      end
+
       def assert_unsubscribed(uuid)
         assert_requested(:post, "#{EMAIL_ALERT_API_ENDPOINT}/unsubscribe/#{uuid}", times: 1)
       end


### PR DESCRIPTION
See also https://github.com/alphagov/email-alert-api/pull/1644

---

[Trello card](https://trello.com/c/Vzd8so2T/874-implement-designs-for-managing-your-email-notifications-via-the-account)