### PR TITLE
Add email-alert-api bulk_unsubscribe endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Add `bulk_unsubscribe` endpoint (for Email Alert API)
+
 # 77.0.0
 
 * BREAKING: Remove `cookie_consent` and `feedback_consent` from `update_user_by_subject_identifier` (for Account API)

--- a/lib/gds_api/email_alert_api.rb
+++ b/lib/gds_api/email_alert_api.rb
@@ -247,6 +247,22 @@ class GdsApi::EmailAlertApi < GdsApi::Base
     )
   end
 
+  # Unsubscribe all users for a subscription list
+  # optionally send a notification email explaining the reason
+  #
+  # @param [string]               subscriber_list_id    Identifier for the subscription list
+  # @param [string] (optional)    body                  Optional email body to send to alert users they are being unsubscribed
+  # @param [string] (optional)    sender_message_id     A UUID to prevent multiple emails for the same event
+  def bulk_unsubscribe(subscriber_list_id:, body: nil, sender_message_id: nil)
+    post_json(
+      "#{endpoint}/subscriber-lists/#{subscriber_list_id}/bulk-unsubscribe",
+      {
+        body: body,
+        sender_message_id: sender_message_id,
+      }.compact,
+    )
+  end
+
 private
 
   def nested_query_string(params)

--- a/lib/gds_api/test_helpers/email_alert_api.rb
+++ b/lib/gds_api/test_helpers/email_alert_api.rb
@@ -408,6 +408,53 @@ module GdsApi
           .to_return(status: 404)
       end
 
+      def stub_email_alert_api_bulk_unsubscribe(subscriber_list_id:)
+        stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscriber-lists/#{subscriber_list_id}/bulk-unsubscribe")
+          .to_return(status: 202)
+      end
+
+      def stub_email_alert_api_bulk_unsubscribe_with_message(subscriber_list_id:, body:, sender_message_id:)
+        stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscriber-lists/#{subscriber_list_id}/bulk-unsubscribe")
+        .with(
+          body: {
+            body: body,
+            sender_message_id: sender_message_id,
+          }.to_json,
+        ).to_return(status: 202)
+      end
+
+      def stub_email_alert_api_bulk_unsubscribe_not_found(subscriber_list_id:)
+        stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscriber-lists/#{subscriber_list_id}/bulk-unsubscribe")
+          .to_return(status: 404)
+      end
+
+      def stub_email_alert_api_bulk_unsubscribe_not_found_with_message(subscriber_list_id:, body:, sender_message_id:)
+        stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscriber-lists/#{subscriber_list_id}/bulk-unsubscribe")
+        .with(
+          body: {
+            body: body,
+            sender_message_id: sender_message_id,
+          }.to_json,
+        ).to_return(status: 404)
+      end
+
+      def stub_email_alert_api_bulk_unsubscribe_conflict_with_message(subscriber_list_id:, body:, sender_message_id:)
+        stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscriber-lists/#{subscriber_list_id}/bulk-unsubscribe")
+        .with(
+          body: {
+            body: body,
+            sender_message_id: sender_message_id,
+          }.to_json,
+        ).to_return(status: 409)
+      end
+
+      def stub_email_alert_api_bulk_unsubscribe_bad_request(subscriber_list_id:, body:)
+        stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscriber-lists/#{subscriber_list_id}/bulk-unsubscribe")
+        .with(
+          body: { body: body }.to_json,
+        ).to_return(status: 422)
+      end
+
     private
 
       def get_subscriber_response(id, address, govuk_account_id)

--- a/test/email_alert_api_test.rb
+++ b/test/email_alert_api_test.rb
@@ -808,4 +808,63 @@ describe GdsApi::EmailAlertApi do
       end
     end
   end
+
+  describe "bulk_unsubscribe" do
+    let(:subscriber_list_id) { SecureRandom.uuid }
+    let(:public_updated_at) { Time.now }
+    let(:body) { "email message goes here" }
+    let(:sender_message_id) { SecureRandom.uuid }
+
+    it "returns 202 with just a subscriber_list_id" do
+      stub_email_alert_api_bulk_unsubscribe(subscriber_list_id: subscriber_list_id)
+      api_response = api_client.bulk_unsubscribe(subscriber_list_id: subscriber_list_id)
+      assert_equal(202, api_response.code)
+    end
+
+    it "returns 202 with a message" do
+      stub_email_alert_api_bulk_unsubscribe_with_message(subscriber_list_id: subscriber_list_id, body: body, sender_message_id: sender_message_id)
+      api_response = api_client.bulk_unsubscribe(
+        subscriber_list_id: subscriber_list_id,
+        body: body,
+        sender_message_id: sender_message_id,
+      )
+      assert_equal(202, api_response.code)
+    end
+
+    it "returns 404 if the subscription list is not found" do
+      stub_email_alert_api_bulk_unsubscribe_not_found(subscriber_list_id: subscriber_list_id)
+      assert_raises GdsApi::HTTPNotFound do
+        api_client.bulk_unsubscribe(subscriber_list_id: subscriber_list_id)
+      end
+    end
+
+    it "returns 404 if the subscription list is not found and a message is provided" do
+      stub_email_alert_api_bulk_unsubscribe_not_found_with_message(subscriber_list_id: subscriber_list_id, body: body, sender_message_id: sender_message_id)
+      assert_raises GdsApi::HTTPNotFound do
+        api_client.bulk_unsubscribe(
+          subscriber_list_id: subscriber_list_id,
+          body: body,
+          sender_message_id: sender_message_id,
+        )
+      end
+    end
+
+    it "returns 409 if a message has already been received" do
+      stub_email_alert_api_bulk_unsubscribe_conflict_with_message(subscriber_list_id: subscriber_list_id, body: body, sender_message_id: sender_message_id)
+      assert_raises GdsApi::HTTPConflict do
+        api_client.bulk_unsubscribe(
+          subscriber_list_id: subscriber_list_id,
+          body: body,
+          sender_message_id: sender_message_id,
+        )
+      end
+    end
+
+    it "returns 422 if a body is sent without a sender_message_id" do
+      stub_email_alert_api_bulk_unsubscribe_bad_request(subscriber_list_id: subscriber_list_id, body: body)
+      assert_raises GdsApi::HTTPUnprocessableEntity do
+        api_client.bulk_unsubscribe(subscriber_list_id: subscriber_list_id, body: body)
+      end
+    end
+  end
 end


### PR DESCRIPTION
[Trello](https://trello.com/c/mQNmwCo2/1140-send-users-an-email-when-a-single-page-is-unpublished)

Add bulk_unsubscribe endpoint for email-alert-api

Replaces - https://github.com/alphagov/gds-api-adapters/pull/1124
Depends on - https://github.com/alphagov/email-alert-api/pull/1696
Depends on - https://github.com/alphagov/email-alert-api/pull/1694