### PR TITLE
Add govuk_request_id to bulk unsubscribe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Fix `bulk_unsubscribe` requires a `govuk_request_id` if you want to send a message
+
 # 78.0.0
 
 * Fix `bulk_unsubscribe` should use a `slug` not `subscriber_list_id`

--- a/lib/gds_api/email_alert_api.rb
+++ b/lib/gds_api/email_alert_api.rb
@@ -251,14 +251,18 @@ class GdsApi::EmailAlertApi < GdsApi::Base
   # optionally send a notification email explaining the reason
   #
   # @param [string]               slug                  Identifier for the subscription list
-  # @param [string] (optional)    body                  Optional email body to send to alert users they are being unsubscribed
-  # @param [string] (optional)    sender_message_id     A UUID to prevent multiple emails for the same event
-  def bulk_unsubscribe(slug:, body: nil, sender_message_id: nil)
+  # @param [string] (optional)    govuk_request_id      An ID allowing us to trace requests across our infra. Required if you want to send an email.
+  # @param [string] (optional)    body                  Optional email body to send to alert users they are being unsubscribed. Required if you want to send an email
+  # @param [string] (optional)    sender_message_id     A UUID to prevent multiple emails for the same event. Required if you want to send an email.
+  def bulk_unsubscribe(slug:, govuk_request_id: nil, body: nil, sender_message_id: nil)
     post_json(
       "#{endpoint}/subscriber-lists/#{slug}/bulk-unsubscribe",
       {
         body: body,
         sender_message_id: sender_message_id,
+      }.compact,
+      {
+        "Govuk-Request-Id" => govuk_request_id,
       }.compact,
     )
   end

--- a/lib/gds_api/test_helpers/email_alert_api.rb
+++ b/lib/gds_api/test_helpers/email_alert_api.rb
@@ -413,13 +413,14 @@ module GdsApi
           .to_return(status: 202)
       end
 
-      def stub_email_alert_api_bulk_unsubscribe_with_message(slug:, body:, sender_message_id:)
+      def stub_email_alert_api_bulk_unsubscribe_with_message(slug:, govuk_request_id:, body:, sender_message_id:)
         stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscriber-lists/#{slug}/bulk-unsubscribe")
         .with(
           body: {
             body: body,
             sender_message_id: sender_message_id,
           }.to_json,
+          headers: { "Govuk-Request-Id" => govuk_request_id },
         ).to_return(status: 202)
       end
 
@@ -428,23 +429,25 @@ module GdsApi
           .to_return(status: 404)
       end
 
-      def stub_email_alert_api_bulk_unsubscribe_not_found_with_message(slug:, body:, sender_message_id:)
+      def stub_email_alert_api_bulk_unsubscribe_not_found_with_message(slug:, govuk_request_id:, body:, sender_message_id:)
         stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscriber-lists/#{slug}/bulk-unsubscribe")
         .with(
           body: {
             body: body,
             sender_message_id: sender_message_id,
           }.to_json,
+          headers: { "Govuk-Request-Id" => govuk_request_id },
         ).to_return(status: 404)
       end
 
-      def stub_email_alert_api_bulk_unsubscribe_conflict_with_message(slug:, body:, sender_message_id:)
+      def stub_email_alert_api_bulk_unsubscribe_conflict_with_message(slug:, govuk_request_id:, body:, sender_message_id:)
         stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscriber-lists/#{slug}/bulk-unsubscribe")
         .with(
           body: {
             body: body,
             sender_message_id: sender_message_id,
           }.to_json,
+          headers: { "Govuk-Request-Id" => govuk_request_id },
         ).to_return(status: 409)
       end
 

--- a/test/email_alert_api_test.rb
+++ b/test/email_alert_api_test.rb
@@ -822,9 +822,15 @@ describe GdsApi::EmailAlertApi do
     end
 
     it "returns 202 with a message" do
-      stub_email_alert_api_bulk_unsubscribe_with_message(slug: slug, body: body, sender_message_id: sender_message_id)
+      stub_email_alert_api_bulk_unsubscribe_with_message(
+        slug: slug,
+        govuk_request_id: "govuk_request_id",
+        body: body,
+        sender_message_id: sender_message_id,
+      )
       api_response = api_client.bulk_unsubscribe(
         slug: slug,
+        govuk_request_id: "govuk_request_id",
         body: body,
         sender_message_id: sender_message_id,
       )
@@ -839,10 +845,16 @@ describe GdsApi::EmailAlertApi do
     end
 
     it "returns 404 if the subscription list is not found and a message is provided" do
-      stub_email_alert_api_bulk_unsubscribe_not_found_with_message(slug: slug, body: body, sender_message_id: sender_message_id)
+      stub_email_alert_api_bulk_unsubscribe_not_found_with_message(
+        slug: slug,
+        govuk_request_id: "govuk_request_id",
+        body: body,
+        sender_message_id: sender_message_id,
+      )
       assert_raises GdsApi::HTTPNotFound do
         api_client.bulk_unsubscribe(
           slug: slug,
+          govuk_request_id: "govuk_request_id",
           body: body,
           sender_message_id: sender_message_id,
         )
@@ -850,10 +862,16 @@ describe GdsApi::EmailAlertApi do
     end
 
     it "returns 409 if a message has already been received" do
-      stub_email_alert_api_bulk_unsubscribe_conflict_with_message(slug: slug, body: body, sender_message_id: sender_message_id)
+      stub_email_alert_api_bulk_unsubscribe_conflict_with_message(
+        slug: slug,
+        govuk_request_id: "govuk_request_id",
+        body: body,
+        sender_message_id: sender_message_id,
+      )
       assert_raises GdsApi::HTTPConflict do
         api_client.bulk_unsubscribe(
           slug: slug,
+          govuk_request_id: "govuk_request_id",
           body: body,
           sender_message_id: sender_message_id,
         )


### PR DESCRIPTION
[Trello](https://trello.com/c/mQNmwCo2/1140-send-users-an-email-when-a-single-page-is-unpublished)

We've discovered that to send a message through the email-alert-api
system (in the case of unpublication) we require a govuk_request_id.
Otherwise we see unexpected Unprocessable Entity errors returned from
the API.