### PR TITLE
Forbid creating a SubscriberList with a content_id AND tags or links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# unreleased
+
+* Forbid creating a SubscriberList with a content_id AND tags or links (for Email Alert API)
+
 # 75.2.0
 
 - Add `feedback_consent` to `stub_account_api_validates_auth_response` test helper (for Account API)

--- a/lib/gds_api/email_alert_api.rb
+++ b/lib/gds_api/email_alert_api.rb
@@ -10,8 +10,9 @@ class GdsApi::EmailAlertApi < GdsApi::Base
   #
   # @param attributes [Hash] document_type, links, tags used to search existing subscriber lists
   def find_or_create_subscriber_list(attributes)
-    if attributes["tags"] && attributes["links"]
-      message = "please provide either tags or links (or neither), but not both"
+    present_fields = [attributes["content_id"], attributes["links"], attributes["tags"]].compact.count
+    if present_fields > 1
+      message = "please provide content_id, tags, or links (or none), but not more than one of them"
       raise ArgumentError, message
     end
 

--- a/test/email_alert_api_test.rb
+++ b/test/email_alert_api_test.rb
@@ -331,6 +331,22 @@ describe GdsApi::EmailAlertApi do
           end
         end
       end
+
+      describe "when content_id and tags are provided" do
+        let(:params) do
+          {
+            "title" => title,
+            "content_id" => "fd427f55-7492-440d-ae3f-0fb6c3592b21",
+            "links" => links,
+          }
+        end
+
+        it "excludes that attribute from the query string" do
+          assert_raises do
+            api_client.find_or_create_subscriber_list(params)
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
In [1] we changed email-alert-api to allow signing up to notifications
about a specific content ID.  We're now building the user journeys for
this feature, so we'll be creating such subscriber lists.

It doesn't make sense to create a list with both a `content_id`
restriction *and* `tags` or `links`, because the `content_id` already
restricts potential email triggers to that single page: additional
filtering adds nothing, and runs the risk of creating a list which can
never trigger emails.

[1] https://github.com/alphagov/email-alert-api/pull/1640