### PR TITLE
Remove Transition Checker email subscription methods & helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 - BREAKING: Remove `create_registration_state` method and helpers (for Account API)
 - BREAKING: Remove `state_id` parameter from auth URL method and helpers (for Account API)
+- BREAKING: Remove `check_for_email_subscription` method and helpers (for Account API)
+- BREAKING: Remove `set_email_subscription` method and helpers (for Account API)
+- BREAKING: Rename `stub_account_api_get_email_subscription_unauthorized` to `stub_account_api_unauthorized_get_email_subscription` for consistency (for Account API)
+- BREAKING: Rename `stub_account_api_delete_saved_page_unauthorised` to `stub_account_api_unauthorized_delete_saved_page` for consistency (for Account API)
 
 # 71.9.0
 

--- a/lib/gds_api/account_api.rb
+++ b/lib/gds_api/account_api.rb
@@ -61,25 +61,6 @@ class GdsApi::AccountApi < GdsApi::Base
     patch_json("#{endpoint}/api/oidc-users/#{subject_identifier}", params)
   end
 
-  # Check if a user has an email subscription for the Transition Checker
-  #
-  # @param [String] govuk_account_session Value of the session header
-  #
-  # @return [Hash] Whether the user has a subscription, and a new session header
-  def check_for_email_subscription(govuk_account_session:)
-    get_json("#{endpoint}/api/transition-checker-email-subscription", auth_headers(govuk_account_session))
-  end
-
-  # Create or update a user's email subscription for the Transition Checker
-  #
-  # @param [String] govuk_account_session Value of the session header
-  # @param [String] slug The email topic slug
-  #
-  # @return [Hash] Whether the user has a subscription, and a new session header
-  def set_email_subscription(govuk_account_session:, slug:)
-    post_json("#{endpoint}/api/transition-checker-email-subscription", { slug: slug }, auth_headers(govuk_account_session))
-  end
-
   # Look up the values of a user's attributes
   #
   # @param [String] attributes Names of the attributes to check

--- a/lib/gds_api/test_helpers/account_api.rb
+++ b/lib/gds_api/test_helpers/account_api.rb
@@ -126,7 +126,7 @@ module GdsApi
         )
       end
 
-      def stub_account_api_get_email_subscription_unauthorized(name:, **options)
+      def stub_account_api_unauthorized_get_email_subscription(name:, **options)
         stub_account_api_request(
           :get,
           "/api/email-subscriptions/#{name}",
@@ -189,79 +189,6 @@ module GdsApi
           :delete,
           "/api/email-subscriptions/#{name}",
           response_status: 401,
-          **options,
-        )
-      end
-
-      ################################################
-      # GET /api/transition-checker-email-subscription
-      ################################################
-      def stub_account_api_has_email_subscription(**options)
-        stub_account_api_request(
-          :get,
-          "/api/transition-checker-email-subscription",
-          response_body: { has_subscription: true },
-          **options,
-        )
-      end
-
-      def stub_account_api_does_not_have_email_subscription(**options)
-        stub_account_api_request(
-          :get,
-          "/api/transition-checker-email-subscription",
-          response_body: { has_subscription: false },
-          **options,
-        )
-      end
-
-      def stub_account_api_unauthorized_get_email_subscription(**options)
-        stub_account_api_request(
-          :get,
-          "/api/transition-checker-email-subscription",
-          response_status: 401,
-          **options,
-        )
-      end
-
-      def stub_account_api_forbidden_get_email_subscription(needed_level_of_authentication: "level1", **options)
-        stub_account_api_request(
-          :get,
-          "/api/transition-checker-email-subscription",
-          response_status: 403,
-          response_body: { needed_level_of_authentication: needed_level_of_authentication },
-          **options,
-        )
-      end
-
-      #################################################
-      # POST /api/transition-checker-email-subscription
-      #################################################
-      def stub_account_api_set_email_subscription(slug: nil, **options)
-        stub_account_api_request(
-          :post,
-          "/api/transition-checker-email-subscription",
-          with: { body: hash_including({ slug: slug }.compact) },
-          **options,
-        )
-      end
-
-      def stub_account_api_unauthorized_set_email_subscription(slug: nil, **options)
-        stub_account_api_request(
-          :post,
-          "/api/transition-checker-email-subscription",
-          with: { body: hash_including({ slug: slug }.compact) },
-          response_status: 401,
-          **options,
-        )
-      end
-
-      def stub_account_api_forbidden_set_email_subscription(slug: nil, needed_level_of_authentication: "level1", **options)
-        stub_account_api_request(
-          :post,
-          "/api/transition-checker-email-subscription",
-          with: { body: hash_including({ slug: slug }.compact) },
-          response_status: 403,
-          response_body: { needed_level_of_authentication: needed_level_of_authentication },
           **options,
         )
       end
@@ -495,7 +422,7 @@ module GdsApi
         )
       end
 
-      def stub_account_api_delete_saved_page_unauthorised(page_path:, **options)
+      def stub_account_api_unauthorized_delete_saved_page(page_path:, **options)
         stub_account_api_request(
           :delete,
           "/api/saved-pages/#{CGI.escape(page_path)}",

--- a/test/account_api/account_api_test.rb
+++ b/test/account_api/account_api_test.rb
@@ -96,41 +96,6 @@ describe GdsApi::AccountApi do
     end
   end
 
-  describe "legacy transition checker email subscriptions" do
-    describe "#check_for_email_subscription" do
-      describe "a transition checker subscription exists" do
-        before { stub_account_api_has_email_subscription(new_govuk_account_session: new_session_id) }
-
-        it "checks if the user has an email subscription" do
-          assert(api_client.check_for_email_subscription(govuk_account_session: session_id)["has_subscription"])
-        end
-
-        it "returns the new session value" do
-          assert_equal(new_session_id, api_client.check_for_email_subscription(govuk_account_session: session_id)["govuk_account_session"])
-        end
-      end
-
-      describe "a transition checker subscription does not exist" do
-        before { stub_account_api_does_not_have_email_subscription(new_govuk_account_session: new_session_id) }
-
-        it "checks if the user has an email subscription" do
-          assert(api_client.check_for_email_subscription(govuk_account_session: session_id)["has_subscription"] == false)
-        end
-
-        it "returns the new session value" do
-          assert_equal(new_session_id, api_client.check_for_email_subscription(govuk_account_session: session_id)["govuk_account_session"])
-        end
-      end
-    end
-
-    describe "#set_email_subscription" do
-      it "returns a new session when setting the email subscription" do
-        stub_account_api_set_email_subscription(new_govuk_account_session: new_session_id)
-        assert_equal(new_session_id, api_client.set_email_subscription(govuk_account_session: session_id, slug: "slug").to_hash["govuk_account_session"])
-      end
-    end
-  end
-
   describe "attributes" do
     describe "#get_attributes" do
       describe "attributes exist" do
@@ -245,20 +210,6 @@ describe GdsApi::AccountApi do
       end
     end
 
-    it "throws a 401 if the user checks their transition checker subscription" do
-      stub_account_api_unauthorized_get_email_subscription
-      assert_raises GdsApi::HTTPUnauthorized do
-        api_client.check_for_email_subscription(govuk_account_session: session_id)
-      end
-    end
-
-    it "throws a 401 if the user updates their transition checker subscription" do
-      stub_account_api_unauthorized_set_email_subscription
-      assert_raises GdsApi::HTTPUnauthorized do
-        api_client.set_email_subscription(slug: "email-topic-slug", govuk_account_session: session_id)
-      end
-    end
-
     it "throws a 401 if the user gets their attributes" do
       stub_account_api_unauthorized_has_attributes(attributes: %w[foo bar baz])
       assert_raises GdsApi::HTTPUnauthorized do
@@ -302,14 +253,14 @@ describe GdsApi::AccountApi do
     end
 
     it "throws a 401 if the user deletes a saved page" do
-      stub_account_api_delete_saved_page_unauthorised(page_path: "/foo")
+      stub_account_api_unauthorized_delete_saved_page(page_path: "/foo")
       assert_raises GdsApi::HTTPUnauthorized do
         api_client.delete_saved_page(page_path: "/foo", govuk_account_session: session_id)
       end
     end
 
     it "throws a 401 if the user gets an email subscription" do
-      stub_account_api_get_email_subscription_unauthorized(name: "foo")
+      stub_account_api_unauthorized_get_email_subscription(name: "foo")
       assert_raises GdsApi::HTTPUnauthorized do
         api_client.get_email_subscription(name: "foo", govuk_account_session: session_id)
       end
@@ -331,22 +282,6 @@ describe GdsApi::AccountApi do
   end
 
   describe "the user is logged in at too low a level of authentication" do
-    it "throws a 403 and returns a level of authentication if the user checks their transition checker subscription" do
-      stub_account_api_forbidden_get_email_subscription
-      error = assert_raises GdsApi::HTTPForbidden do
-        api_client.check_for_email_subscription(govuk_account_session: session_id)
-      end
-      assert_equal("level1", JSON.parse(error.http_body)["needed_level_of_authentication"])
-    end
-
-    it "throws a 403 and returns a level of authentication if the user updates their transition checker subscription" do
-      stub_account_api_forbidden_set_email_subscription
-      error = assert_raises GdsApi::HTTPForbidden do
-        api_client.set_email_subscription(slug: "email-topic-slug", govuk_account_session: session_id)
-      end
-      assert_equal("level1", JSON.parse(error.http_body)["needed_level_of_authentication"])
-    end
-
     it "throws a 403 and returns a level of authentication if the user gets their attributes" do
       stub_account_api_forbidden_has_attributes(attributes: %w[foo bar baz])
       error = assert_raises GdsApi::HTTPForbidden do

--- a/test/account_api_test.rb
+++ b/test/account_api_test.rb
@@ -234,50 +234,6 @@ describe GdsApi::AccountApi do
       end
     end
 
-    describe "legacy transition checker email subscriptions" do
-      let(:path) { "/api/transition-checker-email-subscription" }
-
-      describe "#check_for_email_subscription" do
-        it "responds with 200 OK and 'has_subscription: false' if one does not exist" do
-          response_body = response_body_with_session_identifier.merge(has_subscription: false)
-
-          account_api
-            .given("there is a valid user session")
-            .upon_receiving("a has-subscription request")
-            .with(method: :get, path: path, headers: headers)
-            .will_respond_with(status: 200, headers: json_response_headers, body: response_body)
-
-          api_client.check_for_email_subscription(govuk_account_session: govuk_account_session)
-        end
-
-        it "responds with 200 OK and 'has_subscription: true' if one exists" do
-          response_body = response_body_with_session_identifier.merge(has_subscription: true)
-
-          account_api
-            .given("there is a valid user session, with a transition checker email subscription")
-            .upon_receiving("a has-subscription request")
-            .with(method: :get, path: path, headers: headers)
-            .will_respond_with(status: 200, headers: json_response_headers, body: response_body)
-
-          api_client.check_for_email_subscription(govuk_account_session: govuk_account_session)
-        end
-      end
-
-      describe "#set_email_subscription" do
-        it "responds with 200 OK" do
-          slug = "brexit-emails-123"
-
-          account_api
-            .given("there is a valid user session")
-            .upon_receiving("a set-subscription request")
-            .with(method: :post, path: path, headers: headers_with_json_body, body: { slug: slug })
-            .will_respond_with(status: 200, headers: json_response_headers, body: response_body_with_session_identifier)
-
-          api_client.set_email_subscription(govuk_account_session: govuk_account_session, slug: slug)
-        end
-      end
-    end
-
     describe "attributes" do
       let(:path) { "/api/attributes" }
 


### PR DESCRIPTION
These are no longer used.  I've also renamed some test helpers for
consistency.

---

[Trello card](https://trello.com/c/UTnej4if/886-delete-transition-checker-specific-email-endpoints)