### PR TITLE
Remove `create_registration_state` and `state_id`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# unreleased
+
+- BREAKING: Remove `create_registration_state` method and helpers (for Account API)
+- BREAKING: Remove `state_id` parameter from auth URL method and helpers (for Account API)
+
 # 71.9.0
 
 - Add `cookie_consent` to Account API auth callback test helper

--- a/lib/gds_api/account_api.rb
+++ b/lib/gds_api/account_api.rb
@@ -11,15 +11,13 @@ class GdsApi::AccountApi < GdsApi::Base
   # Get an OAuth sign-in URL to redirect the user to
   #
   # @param [String, nil] redirect_path path on GOV.UK to send the user to after authentication
-  # @param [String, nil] state_id identifier originally returned by #create_registration_state
   # @param [String, nil] level_of_authentication either "level1" (require MFA) or "level0" (do not require MFA)
   #
   # @return [Hash] An authentication URL and the OAuth state parameter (for CSRF protection)
-  def get_sign_in_url(redirect_path: nil, state_id: nil, level_of_authentication: nil)
+  def get_sign_in_url(redirect_path: nil, level_of_authentication: nil)
     querystring = nested_query_string(
       {
         redirect_path: redirect_path,
-        state_id: state_id,
         level_of_authentication: level_of_authentication,
       }.compact,
     )
@@ -34,15 +32,6 @@ class GdsApi::AccountApi < GdsApi::Base
   # @return [Hash] The value for the govuk_account_session header, the path to redirect the user to, and the GA client ID (if there is one)
   def validate_auth_response(code:, state:)
     post_json("#{endpoint}/api/oauth2/callback", code: code, state: state)
-  end
-
-  # Register some initial state, to pass to get_sign_in_url, which is used to initialise the account if the user signs up
-  #
-  # @param [Hash, nil] attributes Initial attributes to store
-  #
-  # @return [Hash] The state ID to pass to get_sign_in_url
-  def create_registration_state(attributes:)
-    post_json("#{endpoint}/api/oauth2/state", attributes: attributes)
   end
 
   # Get all the information about a user needed to render the account home page

--- a/lib/gds_api/test_helpers/account_api.rb
+++ b/lib/gds_api/test_helpers/account_api.rb
@@ -19,8 +19,8 @@ module GdsApi
       #########################
       # GET /api/oauth2/sign-in
       #########################
-      def stub_account_api_get_sign_in_url(redirect_path: nil, state_id: nil, level_of_authentication: nil, auth_uri: "http://auth/provider", state: "state")
-        querystring = Rack::Utils.build_nested_query({ redirect_path: redirect_path, state_id: state_id, level_of_authentication: level_of_authentication }.compact)
+      def stub_account_api_get_sign_in_url(redirect_path: nil, level_of_authentication: nil, auth_uri: "http://auth/provider", state: "state")
+        querystring = Rack::Utils.build_nested_query({ redirect_path: redirect_path, level_of_authentication: level_of_authentication }.compact)
         stub_request(:get, "#{ACCOUNT_API_ENDPOINT}/api/oauth2/sign-in?#{querystring}")
           .to_return(
             status: 200,
@@ -44,18 +44,6 @@ module GdsApi
         stub_request(:post, "#{ACCOUNT_API_ENDPOINT}/api/oauth2/callback")
           .with(body: hash_including({ code: code, state: state }.compact))
           .to_return(status: 401)
-      end
-
-      ########################
-      # POST /api/oauth2/state
-      ########################
-      def stub_account_api_create_registration_state(attributes: nil, state_id: "state-id")
-        stub_request(:post, "#{ACCOUNT_API_ENDPOINT}/api/oauth2/state")
-          .with(body: hash_including({ attributes: attributes }.compact))
-          .to_return(
-            status: 200,
-            body: { state_id: state_id }.to_json,
-          )
       end
 
       ###############

--- a/test/account_api/account_api_test.rb
+++ b/test/account_api/account_api_test.rb
@@ -31,13 +31,6 @@ describe GdsApi::AccountApi do
     end
   end
 
-  describe "#create_registration_state" do
-    it "returns gives a state ID" do
-      stub_account_api_create_registration_state(attributes: { foo: "bar" }, state_id: "state-id")
-      assert_equal("state-id", api_client.create_registration_state(attributes: { foo: "bar" }).to_hash["state_id"])
-    end
-  end
-
   describe "#get_user" do
     it "gets the user's information" do
       stub_account_api_user_info(

--- a/test/account_api_test.rb
+++ b/test/account_api_test.rb
@@ -84,22 +84,6 @@ describe GdsApi::AccountApi do
     end
   end
 
-  describe "#create_registration_state" do
-    let(:path) { "/api/oauth2/state" }
-
-    it "responds with 200 OK and a state_id" do
-      attributes = { foo: "bar" }
-      response_body = { state_id: Pact.like("reference-to-pass-to-get_sign_in_url") }
-
-      account_api
-        .upon_receiving("a create-state request")
-        .with(method: :post, path: path, headers: headers_with_json_body, body: { attributes: attributes })
-        .will_respond_with(status: 200, headers: json_response_headers, body: response_body)
-
-      api_client.create_registration_state(attributes: attributes)
-    end
-  end
-
   describe "#update_user_by_subject_identifier" do
     let(:subject_identifier) { "the-subject-identifier" }
     let(:path) { "/api/oidc-users/#{subject_identifier}" }


### PR DESCRIPTION
These are no longer used.

See also https://github.com/alphagov/finder-frontend/pull/2575

---

[Trello card](https://trello.com/c/aEbuS4Tf/884-remove-the-jwt-sign-up-flow)