### PR TITLE
Add test helper for Email Alert API auth tokens for GOV.UK Account users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# unreleased
+
+- Add test helper for Email Alert API auth tokens for GOV.UK Account users
+
 # 71.7.0
 
 * Add `id` to Account API user info test helper.

--- a/lib/gds_api/test_helpers/email_alert_api.rb
+++ b/lib/gds_api/test_helpers/email_alert_api.rb
@@ -283,6 +283,11 @@ module GdsApi
           .to_return(status: 404)
       end
 
+      def stub_email_alert_api_subscriber_verification_email_linked_to_govuk_account
+        stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscribers/auth-token")
+          .to_return(status: 403)
+      end
+
       def stub_email_alert_api_authenticate_subscriber_by_govuk_account(govuk_account_session, subscriber_id, address, govuk_account_id: "user-id", new_govuk_account_session: nil)
         stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscribers/govuk-account")
           .with(


### PR DESCRIPTION
See also https://github.com/alphagov/email-alert-api/pull/1646

---

[Trello card](https://trello.com/c/Vzd8so2T/874-implement-designs-for-managing-your-email-notifications-via-the-account)