### PR TITLE
Prepare for govuk_app_config v4 (Sentry fingerprinting)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - BREAKING: Remove `set_email_subscription` method and helpers (for Account API)
 - BREAKING: Rename `stub_account_api_get_email_subscription_unauthorized` to `stub_account_api_unauthorized_get_email_subscription` for consistency (for Account API)
 - BREAKING: Rename `stub_account_api_delete_saved_page_unauthorised` to `stub_account_api_unauthorized_delete_saved_page` for consistency (for Account API)
+- BREAKING: Change how we apply Sentry's fingerprinting algorithm ([#1096](https://github.com/alphagov/gds-api-adapters/pull/1096)).
+  Updating gds-api-adapters but failing to update govuk_app_config to v4 may mean application errors are not as effectively 'grouped' in Sentry.
 
 # 71.9.0
 

--- a/lib/gds_api/exceptions.rb
+++ b/lib/gds_api/exceptions.rb
@@ -3,7 +3,7 @@ module GdsApi
   class BaseError < StandardError
     # Give Sentry extra context about this event
     # https://docs.sentry.io/clients/ruby/context/
-    def raven_context
+    def sentry_context
       {
         # Make Sentry group exceptions by type instead of message, so all
         # exceptions like `GdsApi::TimedOutException` will get grouped as one

--- a/test/exceptions_test.rb
+++ b/test/exceptions_test.rb
@@ -4,6 +4,6 @@ class GdsApiBaseTest < Minitest::Test
   def test_fingerprints_per_exception_type
     exception = GdsApi::HTTPBadGateway.new(200)
 
-    assert_equal ["GdsApi::HTTPBadGateway"], exception.raven_context[:fingerprint]
+    assert_equal ["GdsApi::HTTPBadGateway"], exception.sentry_context[:fingerprint]
   end
 end


### PR DESCRIPTION
In govuk_app_config v4, we're swapping out the underlying gem
used to communicate with Sentry, from `sentry-raven` (deprecated)
to the new `sentry-ruby`. There is a [migration guide][] to follow,
but the only thing identified is the old use of `raven_context`,
which should now be `sentry_context`.

I did consider switching to [structured contexts][], which appear
to be best practice, but this doesn't appear to offer any benefits
and could in fact be quite difficult to implement, as we can now
only call `GovukError.configure` once, and we don't want any
explicit references to the Sentry API in gds-api-adapters.
It is lower risk to simply swap out what we had already with the
simplest new alternative.

[migration guide]: https://github.com/getsentry/sentry-ruby/blob/master/MIGRATION.md
[structured contexts]: https://docs.sentry.io/platforms/ruby/enriching-events/context/#structured-context

Trello: https://trello.com/c/xo4l4GWQ/2587-update-gds-api-adapters-to-use-pre-released-govukappconfig-3