### PR TITLE
Add `update_subscriber_list_details` (for Email Alert API)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
-# unreleased
+# Unreleased
 
 * Add both with- and without-message variants for bulk unsubscribe test helpers (for Email Alert API)
 * BREAKING: Add `sender_message_id` and `govuk_request_id` to bulk unsubscribe (bad request) test helper (for Email Alert API)
 * Add `content_id` to subscriber lists URL helper (for Email Alert API)
+* Add `update_subscriber_list_details` (for Email Alert API)
 
 # 78.1.0
 

--- a/lib/gds_api/email_alert_api.rb
+++ b/lib/gds_api/email_alert_api.rb
@@ -267,6 +267,17 @@ class GdsApi::EmailAlertApi < GdsApi::Base
     )
   end
 
+  # Update subscriber list details, such as title
+  # @param [Hash]         params        A hash of detail paramaters that can be updated. For example title.
+  #                                     For allowed parameters see:
+  #                                     https://github.com/alphagov/email-alert-api/blob/main/docs/api.md#patch-subscriber-listsxxx
+  def update_subscriber_list_details(slug:, params: {})
+    patch_json(
+      "#{endpoint}/subscriber-lists/#{slug}",
+      params,
+    )
+  end
+
 private
 
   def nested_query_string(params)

--- a/lib/gds_api/test_helpers/email_alert_api.rb
+++ b/lib/gds_api/test_helpers/email_alert_api.rb
@@ -472,6 +472,27 @@ module GdsApi
         ).to_return(status: 422)
       end
 
+      def stub_update_subscriber_list_details(slug:, params:)
+        stub_request(:patch, "#{EMAIL_ALERT_API_ENDPOINT}/subscriber-lists/#{slug}")
+        .with(body: params.to_json)
+        .to_return(
+          status: 200,
+          body: get_subscriber_list_response(params).to_json,
+        )
+      end
+
+      def stub_update_subscriber_list_details_not_found(slug:, params:)
+        stub_request(:patch, "#{EMAIL_ALERT_API_ENDPOINT}/subscriber-lists/#{slug}")
+        .with(body: params.to_json)
+        .to_return(status: 404)
+      end
+
+      def stub_update_subscriber_list_details_unprocessible_entity(slug:, params: {})
+        stub_request(:patch, "#{EMAIL_ALERT_API_ENDPOINT}/subscriber-lists/#{slug}")
+        .with(body: params.to_json)
+        .to_return(status: 422)
+      end
+
     private
 
       def get_subscriber_response(id, address, govuk_account_id)

--- a/test/email_alert_api_test.rb
+++ b/test/email_alert_api_test.rb
@@ -909,4 +909,37 @@ describe GdsApi::EmailAlertApi do
       end
     end
   end
+
+  describe "update_subscriber_list_details" do
+    let(:slug) { "i_am_a_subscriber_list_slug" }
+
+    it "returns 200 and subscriber list with updated title" do
+      params = { "title" => "New Title" }
+
+      stub_update_subscriber_list_details(slug: slug, params: params)
+      api_response = api_client.update_subscriber_list_details(slug: slug, params: params)
+
+      assert_equal(200, api_response.code)
+      assert_equal(params["title"], api_response.to_h.dig("subscriber_list", "title"))
+    end
+
+    it "returns 404 when subscriber list is not found" do
+      params = { "title" => "New Title" }
+
+      stub_update_subscriber_list_details_not_found(slug: slug, params: params)
+
+      assert_raises GdsApi::HTTPNotFound do
+        api_client.update_subscriber_list_details(slug: slug, params: params)
+      end
+    end
+
+    it "returns 422 when provided with invalid parameters" do
+      params = { "title" => nil }
+      stub_update_subscriber_list_details_unprocessible_entity(slug: slug, params: params)
+
+      assert_raises GdsApi::HTTPUnprocessableEntity do
+        api_client.update_subscriber_list_details(slug: slug, params: params)
+      end
+    end
+  end
 end


### PR DESCRIPTION
[Trello](https://trello.com/c/IkYegsOt/1225-update-subscriberlist-titles-on-major-minor-publishing-change)

Allow PATCH updates to subscriber list titles

See also: https://github.com/alphagov/email-alert-api/pull/1704