### PR TITLE
Remove `has_unconfirmed_email` parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+* Remove `has_unconfirmed_email` parameter from Account API calls
+
 # 75.3.0
 
 * Add `match_user_by_email` and test helpers (for Account API)

--- a/lib/gds_api/account_api.rb
+++ b/lib/gds_api/account_api.rb
@@ -75,16 +75,14 @@ class GdsApi::AccountApi < GdsApi::Base
   # @param [String] subject_identifier The identifier of the user, shared between the auth service and GOV.UK.
   # @param [String, nil] email The user's current email address
   # @param [Boolean, nil] email_verified Whether the user's current email address is verified
-  # @param [Boolean, nil] has_unconfirmed_email Whether the user has a new, pending, email address
   # @param [Boolean, nil] cookie_consent Whether the user has consented to analytics cookies
   # @param [Boolean, nil] feedback_consent Whether the user has consented to being contacted for feedback
   #
   # @return [Hash] The user's subject identifier and email attributes
-  def update_user_by_subject_identifier(subject_identifier:, email: nil, email_verified: nil, has_unconfirmed_email: nil, cookie_consent: nil, feedback_consent: nil)
+  def update_user_by_subject_identifier(subject_identifier:, email: nil, email_verified: nil, cookie_consent: nil, feedback_consent: nil)
     params = {
       email: email,
       email_verified: email_verified,
-      has_unconfirmed_email: has_unconfirmed_email,
       cookie_consent: cookie_consent,
       feedback_consent: feedback_consent,
     }.compact

--- a/lib/gds_api/test_helpers/account_api.rb
+++ b/lib/gds_api/test_helpers/account_api.rb
@@ -69,7 +69,7 @@ module GdsApi
       ###############
       # GET /api/user
       ###############
-      def stub_account_api_user_info(id: "user-id", mfa: false, email: "email@example.com", email_verified: true, has_unconfirmed_email: false, services: {}, **options)
+      def stub_account_api_user_info(id: "user-id", mfa: false, email: "email@example.com", email_verified: true, services: {}, **options)
         stub_account_api_request(
           :get,
           "/api/user",
@@ -78,7 +78,6 @@ module GdsApi
             mfa: mfa,
             email: email,
             email_verified: email_verified,
-            has_unconfirmed_email: has_unconfirmed_email,
             services: services,
           },
           **options,
@@ -160,16 +159,15 @@ module GdsApi
       ###########################################
       # PATCH /api/oidc-users/:subject_identifier
       ###########################################
-      def stub_update_user_by_subject_identifier(subject_identifier:, email: nil, email_verified: nil, has_unconfirmed_email: nil, cookie_consent: nil, feedback_consent: nil, old_email: nil, old_email_verified: nil, old_has_unconfirmed_email: nil, old_cookie_consent: nil, old_feedback_consent: nil)
+      def stub_update_user_by_subject_identifier(subject_identifier:, email: nil, email_verified: nil, cookie_consent: nil, feedback_consent: nil, old_email: nil, old_email_verified: nil, old_cookie_consent: nil, old_feedback_consent: nil)
         stub_account_api_request(
           :patch,
           "/api/oidc-users/#{subject_identifier}",
-          with: { body: hash_including({ email: email, email_verified: email_verified, has_unconfirmed_email: has_unconfirmed_email, cookie_consent: cookie_consent, feedback_consent: feedback_consent }.compact) },
+          with: { body: hash_including({ email: email, email_verified: email_verified, cookie_consent: cookie_consent, feedback_consent: feedback_consent }.compact) },
           response_body: {
             sub: subject_identifier,
             email: email || old_email,
             email_verified: email_verified || old_email_verified,
-            has_unconfirmed_email: has_unconfirmed_email || old_has_unconfirmed_email,
             cookie_consent: cookie_consent || old_cookie_consent,
             feedback_consent: feedback_consent || old_feedback_consent,
           },

--- a/test/account_api_test.rb
+++ b/test/account_api_test.rb
@@ -109,7 +109,6 @@ describe GdsApi::AccountApi do
       email_attributes = {
         email: "example.email.address@gov.uk",
         email_verified: true,
-        has_unconfirmed_email: false,
       }
       response_body = email_attributes.merge(sub: subject_identifier)
 
@@ -189,7 +188,6 @@ describe GdsApi::AccountApi do
           mfa: Pact.like(true),
           email: Pact.like("user@example.com"),
           email_verified: Pact.like(true),
-          has_unconfirmed_email: Pact.like(true),
           services: {
             transition_checker: "no",
           },


### PR DESCRIPTION
from Account API calls. This attribute is no longer used since we
switched to DI's SSO service as they require users to confirm their
email address as part of the account creation journey.

[Trello](https://trello.com/c/SdkcF8EO/13-remove-hasunconfirmedemail-attribute)