### PR TITLE
Add new areas/postcode pact test

### DIFF
--- a/test/imminence/imminence_api_pact_test.rb
+++ b/test/imminence/imminence_api_pact_test.rb
@@ -54,4 +54,55 @@ describe GdsApi::Imminence do
       api_client.places("number-plate-supplier", "-2.01", "53.1", "5")
     end
   end
+
+  describe "#areas" do
+    let(:api_client) { GdsApi::Imminence.new(imminence_api_host) }
+
+    it "responds with all responses for the given dataset" do
+      imminence_api
+        .given("a place exists with a postcode and areas")
+        .upon_receiving("the request to retrieve the area for the given postcode")
+        .with(
+          method: :get,
+          path: "/areas/WC2B%206SE.json",
+          headers: GdsApi::JsonClient.default_request_headers,
+        )
+        .will_respond_with(
+          status: 200,
+          body: {
+            _response_info: {
+              status: "ok",
+              links: [],
+            },
+            total: 2,
+            start_index: 1,
+            page_size: 2,
+            current_page: 1,
+            pages: 1,
+            results: [
+              {
+                name: "Westminster City Council",
+                country_name: nil,
+                type: "LBO",
+                codes: {
+                  gss: nil,
+                },
+              },
+              {
+                name: "London",
+                country_name: nil,
+                type: "EUR",
+                codes: {
+                  gss: nil,
+                },
+              },
+            ],
+          },
+          headers: {
+            "Content-Type" => "application/json; charset=utf-8",
+          },
+        )
+      api_client.areas_for_postcode("WC2B 6SE")
+    end
+  end
 end

--- a/test/imminence/imminence_api_pact_test.rb
+++ b/test/imminence/imminence_api_pact_test.rb
@@ -82,18 +82,18 @@ describe GdsApi::Imminence do
             results: [
               {
                 name: "Westminster City Council",
-                country_name: nil,
+                country_name: "England",
                 type: "LBO",
                 codes: {
-                  gss: nil,
+                  gss: "E12000008",
                 },
               },
               {
                 name: "London",
-                country_name: nil,
+                country_name: "England",
                 type: "EUR",
                 codes: {
-                  gss: nil,
+                  gss: "E12000009",
                 },
               },
             ],


### PR DESCRIPTION
An additional pact test for imminence, so we can test an endpoint that doesn't just return a place (as most of them do).

Trello: https://trello.com/c/clyNd0c5/2521-3-finish-adding-contract-tests-for-imminence