### PR TITLE
Add `on_conflict` param to email-alert-api `change_subscriber`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # unreleased
 
+- Add `on_conflict` parameter to `change_subscriber` (for Email Alert API)
 - Add test helper for Email Alert API auth tokens for GOV.UK Account users
 
 # 71.7.0

--- a/lib/gds_api/email_alert_api.rb
+++ b/lib/gds_api/email_alert_api.rb
@@ -156,10 +156,10 @@ class GdsApi::EmailAlertApi < GdsApi::Base
   # @param [string] Subscriber new_address
   #
   # @return [Hash] subscriber
-  def change_subscriber(id:, new_address:)
+  def change_subscriber(id:, new_address:, on_conflict: nil)
     patch_json(
       "#{endpoint}/subscribers/#{uri_encode(id)}",
-      new_address: new_address,
+      { new_address: new_address, on_conflict: on_conflict }.compact,
     )
   end
 


### PR DESCRIPTION
See also https://github.com/alphagov/email-alert-api/pull/1647

---

[Trello card](https://trello.com/c/Vzd8so2T/874-implement-designs-for-managing-your-email-notifications-via-the-account)