### PR TITLE
Add `feedback_consent` to auth validation test helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# unreleased
+
+- Add `feedback_consent` to `stub_account_api_validates_auth_response` test helper (for Account API)
+
 # 75.1.0
 
 - Add `cookie_consent` and `feedback_consent` to `update_user_by_subject_identifier` (for Account API)

--- a/lib/gds_api/test_helpers/account_api.rb
+++ b/lib/gds_api/test_helpers/account_api.rb
@@ -31,12 +31,12 @@ module GdsApi
       ###########################
       # POST /api/oauth2/callback
       ###########################
-      def stub_account_api_validates_auth_response(code: nil, state: nil, govuk_account_session: "govuk-account-session", redirect_path: "/", ga_client_id: "ga-client-id", cookie_consent: false)
+      def stub_account_api_validates_auth_response(code: nil, state: nil, govuk_account_session: "govuk-account-session", redirect_path: "/", ga_client_id: "ga-client-id", cookie_consent: false, feedback_consent: false)
         stub_request(:post, "#{ACCOUNT_API_ENDPOINT}/api/oauth2/callback")
           .with(body: hash_including({ code: code, state: state }.compact))
           .to_return(
             status: 200,
-            body: { govuk_account_session: govuk_account_session, redirect_path: redirect_path, ga_client_id: ga_client_id, cookie_consent: cookie_consent }.to_json,
+            body: { govuk_account_session: govuk_account_session, redirect_path: redirect_path, ga_client_id: ga_client_id, cookie_consent: cookie_consent, feedback_consent: feedback_consent }.to_json,
           )
       end
 

--- a/test/account_api/account_api_test.rb
+++ b/test/account_api/account_api_test.rb
@@ -22,6 +22,13 @@ describe GdsApi::AccountApi do
       assert(!api_client.validate_auth_response(code: "foo", state: "bar")["govuk_account_session"].nil?)
     end
 
+    it "returns the cookie & feedback consents" do
+      stub_account_api_validates_auth_response(code: "foo", state: "bar", cookie_consent: true, feedback_consent: false)
+      response = api_client.validate_auth_response(code: "foo", state: "bar")
+      assert_equal(true, response["cookie_consent"])
+      assert_equal(false, response["feedback_consent"])
+    end
+
     it "throws a 401 if the auth response does not validate" do
       stub_account_api_rejects_auth_response(code: "foo", state: "bar")
 


### PR DESCRIPTION
This is now returned from account-api, and we want to have frontend do
different things depending on whether it's true / false or nil.

---

[Trello card](https://trello.com/c/lmDB5MRJ/1063-show-the-control-how-we-use-information-about-you-page-at-first-login)