### PR TITLE
(WIP) Add send send_unpublish_message to email-alert-api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Add `send_unpublish_message` (for Email Alert API)
+
 # 77.0.0
 
 * BREAKING: Remove `cookie_consent` and `feedback_consent` from `update_user_by_subject_identifier` (for Account API)

--- a/lib/gds_api/email_alert_api.rb
+++ b/lib/gds_api/email_alert_api.rb
@@ -70,6 +70,24 @@ class GdsApi::EmailAlertApi < GdsApi::Base
     delete_json("#{endpoint}/subscribers/#{uri_encode(id)}")
   end
 
+  # Identify a subscription list for an unpublished piece of content, and notify all users.
+  #
+  # @param [UUID]     content_id            Unique identifier for a piece of content
+  # @param [string]   notification_template    Which email template should be used in the notification
+  # to users (optional). If not set sends a generic message.
+  #
+  # @return [nil]
+  def send_unpublish_message(content_id, notification_template = "default")
+    # @TODO, the params here are TBC, looking at the email-alert-api side, we may not
+    # be able to get everything off the content item... in which case we may need to pass through
+    # more than just a content_id, or narrow the scope of variations on the email.
+    post_json(
+      "#{endpoint}/unpublication_notification",
+      content_id: content_id,
+      notification_template: notification_template,
+    )
+  end
+
   # Subscribe
   #
   # @return [Hash] subscription_id

--- a/lib/gds_api/test_helpers/email_alert_api.rb
+++ b/lib/gds_api/test_helpers/email_alert_api.rb
@@ -191,6 +191,50 @@ module GdsApi
         assert_requested(:post, "#{EMAIL_ALERT_API_ENDPOINT}/messages", times: 1, &matcher)
       end
 
+      def stub_email_alert_api_unpublication_notification_default_message(content_id)
+        request_params = {
+          content_id: content_id,
+          notification_template: "default",
+        }
+
+        stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/unpublication_notification")
+          .with(body: request_params.compact.to_json)
+          .to_return(status: 202)
+      end
+
+      def stub_email_alert_api_unpublication_notification_with_unpublishing_type(content_id, notification_template)
+        request_params = {
+          content_id: content_id,
+          notification_template: notification_template,
+        }
+
+        stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/unpublication_notification")
+          .with(body: request_params.compact.to_json)
+          .to_return(status: 202)
+      end
+
+      def stub_email_alert_api_unpublication_notification_subscription_list_not_found(content_id)
+        request_params = {
+          content_id: content_id,
+          notification_template: "default",
+        }
+
+        stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/unpublication_notification")
+          .with(body: request_params.compact.to_json)
+          .to_return(status: 404)
+      end
+
+      def stub_email_alert_api_unpublication_notification_unsupported_unpublishing_type(content_id, notification_template)
+        request_params = {
+          content_id: content_id,
+          notification_template: notification_template,
+        }
+
+        stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/unpublication_notification")
+          .with(body: request_params.compact.to_json)
+          .to_return(status: 400)
+      end
+
       def stub_email_alert_api_unsubscribes_a_subscription(uuid)
         stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/unsubscribe/#{uuid}")
           .with(body: "{}")

--- a/test/email_alert_api_test.rb
+++ b/test/email_alert_api_test.rb
@@ -808,4 +808,34 @@ describe GdsApi::EmailAlertApi do
       end
     end
   end
+
+  describe "send_unpublish_message" do
+    let(:content_id) { SecureRandom.uuid }
+
+    it "returns 202" do
+      stub_email_alert_api_unpublication_notification_default_message(content_id)
+      api_response = api_client.send_unpublish_message(content_id)
+      assert_equal(202, api_response.code)
+    end
+
+    it "returns 202" do
+      stub_email_alert_api_unpublication_notification_with_unpublishing_type(content_id, "published_in_error_with_redirect")
+      api_response = api_client.send_unpublish_message(content_id, "published_in_error_with_redirect")
+      assert_equal(202, api_response.code)
+    end
+
+    it "returns 404" do
+      stub_email_alert_api_unpublication_notification_subscription_list_not_found(content_id)
+      assert_raises GdsApi::HTTPNotFound do
+        api_client.send_unpublish_message(content_id)
+      end
+    end
+
+    it "returns 400" do
+      stub_email_alert_api_unpublication_notification_unsupported_unpublishing_type(content_id, "automagically_unpublished")
+      assert_raises GdsApi::HTTPBadRequest do
+        api_client.send_unpublish_message(content_id, "automagically_unpublished")
+      end
+    end
+  end
 end


### PR DESCRIPTION
[Trello](https://trello.com/c/mQNmwCo2/1140-send-users-an-email-when-a-single-page-is-unpublished)

WIP - notes and all so we remember what we were doing in the new year.