### PR TITLE
Deprecate Email Alert API's create_message endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Deprecate `create_message` for Email Alert API
+
 # 79.1.0
 
 * Add `local_custodian_code_for_postcode` and `coordinates_for_postcode` methods for Locations API

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 79.1.1
 
 * Deprecate `create_message` for Email Alert API
 

--- a/lib/gds_api/email_alert_api.rb
+++ b/lib/gds_api/email_alert_api.rb
@@ -38,6 +38,7 @@ class GdsApi::EmailAlertApi < GdsApi::Base
   #
   # @param message [Hash] Valid message attributes
   def create_message(message, headers = {})
+    warn "#create_message is deprecated and will be removed in a future version."
     post_json("#{endpoint}/messages", message, headers)
   end
 

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = "79.1.0".freeze
+  VERSION = "79.1.1".freeze
 end


### PR DESCRIPTION
This was created for the Brexit checker. I don't believe it is used by anything since the checker was retired, so intend to remove it.

https://trello.com/c/8x01txnU/202-brexit-checker-uses-email-alert-api-as-a-substitute-database