### PR TITLE
Add `get_end_session_url` (for Account API)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# unreleased
+
+- Add `get_end_session_url` (for Account API)
+
 # 73.0.0
 
 - BREAKING: Remove `get_attributes_names` method and helpers (for Account API)

--- a/lib/gds_api/account_api.rb
+++ b/lib/gds_api/account_api.rb
@@ -34,6 +34,15 @@ class GdsApi::AccountApi < GdsApi::Base
     post_json("#{endpoint}/api/oauth2/callback", code: code, state: state)
   end
 
+  # Get an OIDC end-session URL to redirect the user to
+  #
+  # @param [String, nil] govuk_account_session Value of the session header
+  #
+  # @return [Hash] An end-session URL
+  def get_end_session_url(govuk_account_session: nil)
+    get_json("#{endpoint}/api/oauth2/end-session", auth_headers(govuk_account_session))
+  end
+
   # Get all the information about a user needed to render the account home page
   #
   # @param [String] govuk_account_session Value of the session header

--- a/lib/gds_api/test_helpers/account_api.rb
+++ b/lib/gds_api/test_helpers/account_api.rb
@@ -46,6 +46,26 @@ module GdsApi
           .to_return(status: 401)
       end
 
+      #############################
+      # GET /api/oauth2/end-session
+      #############################
+      def stub_account_api_get_end_session_url(govuk_account_session: nil, end_session_uri: "http://auth/provider")
+        if govuk_account_session
+          stub_request(:get, "#{ACCOUNT_API_ENDPOINT}/api/oauth2/end-session")
+            .with(headers: { GdsApi::AccountApi::AUTH_HEADER_NAME => govuk_account_session })
+            .to_return(
+              status: 200,
+              body: { end_session_uri: end_session_uri }.to_json,
+            )
+        else
+          stub_request(:get, "#{ACCOUNT_API_ENDPOINT}/api/oauth2/end-session")
+            .to_return(
+              status: 200,
+              body: { end_session_uri: end_session_uri }.to_json,
+            )
+        end
+      end
+
       ###############
       # GET /api/user
       ###############

--- a/test/account_api/account_api_test.rb
+++ b/test/account_api/account_api_test.rb
@@ -31,6 +31,18 @@ describe GdsApi::AccountApi do
     end
   end
 
+  describe "#get_end_session_url" do
+    it "gives an end-session URI" do
+      stub_account_api_get_end_session_url(end_session_uri: "https://www.example.com/end-session")
+      assert_equal("https://www.example.com/end-session", api_client.get_end_session_url.to_hash["end_session_uri"])
+    end
+
+    it "passes the GOVUK-Account-Session" do
+      stub_account_api_get_end_session_url(govuk_account_session: session_id, end_session_uri: "https://www.example.com/end-session")
+      assert_equal("https://www.example.com/end-session", api_client.get_end_session_url(govuk_account_session: session_id).to_hash["end_session_uri"])
+    end
+  end
+
   describe "#get_user" do
     it "gets the user's information" do
       stub_account_api_user_info(

--- a/test/account_api_test.rb
+++ b/test/account_api_test.rb
@@ -84,6 +84,23 @@ describe GdsApi::AccountApi do
     end
   end
 
+  describe "#get_end_session_url" do
+    let(:path) { "/api/oauth2/end-session" }
+
+    it "responds with 200 OK and an end-session URI" do
+      response_body = {
+        end_session_uri: Pact.like("http://authentication-provider/some/end/session/url"),
+      }
+
+      account_api
+        .upon_receiving("an end-session request")
+        .with(method: :get, path: path, headers: headers)
+        .will_respond_with(status: 200, headers: json_response_headers, body: response_body)
+
+      api_client.get_end_session_url
+    end
+  end
+
   describe "#update_user_by_subject_identifier" do
     let(:subject_identifier) { "the-subject-identifier" }
     let(:path) { "/api/oidc-users/#{subject_identifier}" }


### PR DESCRIPTION
Depends on https://github.com/alphagov/account-api/pull/190

---

This is a new endpoint[1] to generate an appropriate sign-out URL
based on the user's session and which auth service we're using.

I decided against putting this in `GovukPersonalisation::Urls`[2]
because generating the right URL requires looking at the
`.well-known/oidc-configuration` endpoint, which so far is an
account-api concern.

[1] https://github.com/alphagov/account-api/pull/190
[2] https://github.com/alphagov/govuk_personalisation/pull/14

---

[Trello card](https://trello.com/c/ZvDGaba4/958-use-di-auth-in-integration-give-feedback-on-their-documentation)