### PR TITLE
Use transition_checker_state in account-api attribute pacts

### DIFF
--- a/test/account_api_test.rb
+++ b/test/account_api_test.rb
@@ -270,7 +270,7 @@ describe GdsApi::AccountApi do
       let(:path) { "/api/attributes" }
 
       describe "#get_attributes" do
-        let(:attribute_name) { "test_attribute_1" }
+        let(:attribute_name) { "transition_checker_state" }
 
         it "responds with 200 OK and no attributes, if none exist" do
           response_body = response_body_with_session_identifier.merge(values: {})
@@ -285,7 +285,7 @@ describe GdsApi::AccountApi do
         end
 
         it "responds with 200 OK and the attributes, if some exist" do
-          response_body = response_body_with_session_identifier.merge(values: { attribute_name => { bar: "baz" } })
+          response_body = response_body_with_session_identifier.merge(values: { attribute_name => { array: [1, 2, 3], some: { nested: "json" } } })
 
           account_api
             .given("there is a valid user session, with an attribute called '#{attribute_name}'")
@@ -298,7 +298,7 @@ describe GdsApi::AccountApi do
       end
 
       describe "#set_attributes" do
-        let(:attributes) { { test_attribute_1: [1, 2, 3], test_attribute_2: { nested: "json" } } }
+        let(:attributes) { { transition_checker_state: { array: [1, 2, 3], some: { nested: "json" } } } }
 
         it "responds with 200 OK" do
           account_api


### PR DESCRIPTION
Depends on: https://github.com/alphagov/account-api/pull/259

---

Using the test_attribute_1 and test_attribute_2 will make these tests
fail when we delete the account-manager compatibility code from
account-api.  This is because Digital Identity does not support
updating attribute values.

So, switch to an attributes which will stick around and which we can
write to.