### PR TITLE
Delete account api oidc users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Add `delete_user_by_subject_identifier` (for Account API)
+
 # 72.0.0
 
 - BREAKING: Remove `create_registration_state` method and helpers (for Account API)

--- a/lib/gds_api/account_api.rb
+++ b/lib/gds_api/account_api.rb
@@ -43,6 +43,13 @@ class GdsApi::AccountApi < GdsApi::Base
     get_json("#{endpoint}/api/user", auth_headers(govuk_account_session))
   end
 
+  # Delete a users account
+  #
+  # @param [String] subject_identifier The identifier of the user, shared between the auth service and GOV.UK.
+  def delete_user_by_subject_identifier(subject_identifier:)
+    delete_json("#{endpoint}/api/oidc-users/#{subject_identifier}")
+  end
+
   # Update the user record with privileged information from the auth service.  Only the auth service will call this.
   #
   # @param [String] subject_identifier The identifier of the user, shared between the auth service and GOV.UK.

--- a/lib/gds_api/test_helpers/account_api.rb
+++ b/lib/gds_api/test_helpers/account_api.rb
@@ -82,6 +82,26 @@ module GdsApi
         )
       end
 
+      ############################################
+      # DELETE /api/oidc-users/:subject_identifier
+      ############################################
+
+      def stub_account_api_delete_user_by_subject_identifier(subject_identifier:)
+        stub_account_api_request(
+          :delete,
+          "/api/oidc-users/#{subject_identifier}",
+          response_status: 204,
+        )
+      end
+
+      def stub_account_api_delete_user_by_subject_identifier_does_not_exist(subject_identifier:)
+        stub_account_api_request(
+          :delete,
+          "/api/oidc-users/#{subject_identifier}",
+          response_status: 404,
+        )
+      end
+
       ###########################################
       # PATCH /api/oidc-users/:subject_identifier
       ###########################################

--- a/test/account_api/account_api_test.rb
+++ b/test/account_api/account_api_test.rb
@@ -52,6 +52,20 @@ describe GdsApi::AccountApi do
     end
   end
 
+  describe "#delete_user_by_subject_identifier" do
+    it "returns 204 if the account is successfully deleted" do
+      stub_account_api_delete_user_by_subject_identifier(subject_identifier: "sid")
+      assert_equal(204, api_client.delete_user_by_subject_identifier(subject_identifier: "sid").code)
+    end
+
+    it "returns 404 if the user cannot be found" do
+      stub_account_api_delete_user_by_subject_identifier_does_not_exist(subject_identifier: "sid")
+      assert_raises GdsApi::HTTPNotFound do
+        api_client.delete_user_by_subject_identifier(subject_identifier: "sid")
+      end
+    end
+  end
+
   describe "#update_user_by_subject_identifier" do
     it "updates the user's email attributes" do
       stub_update_user_by_subject_identifier(subject_identifier: "sid", email_verified: true, old_email: "email@example.com")

--- a/test/account_api_test.rb
+++ b/test/account_api_test.rb
@@ -108,6 +108,32 @@ describe GdsApi::AccountApi do
     end
   end
 
+  describe "#delete_user_by_subject_identifier" do
+    let(:subject_identifier) { "the-subject-identifier" }
+    let(:path) { "/api/oidc-users/#{subject_identifier}" }
+
+    it "responds with 204 No Content if the user existed and has been deleted" do
+      account_api
+        .given("there is a user with subject identifier '#{subject_identifier}'")
+        .upon_receiving("a delete-user request for '#{subject_identifier}'")
+        .with(method: :delete, path: path, headers: headers)
+        .will_respond_with(status: 204)
+
+      api_client.delete_user_by_subject_identifier(subject_identifier: subject_identifier)
+    end
+
+    it "responds with 404 if the user does not exist" do
+      account_api
+        .upon_receiving("a delete-user request")
+        .with(method: :delete, path: path, headers: headers)
+        .will_respond_with(status: 404)
+
+      assert_raises GdsApi::HTTPNotFound do
+        api_client.delete_user_by_subject_identifier(subject_identifier: subject_identifier)
+      end
+    end
+  end
+
   describe "the user is logged in" do
     let(:govuk_account_session) { "logged-in-user-session" }
 


### PR DESCRIPTION
A part of: [trello ticket](https://trello.com/c/b95YV8qC/912-%E2%9D%97-delete-users-in-account-api-when-theyre-deleted-in-account-manager)
See also: [account-api#154](https://github.com/alphagov/account-api/pull/154)

We are currently migrating features from our PaaS based
account-manager-prototype
to account-api.

Accounts API now acts as an additional store of user data. When a user
deletes their account through the account manager we require an
authenticated endpoint that will forward the request to account-api so
we can remove their data there too.

The API has a new delete user endpoint, these should be called via
the GDS API wrapper. This PR adds those methods here.