### PR TITLE
Replace `level_of_authentication` with `mfa` for account-api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# unreleased
+
+- BREAKING: Replace `level_of_authentication` parameter with `mfa` (for Account API)
+
 # 73.1.0
 
 - Add `get_end_session_url` (for Account API)

--- a/lib/gds_api/account_api.rb
+++ b/lib/gds_api/account_api.rb
@@ -11,14 +11,14 @@ class GdsApi::AccountApi < GdsApi::Base
   # Get an OAuth sign-in URL to redirect the user to
   #
   # @param [String, nil] redirect_path path on GOV.UK to send the user to after authentication
-  # @param [String, nil] level_of_authentication either "level1" (require MFA) or "level0" (do not require MFA)
+  # @param [Boolean, nil] mfa whether to authenticate the user with MFA or not
   #
   # @return [Hash] An authentication URL and the OAuth state parameter (for CSRF protection)
-  def get_sign_in_url(redirect_path: nil, level_of_authentication: nil)
+  def get_sign_in_url(redirect_path: nil, mfa: false)
     querystring = nested_query_string(
       {
         redirect_path: redirect_path,
-        level_of_authentication: level_of_authentication,
+        mfa: mfa,
       }.compact,
     )
     get_json("#{endpoint}/api/oauth2/sign-in?#{querystring}")

--- a/lib/gds_api/test_helpers/account_api.rb
+++ b/lib/gds_api/test_helpers/account_api.rb
@@ -19,8 +19,8 @@ module GdsApi
       #########################
       # GET /api/oauth2/sign-in
       #########################
-      def stub_account_api_get_sign_in_url(redirect_path: nil, level_of_authentication: nil, auth_uri: "http://auth/provider", state: "state")
-        querystring = Rack::Utils.build_nested_query({ redirect_path: redirect_path, level_of_authentication: level_of_authentication }.compact)
+      def stub_account_api_get_sign_in_url(redirect_path: nil, mfa: false, auth_uri: "http://auth/provider", state: "state")
+        querystring = Rack::Utils.build_nested_query({ redirect_path: redirect_path, mfa: mfa }.compact)
         stub_request(:get, "#{ACCOUNT_API_ENDPOINT}/api/oauth2/sign-in?#{querystring}")
           .to_return(
             status: 200,
@@ -69,13 +69,13 @@ module GdsApi
       ###############
       # GET /api/user
       ###############
-      def stub_account_api_user_info(id: "user-id", level_of_authentication: "level0", email: "email@example.com", email_verified: true, has_unconfirmed_email: false, services: {}, **options)
+      def stub_account_api_user_info(id: "user-id", mfa: false, email: "email@example.com", email_verified: true, has_unconfirmed_email: false, services: {}, **options)
         stub_account_api_request(
           :get,
           "/api/user",
           response_body: {
             id: id,
-            level_of_authentication: level_of_authentication,
+            mfa: mfa,
             email: email,
             email_verified: email_verified,
             has_unconfirmed_email: has_unconfirmed_email,
@@ -256,13 +256,12 @@ module GdsApi
         )
       end
 
-      def stub_account_api_forbidden_has_attributes(attributes: [], needed_level_of_authentication: "level1", **options)
+      def stub_account_api_forbidden_has_attributes(attributes: [], **options)
         querystring = Rack::Utils.build_nested_query({ attributes: attributes }.compact)
         stub_account_api_request(
           :get,
           "/api/attributes?#{querystring}",
           response_status: 403,
-          response_body: { needed_level_of_authentication: needed_level_of_authentication },
           **options,
         )
       end
@@ -289,13 +288,12 @@ module GdsApi
         )
       end
 
-      def stub_account_api_forbidden_set_attributes(attributes: nil, needed_level_of_authentication: "level1", **options)
+      def stub_account_api_forbidden_set_attributes(attributes: nil, **options)
         stub_account_api_request(
           :patch,
           "/api/attributes",
           with: { body: hash_including({ attributes: attributes }.compact) },
           response_status: 403,
-          response_body: { needed_level_of_authentication: needed_level_of_authentication },
           **options,
         )
       end

--- a/test/account_api_test.rb
+++ b/test/account_api_test.rb
@@ -160,7 +160,7 @@ describe GdsApi::AccountApi do
       it "responds with 200 OK" do
         user_details = response_body_with_session_identifier.merge(
           id: Pact.like("user-id"),
-          level_of_authentication: Pact.like("level0"),
+          mfa: Pact.like(true),
           email: Pact.like("user@example.com"),
           email_verified: Pact.like(true),
           has_unconfirmed_email: Pact.like(true),


### PR DESCRIPTION
We don't need the generality, or complexity, of arbitrary levels of
authentication.  We just need two.

See also https://github.com/alphagov/account-api/pull/210

---

[Trello card](https://trello.com/c/ZvDGaba4/958-use-di-auth-in-integration-give-feedback-on-their-documentation)