### PR TITLE
Remove cookie and feedback from `update_user_by_subject_identifier`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
+# unreleased
+
+* BREAKING: Remove `cookie_consent` and `feedback_consent` from `update_user_by_subject_identifier` (for Account API)
+
 # 76.0.0
-* Remove `has_unconfirmed_email` parameter from Account API calls
+
+* BREAKING: Remove `has_unconfirmed_email` parameter from Account API calls
 
 # 75.3.0
 

--- a/lib/gds_api/account_api.rb
+++ b/lib/gds_api/account_api.rb
@@ -75,16 +75,12 @@ class GdsApi::AccountApi < GdsApi::Base
   # @param [String] subject_identifier The identifier of the user, shared between the auth service and GOV.UK.
   # @param [String, nil] email The user's current email address
   # @param [Boolean, nil] email_verified Whether the user's current email address is verified
-  # @param [Boolean, nil] cookie_consent Whether the user has consented to analytics cookies
-  # @param [Boolean, nil] feedback_consent Whether the user has consented to being contacted for feedback
   #
   # @return [Hash] The user's subject identifier and email attributes
-  def update_user_by_subject_identifier(subject_identifier:, email: nil, email_verified: nil, cookie_consent: nil, feedback_consent: nil)
+  def update_user_by_subject_identifier(subject_identifier:, email: nil, email_verified: nil)
     params = {
       email: email,
       email_verified: email_verified,
-      cookie_consent: cookie_consent,
-      feedback_consent: feedback_consent,
     }.compact
 
     patch_json("#{endpoint}/api/oidc-users/#{subject_identifier}", params)

--- a/lib/gds_api/test_helpers/account_api.rb
+++ b/lib/gds_api/test_helpers/account_api.rb
@@ -159,17 +159,15 @@ module GdsApi
       ###########################################
       # PATCH /api/oidc-users/:subject_identifier
       ###########################################
-      def stub_update_user_by_subject_identifier(subject_identifier:, email: nil, email_verified: nil, cookie_consent: nil, feedback_consent: nil, old_email: nil, old_email_verified: nil, old_cookie_consent: nil, old_feedback_consent: nil)
+      def stub_update_user_by_subject_identifier(subject_identifier:, email: nil, email_verified: nil, old_email: nil, old_email_verified: nil)
         stub_account_api_request(
           :patch,
           "/api/oidc-users/#{subject_identifier}",
-          with: { body: hash_including({ email: email, email_verified: email_verified, cookie_consent: cookie_consent, feedback_consent: feedback_consent }.compact) },
+          with: { body: hash_including({ email: email, email_verified: email_verified }.compact) },
           response_body: {
             sub: subject_identifier,
             email: email || old_email,
             email_verified: email_verified || old_email_verified,
-            cookie_consent: cookie_consent || old_cookie_consent,
-            feedback_consent: feedback_consent || old_feedback_consent,
           },
         )
       end


### PR DESCRIPTION
These parameters were only used for importing this data from the
account manager