### PR TITLE
Release version 76.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 76.0.0
 * Remove `has_unconfirmed_email` parameter from Account API calls
 
 # 75.3.0

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = "75.3.0".freeze
+  VERSION = "76.0.0".freeze
 end


### PR DESCRIPTION
Includes [Remove `has_unconfirmed_email` parameter from Account API calls (#1120)](https://github.com/alphagov/gds-api-adapters/pull/1120)

[Trello](https://trello.com/c/SdkcF8EO/13-remove-hasunconfirmedemail-attribute)