### PR TITLE
Three improvements to the email-alert-api test helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # unreleased
 
+* BREAKING: Add `sender_message_id` and `govuk_request_id` to bulk unsubscribe (bad request) test helper (for Email Alert API)
 * Add `content_id` to subscriber lists URL helper (for Email Alert API)
 
 # 78.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# unreleased
+
+* Add `content_id` to subscriber lists URL helper (for Email Alert API)
+
 # 78.1.0
 
 * Fix `bulk_unsubscribe` requires a `govuk_request_id` if you want to send a message

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # unreleased
 
+* Add both with- and without-message variants for bulk unsubscribe test helpers (for Email Alert API)
 * BREAKING: Add `sender_message_id` and `govuk_request_id` to bulk unsubscribe (bad request) test helper (for Email Alert API)
 * Add `content_id` to subscriber lists URL helper (for Email Alert API)
 

--- a/lib/gds_api/test_helpers/email_alert_api.rb
+++ b/lib/gds_api/test_helpers/email_alert_api.rb
@@ -537,6 +537,7 @@ module GdsApi
         if attributes
           tags = attributes["tags"]
           links = attributes["links"]
+          content_id = attributes["content_id"]
           document_type = attributes["document_type"]
           email_document_supertype = attributes["email_document_supertype"]
           government_document_supertype = attributes["government_document_supertype"]
@@ -546,6 +547,7 @@ module GdsApi
           params = {}
           params[:tags] = tags if tags
           params[:links] = links if links
+          params[:content_id] = content_id if content_id
           params[:document_type] = document_type if document_type
           params[:email_document_supertype] = email_document_supertype if email_document_supertype
           params[:government_document_supertype] = government_document_supertype if government_document_supertype

--- a/lib/gds_api/test_helpers/email_alert_api.rb
+++ b/lib/gds_api/test_helpers/email_alert_api.rb
@@ -451,10 +451,14 @@ module GdsApi
         ).to_return(status: 409)
       end
 
-      def stub_email_alert_api_bulk_unsubscribe_bad_request(slug:, body:)
+      def stub_email_alert_api_bulk_unsubscribe_bad_request(slug:, govuk_request_id:, body:, sender_message_id:)
         stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscriber-lists/#{slug}/bulk-unsubscribe")
         .with(
-          body: { body: body }.to_json,
+          body: {
+            body: body,
+            sender_message_id: sender_message_id,
+          }.to_json,
+          headers: { "Govuk-Request-Id" => govuk_request_id },
         ).to_return(status: 422)
       end
 

--- a/lib/gds_api/test_helpers/email_alert_api.rb
+++ b/lib/gds_api/test_helpers/email_alert_api.rb
@@ -440,6 +440,11 @@ module GdsApi
         ).to_return(status: 404)
       end
 
+      def stub_email_alert_api_bulk_unsubscribe_conflict(slug:)
+        stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscriber-lists/#{slug}/bulk-unsubscribe")
+          .to_return(status: 409)
+      end
+
       def stub_email_alert_api_bulk_unsubscribe_conflict_with_message(slug:, govuk_request_id:, body:, sender_message_id:)
         stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscriber-lists/#{slug}/bulk-unsubscribe")
         .with(
@@ -451,7 +456,12 @@ module GdsApi
         ).to_return(status: 409)
       end
 
-      def stub_email_alert_api_bulk_unsubscribe_bad_request(slug:, govuk_request_id:, body:, sender_message_id:)
+      def stub_email_alert_api_bulk_unsubscribe_bad_request(slug:)
+        stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscriber-lists/#{slug}/bulk-unsubscribe")
+          .to_return(status: 422)
+      end
+
+      def stub_email_alert_api_bulk_unsubscribe_bad_request_with_message(slug:, govuk_request_id:, body:, sender_message_id:)
         stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscriber-lists/#{slug}/bulk-unsubscribe")
         .with(
           body: {

--- a/test/email_alert_api_test.rb
+++ b/test/email_alert_api_test.rb
@@ -861,7 +861,14 @@ describe GdsApi::EmailAlertApi do
       end
     end
 
-    it "returns 409 if a message has already been received" do
+    it "returns 409 on conflict" do
+      stub_email_alert_api_bulk_unsubscribe_conflict(slug: slug)
+      assert_raises GdsApi::HTTPConflict do
+        api_client.bulk_unsubscribe(slug: slug)
+      end
+    end
+
+    it "returns 409 on conflict if a message is provided" do
       stub_email_alert_api_bulk_unsubscribe_conflict_with_message(
         slug: slug,
         govuk_request_id: "govuk_request_id",
@@ -878,10 +885,27 @@ describe GdsApi::EmailAlertApi do
       end
     end
 
-    it "returns 422 if a body is sent without a sender_message_id" do
-      stub_email_alert_api_bulk_unsubscribe_bad_request(slug: slug, body: body)
+    it "returns 422 on bad request" do
+      stub_email_alert_api_bulk_unsubscribe_bad_request(slug: slug)
       assert_raises GdsApi::HTTPUnprocessableEntity do
-        api_client.bulk_unsubscribe(slug: slug, body: body)
+        api_client.bulk_unsubscribe(slug: slug)
+      end
+    end
+
+    it "returns 422 on bad request if a message is provided" do
+      stub_email_alert_api_bulk_unsubscribe_bad_request_with_message(
+        slug: slug,
+        govuk_request_id: "govuk_request_id",
+        body: body,
+        sender_message_id: sender_message_id,
+      )
+      assert_raises GdsApi::HTTPUnprocessableEntity do
+        api_client.bulk_unsubscribe(
+          slug: slug,
+          govuk_request_id: "govuk_request_id",
+          body: body,
+          sender_message_id: sender_message_id,
+        )
       end
     end
   end


### PR DESCRIPTION
Firstly, adding `content_id` to the subscriber lists URL helper.

The way the test helpers handle subscriber lists is kind of weird.  We pass all the parameters---both the request and response ones undifferentiated---into a single `has_subscriber_list` method, which then uses an allowlist to pluck out the parameters which should go in the request URL, and uses the others to construct the response.  This is pretty strange, the only benefit I can see is that some parameters you'd otherwise have to specify twice, but the cost is that we have this list here which has to be kept up to date.  I think it would be better to remove the need for this entirely, but that can be a later change.

Secondly, adding `sender_message_id` and `govuk_request_id` to the bulk-unsubscribe bad-request helper.

These were left off because the only time the endpoint raises a bad request response is if you don't specify these.  But that makes it kind of difficult to actually use in the email-alert-service tests: I *could* blank out the `govuk_request_id` easily enough, but I can't blank out the `sender_message_id` - so in practice this helper can't actually be used.  So I've added those parameters in.

Thirdly, adding both with- and without-message versions of the bulk-unsubscribe helpers.

This is useful because, in cases where we don't care about what the message actually is (like the above case when we're testing a 422 response is gracefully handled), we can use the without-message variants.