### PR TITLE
Release v75.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 75.0.0
 
 - BREAKING: Remove `get_saved_pages` (for Account API)
 - BREAKING: Remove `get_saved_page` (for Account API)

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = "74.0.0".freeze
+  VERSION = "75.0.0".freeze
 end


### PR DESCRIPTION
Removes account api features relating to saving a page.

[Trello](https://trello.com/c/8j4lnc0Y/1049-remove-savedpages-feature)