### PR TITLE
Add cookie & feedback consents for updating users in account-api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# unreleased
+
+- Add `cookie_consent` and `feedback_consent` to `update_user_by_subject_identifier` (for Account API)
+
 # 75.0.0
 
 - BREAKING: Remove `get_saved_pages` (for Account API)

--- a/lib/gds_api/account_api.rb
+++ b/lib/gds_api/account_api.rb
@@ -65,13 +65,17 @@ class GdsApi::AccountApi < GdsApi::Base
   # @param [String, nil] email The user's current
   # @param [Boolean, nil] email_verified Whether the user's current email address is verified
   # @param [Boolean, nil] has_unconfirmed_email Whether the user has a new, pending, email address
+  # @param [Boolean, nil] cookie_consent Whether the user has consented to analytics cookies
+  # @param [Boolean, nil] feedback_consent Whether the user has consented to being contacted for feedback
   #
   # @return [Hash] The user's subject identifier and email attributes
-  def update_user_by_subject_identifier(subject_identifier:, email: nil, email_verified: nil, has_unconfirmed_email: nil)
+  def update_user_by_subject_identifier(subject_identifier:, email: nil, email_verified: nil, has_unconfirmed_email: nil, cookie_consent: nil, feedback_consent: nil)
     params = {
       email: email,
       email_verified: email_verified,
       has_unconfirmed_email: has_unconfirmed_email,
+      cookie_consent: cookie_consent,
+      feedback_consent: feedback_consent,
     }.compact
 
     patch_json("#{endpoint}/api/oidc-users/#{subject_identifier}", params)

--- a/lib/gds_api/test_helpers/account_api.rb
+++ b/lib/gds_api/test_helpers/account_api.rb
@@ -125,16 +125,18 @@ module GdsApi
       ###########################################
       # PATCH /api/oidc-users/:subject_identifier
       ###########################################
-      def stub_update_user_by_subject_identifier(subject_identifier:, email: nil, email_verified: nil, has_unconfirmed_email: nil, old_email: nil, old_email_verified: nil, old_has_unconfirmed_email: nil)
+      def stub_update_user_by_subject_identifier(subject_identifier:, email: nil, email_verified: nil, has_unconfirmed_email: nil, cookie_consent: nil, feedback_consent: nil, old_email: nil, old_email_verified: nil, old_has_unconfirmed_email: nil, old_cookie_consent: nil, old_feedback_consent: nil)
         stub_account_api_request(
           :patch,
           "/api/oidc-users/#{subject_identifier}",
-          with: { body: hash_including({ email: email, email_verified: email_verified, has_unconfirmed_email: has_unconfirmed_email }.compact) },
+          with: { body: hash_including({ email: email, email_verified: email_verified, has_unconfirmed_email: has_unconfirmed_email, cookie_consent: cookie_consent, feedback_consent: feedback_consent }.compact) },
           response_body: {
             sub: subject_identifier,
             email: email || old_email,
             email_verified: email_verified || old_email_verified,
             has_unconfirmed_email: has_unconfirmed_email || old_has_unconfirmed_email,
+            cookie_consent: cookie_consent || old_cookie_consent,
+            feedback_consent: feedback_consent || old_feedback_consent,
           },
         )
       end


### PR DESCRIPTION
See also https://github.com/alphagov/account-api/pull/232

---

[Trello card](https://trello.com/c/9cC8WUfW/1062-store-cookie-feedback-consent-preferences-as-attributes-in-account-api)