### PR TITLE
Release v78.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 78.1.0
 
 * Fix `bulk_unsubscribe` requires a `govuk_request_id` if you want to send a message
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 # 78.0.0
 
-* Fix `bulk_unsubscribe` should use a `slug` not `subscriber_list_id`
+* BREAKING: Fix `bulk_unsubscribe` should use a `slug` not `subscriber_list_id`
 
 # 77.1.0
 

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = "78.0.0".freeze
+  VERSION = "78.1.0".freeze
 end


### PR DESCRIPTION
[Trello](https://trello.com/c/mQNmwCo2/1140-send-users-an-email-when-a-single-page-is-unpublished)