### PR TITLE
Release 77.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 77.1.0
 
 * Add `bulk_unsubscribe` endpoint (for Email Alert API)
 

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = "77.0.0".freeze
+  VERSION = "77.1.0".freeze
 end


### PR DESCRIPTION
[Relates to Trello](https://trello.com/c/mQNmwCo2/1140-send-users-an-email-when-a-single-page-is-unpublished)