### PR TITLE
Remove `get_attributes_names` method and helpers (for Account API)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# unreleased
+
+- BREAKING: Remove `get_attributes_names` method and helpers (for Account API)
+
 # 72.1.0
 
 - Add `delete_user_by_subject_identifier` (for Account API)

--- a/lib/gds_api/account_api.rb
+++ b/lib/gds_api/account_api.rb
@@ -89,17 +89,6 @@ class GdsApi::AccountApi < GdsApi::Base
     patch_json("#{endpoint}/api/attributes", { attributes: attributes }, auth_headers(govuk_account_session))
   end
 
-  # Look up the names of a user's attributes
-  #
-  # @param [String] attributes Names of the attributes to check
-  # @param [String] govuk_account_session Value of the session header
-  #
-  # @return [Hash] The attribute names (if present), and a new session header
-  def get_attributes_names(attributes:, govuk_account_session:)
-    querystring = nested_query_string({ attributes: attributes }.compact)
-    get_json("#{endpoint}/api/attributes/names?#{querystring}", auth_headers(govuk_account_session))
-  end
-
   # Get the details of an account-linked email subscription.
   #
   # @param [String] name Name of the subscription

--- a/lib/gds_api/test_helpers/account_api.rb
+++ b/lib/gds_api/test_helpers/account_api.rb
@@ -280,40 +280,6 @@ module GdsApi
         )
       end
 
-      ###########################
-      # GET /api/attributes/names
-      ###########################
-      def stub_account_api_get_attributes_names(attributes: [], **options)
-        querystring = Rack::Utils.build_nested_query({ attributes: attributes }.compact)
-        stub_account_api_request(
-          :get,
-          "/api/attributes/names?#{querystring}",
-          response_body: { values: attributes },
-          **options,
-        )
-      end
-
-      def stub_account_api_unauthorized_get_attributes_names(attributes: [], **options)
-        querystring = Rack::Utils.build_nested_query({ attributes: attributes }.compact)
-        stub_account_api_request(
-          :get,
-          "/api/attributes/names?#{querystring}",
-          response_status: 401,
-          **options,
-        )
-      end
-
-      def stub_account_api_forbidden_get_attributes_names(attributes: [], needed_level_of_authentication: "level1", **options)
-        querystring = Rack::Utils.build_nested_query({ attributes: attributes }.compact)
-        stub_account_api_request(
-          :get,
-          "/api/attributes/names?#{querystring}",
-          response_status: 403,
-          response_body: { needed_level_of_authentication: needed_level_of_authentication },
-          **options,
-        )
-      end
-
       ######################
       # GET /api/saved-pages
       ######################

--- a/test/account_api/account_api_test.rb
+++ b/test/account_api/account_api_test.rb
@@ -133,16 +133,6 @@ describe GdsApi::AccountApi do
         assert_equal(new_session_id, api_client.set_attributes(govuk_account_session: session_id, attributes: { foo: %w[bar] }).to_hash["govuk_account_session"])
       end
     end
-
-    describe "#get_attributes_names" do
-      it "returns the attribute names" do
-        queried_attribute_names = %w[foo]
-        stub_account_api_get_attributes_names(attributes: queried_attribute_names, new_govuk_account_session: new_session_id)
-        returned_attribute_names = api_client.get_attributes_names(attributes: queried_attribute_names, govuk_account_session: session_id)["values"]
-
-        assert_equal queried_attribute_names, returned_attribute_names
-      end
-    end
   end
 
   describe "saved pages" do
@@ -238,13 +228,6 @@ describe GdsApi::AccountApi do
       end
     end
 
-    it "throws a 401 if the user checks their attribute names" do
-      stub_account_api_unauthorized_get_attributes_names(attributes: %w[foo bar baz])
-      assert_raises GdsApi::HTTPUnauthorized do
-        api_client.get_attributes_names(attributes: %w[foo bar baz], govuk_account_session: session_id)
-      end
-    end
-
     it "throws a 401 if the user checks their saved pages" do
       stub_account_api_unauthorized_get_saved_pages
       assert_raises GdsApi::HTTPUnauthorized do
@@ -308,14 +291,6 @@ describe GdsApi::AccountApi do
       stub_account_api_forbidden_set_attributes(attributes: { foo: %w[bar baz] })
       error = assert_raises GdsApi::HTTPForbidden do
         api_client.set_attributes(attributes: { foo: %w[bar baz] }, govuk_account_session: session_id)
-      end
-      assert_equal("level1", JSON.parse(error.http_body)["needed_level_of_authentication"])
-    end
-
-    it "throws a 403 and returns a level of authentication if the user checks their attribute names" do
-      stub_account_api_forbidden_get_attributes_names(attributes: %w[foo bar baz])
-      error = assert_raises GdsApi::HTTPForbidden do
-        api_client.get_attributes_names(attributes: %w[foo bar baz], govuk_account_session: session_id)
       end
       assert_equal("level1", JSON.parse(error.http_body)["needed_level_of_authentication"])
     end

--- a/test/account_api_test.rb
+++ b/test/account_api_test.rb
@@ -305,35 +305,6 @@ describe GdsApi::AccountApi do
         end
       end
     end
-
-    describe "#get_attributes_names" do
-      let(:path) { "/api/attributes/names" }
-      let(:attribute_name) { "test_attribute_1" }
-
-      it "responds with 200 OK and no attributes, if none exist" do
-        response_body = response_body_with_session_identifier.merge(values: [])
-
-        account_api
-          .given("there is a valid user session")
-          .upon_receiving("a get-attributes-names request")
-          .with(method: :get, path: path, headers: headers, query: { "attributes[]" => [attribute_name] })
-          .will_respond_with(status: 200, headers: json_response_headers, body: response_body)
-
-        api_client.get_attributes_names(govuk_account_session: govuk_account_session, attributes: [attribute_name])
-      end
-
-      it "responds with 200 OK and the attribute names, if they exist" do
-        response_body = response_body_with_session_identifier.merge(values: [attribute_name])
-
-        account_api
-          .given("there is a valid user session, with an attribute called '#{attribute_name}'")
-          .upon_receiving("a get-attributes-names request")
-          .with(method: :get, path: path, headers: headers, query: { "attributes[]" => [attribute_name] })
-          .will_respond_with(status: 200, headers: json_response_headers, body: response_body)
-
-        api_client.get_attributes_names(govuk_account_session: govuk_account_session, attributes: [attribute_name])
-      end
-    end
   end
 
   describe "saved pages" do


### PR DESCRIPTION
This is unused.

We were going to use this for the `/account/home` page, but have since
implemented a special-purpose endpoint just for that, so we only need
to make one request to account-api rather than two or three.