### PR TITLE
Fix bulk unsubscribe queries by slug not by a uuid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Fix `bulk_unsubscribe` should use a `slug` not `subscriber_list_id`
+
 # 77.1.0
 
 * Add `bulk_unsubscribe` endpoint (for Email Alert API)

--- a/lib/gds_api/email_alert_api.rb
+++ b/lib/gds_api/email_alert_api.rb
@@ -250,12 +250,12 @@ class GdsApi::EmailAlertApi < GdsApi::Base
   # Unsubscribe all users for a subscription list
   # optionally send a notification email explaining the reason
   #
-  # @param [string]               subscriber_list_id    Identifier for the subscription list
+  # @param [string]               slug                  Identifier for the subscription list
   # @param [string] (optional)    body                  Optional email body to send to alert users they are being unsubscribed
   # @param [string] (optional)    sender_message_id     A UUID to prevent multiple emails for the same event
-  def bulk_unsubscribe(subscriber_list_id:, body: nil, sender_message_id: nil)
+  def bulk_unsubscribe(slug:, body: nil, sender_message_id: nil)
     post_json(
-      "#{endpoint}/subscriber-lists/#{subscriber_list_id}/bulk-unsubscribe",
+      "#{endpoint}/subscriber-lists/#{slug}/bulk-unsubscribe",
       {
         body: body,
         sender_message_id: sender_message_id,

--- a/lib/gds_api/test_helpers/email_alert_api.rb
+++ b/lib/gds_api/test_helpers/email_alert_api.rb
@@ -408,13 +408,13 @@ module GdsApi
           .to_return(status: 404)
       end
 
-      def stub_email_alert_api_bulk_unsubscribe(subscriber_list_id:)
-        stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscriber-lists/#{subscriber_list_id}/bulk-unsubscribe")
+      def stub_email_alert_api_bulk_unsubscribe(slug:)
+        stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscriber-lists/#{slug}/bulk-unsubscribe")
           .to_return(status: 202)
       end
 
-      def stub_email_alert_api_bulk_unsubscribe_with_message(subscriber_list_id:, body:, sender_message_id:)
-        stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscriber-lists/#{subscriber_list_id}/bulk-unsubscribe")
+      def stub_email_alert_api_bulk_unsubscribe_with_message(slug:, body:, sender_message_id:)
+        stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscriber-lists/#{slug}/bulk-unsubscribe")
         .with(
           body: {
             body: body,
@@ -423,13 +423,13 @@ module GdsApi
         ).to_return(status: 202)
       end
 
-      def stub_email_alert_api_bulk_unsubscribe_not_found(subscriber_list_id:)
-        stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscriber-lists/#{subscriber_list_id}/bulk-unsubscribe")
+      def stub_email_alert_api_bulk_unsubscribe_not_found(slug:)
+        stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscriber-lists/#{slug}/bulk-unsubscribe")
           .to_return(status: 404)
       end
 
-      def stub_email_alert_api_bulk_unsubscribe_not_found_with_message(subscriber_list_id:, body:, sender_message_id:)
-        stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscriber-lists/#{subscriber_list_id}/bulk-unsubscribe")
+      def stub_email_alert_api_bulk_unsubscribe_not_found_with_message(slug:, body:, sender_message_id:)
+        stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscriber-lists/#{slug}/bulk-unsubscribe")
         .with(
           body: {
             body: body,
@@ -438,8 +438,8 @@ module GdsApi
         ).to_return(status: 404)
       end
 
-      def stub_email_alert_api_bulk_unsubscribe_conflict_with_message(subscriber_list_id:, body:, sender_message_id:)
-        stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscriber-lists/#{subscriber_list_id}/bulk-unsubscribe")
+      def stub_email_alert_api_bulk_unsubscribe_conflict_with_message(slug:, body:, sender_message_id:)
+        stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscriber-lists/#{slug}/bulk-unsubscribe")
         .with(
           body: {
             body: body,
@@ -448,8 +448,8 @@ module GdsApi
         ).to_return(status: 409)
       end
 
-      def stub_email_alert_api_bulk_unsubscribe_bad_request(subscriber_list_id:, body:)
-        stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscriber-lists/#{subscriber_list_id}/bulk-unsubscribe")
+      def stub_email_alert_api_bulk_unsubscribe_bad_request(slug:, body:)
+        stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscriber-lists/#{slug}/bulk-unsubscribe")
         .with(
           body: { body: body }.to_json,
         ).to_return(status: 422)

--- a/test/email_alert_api_test.rb
+++ b/test/email_alert_api_test.rb
@@ -810,21 +810,21 @@ describe GdsApi::EmailAlertApi do
   end
 
   describe "bulk_unsubscribe" do
-    let(:subscriber_list_id) { SecureRandom.uuid }
+    let(:slug) { "i_am_a_subscriber_list_slug" }
     let(:public_updated_at) { Time.now }
     let(:body) { "email message goes here" }
     let(:sender_message_id) { SecureRandom.uuid }
 
-    it "returns 202 with just a subscriber_list_id" do
-      stub_email_alert_api_bulk_unsubscribe(subscriber_list_id: subscriber_list_id)
-      api_response = api_client.bulk_unsubscribe(subscriber_list_id: subscriber_list_id)
+    it "returns 202 with just a subscriber_list_slug" do
+      stub_email_alert_api_bulk_unsubscribe(slug: slug)
+      api_response = api_client.bulk_unsubscribe(slug: slug)
       assert_equal(202, api_response.code)
     end
 
     it "returns 202 with a message" do
-      stub_email_alert_api_bulk_unsubscribe_with_message(subscriber_list_id: subscriber_list_id, body: body, sender_message_id: sender_message_id)
+      stub_email_alert_api_bulk_unsubscribe_with_message(slug: slug, body: body, sender_message_id: sender_message_id)
       api_response = api_client.bulk_unsubscribe(
-        subscriber_list_id: subscriber_list_id,
+        slug: slug,
         body: body,
         sender_message_id: sender_message_id,
       )
@@ -832,17 +832,17 @@ describe GdsApi::EmailAlertApi do
     end
 
     it "returns 404 if the subscription list is not found" do
-      stub_email_alert_api_bulk_unsubscribe_not_found(subscriber_list_id: subscriber_list_id)
+      stub_email_alert_api_bulk_unsubscribe_not_found(slug: slug)
       assert_raises GdsApi::HTTPNotFound do
-        api_client.bulk_unsubscribe(subscriber_list_id: subscriber_list_id)
+        api_client.bulk_unsubscribe(slug: slug)
       end
     end
 
     it "returns 404 if the subscription list is not found and a message is provided" do
-      stub_email_alert_api_bulk_unsubscribe_not_found_with_message(subscriber_list_id: subscriber_list_id, body: body, sender_message_id: sender_message_id)
+      stub_email_alert_api_bulk_unsubscribe_not_found_with_message(slug: slug, body: body, sender_message_id: sender_message_id)
       assert_raises GdsApi::HTTPNotFound do
         api_client.bulk_unsubscribe(
-          subscriber_list_id: subscriber_list_id,
+          slug: slug,
           body: body,
           sender_message_id: sender_message_id,
         )
@@ -850,10 +850,10 @@ describe GdsApi::EmailAlertApi do
     end
 
     it "returns 409 if a message has already been received" do
-      stub_email_alert_api_bulk_unsubscribe_conflict_with_message(subscriber_list_id: subscriber_list_id, body: body, sender_message_id: sender_message_id)
+      stub_email_alert_api_bulk_unsubscribe_conflict_with_message(slug: slug, body: body, sender_message_id: sender_message_id)
       assert_raises GdsApi::HTTPConflict do
         api_client.bulk_unsubscribe(
-          subscriber_list_id: subscriber_list_id,
+          slug: slug,
           body: body,
           sender_message_id: sender_message_id,
         )
@@ -861,9 +861,9 @@ describe GdsApi::EmailAlertApi do
     end
 
     it "returns 422 if a body is sent without a sender_message_id" do
-      stub_email_alert_api_bulk_unsubscribe_bad_request(subscriber_list_id: subscriber_list_id, body: body)
+      stub_email_alert_api_bulk_unsubscribe_bad_request(slug: slug, body: body)
       assert_raises GdsApi::HTTPUnprocessableEntity do
-        api_client.bulk_unsubscribe(subscriber_list_id: subscriber_list_id, body: body)
+        api_client.bulk_unsubscribe(slug: slug, body: body)
       end
     end
   end


### PR DESCRIPTION
[Trello](https://trello.com/c/mQNmwCo2/1140-send-users-an-email-when-a-single-page-is-unpublished)

This was a mistake in the previous release.
