### PR TITLE
Remove references to Transition Checker in account-api pact tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # unreleased
 
+* Remove references to Transition Checker in account-api pact tests
 * Add both with- and without-message variants for bulk unsubscribe test helpers (for Email Alert API)
 * BREAKING: Add `sender_message_id` and `govuk_request_id` to bulk unsubscribe (bad request) test helper (for Email Alert API)
 * Add `content_id` to subscriber lists URL helper (for Email Alert API)

--- a/test/account_api_test.rb
+++ b/test/account_api_test.rb
@@ -188,9 +188,6 @@ describe GdsApi::AccountApi do
           mfa: Pact.like(true),
           email: Pact.like("user@example.com"),
           email_verified: Pact.like(true),
-          services: {
-            transition_checker: "no",
-          },
         )
 
         account_api
@@ -294,7 +291,7 @@ describe GdsApi::AccountApi do
       let(:path) { "/api/attributes" }
 
       describe "#get_attributes" do
-        let(:attribute_name) { "transition_checker_state" }
+        let(:attribute_name) { "feedback_consent" }
 
         it "responds with 200 OK and no attributes, if none exist" do
           response_body = response_body_with_session_identifier.merge(values: {})
@@ -309,7 +306,7 @@ describe GdsApi::AccountApi do
         end
 
         it "responds with 200 OK and the attributes, if some exist" do
-          response_body = response_body_with_session_identifier.merge(values: { attribute_name => { array: [1, 2, 3], some: { nested: "json" } } })
+          response_body = response_body_with_session_identifier.merge(values: { attribute_name => true })
 
           account_api
             .given("there is a valid user session, with an attribute called '#{attribute_name}'")
@@ -322,7 +319,7 @@ describe GdsApi::AccountApi do
       end
 
       describe "#set_attributes" do
-        let(:attributes) { { transition_checker_state: { array: [1, 2, 3], some: { nested: "json" } } } }
+        let(:attributes) { { feedback_consent: true } }
 
         it "responds with 200 OK" do
           account_api


### PR DESCRIPTION
Depend on https://github.com/alphagov/account-api/pull/343

---

The Transition Checker has been retired, so we would like to remove
the attribute.  So we have to remove references in these tests first.