### PR TITLE
Locations API fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 79.1.2
+
+* Fix the Locations API endpoints
+
 # 79.1.1
 
 * Deprecate `create_message` for Email Alert API

--- a/lib/gds_api.rb
+++ b/lib/gds_api.rb
@@ -116,6 +116,13 @@ module GdsApi
     GdsApi::LocalLinksManager.new(Plek.find("local-links-manager"), options)
   end
 
+  # Creates a GdsApi::LocationsApi adapter
+  #
+  # @return [GdsApi::LocationsApi]
+  def self.locations_api(options = {})
+    GdsApi::LocationsApi.new(Plek.find("locations-api"), options)
+  end
+
   # Creates a GdsApi::Mapit adapter
   #
   # @return [GdsApi::Mapit]
@@ -201,12 +208,5 @@ module GdsApi
   # @return [GdsApi::Worldwide]
   def self.worldwide(options = {})
     GdsApi::Worldwide.new(Plek.new.website_root, options)
-  end
-
-  # Creates a GdsApi::LocationsApi adapter
-  #
-  # @return [GdsApi::LocationsApi]
-  def self.locations_api(options = {})
-    GdsApi::LocationsApi.new(Plek.find("locations-api"), options)
   end
 end

--- a/lib/gds_api/locations_api.rb
+++ b/lib/gds_api/locations_api.rb
@@ -8,7 +8,7 @@ class GdsApi::LocationsApi < GdsApi::Base
   #
   # @return [Array] All local custodian codes for a specific postcode
   def local_custodian_code_for_postcode(postcode)
-    response = get_json("#{endpoint}/locations?postcode=#{postcode}.json")
+    response = get_json("#{endpoint}/v1/locations?postcode=#{postcode}")
 
     return [] if response["results"].nil?
 
@@ -21,7 +21,7 @@ class GdsApi::LocationsApi < GdsApi::Base
   #
   # @return [Hash] The average coordinates (two fields, "latitude" and "longitude") for a specific postcode
   def coordinates_for_postcode(postcode)
-    response = get_json("#{endpoint}/locations?postcode=#{postcode}.json")
+    response = get_json("#{endpoint}/v1/locations?postcode=#{postcode}")
 
     { "latitude" => response["average_latitude"], "longitude" => response["average_longitude"] } unless response["results"].nil?
   end

--- a/lib/gds_api/test_helpers/locations_api.rb
+++ b/lib/gds_api/test_helpers/locations_api.rb
@@ -20,17 +20,17 @@ module GdsApi
           "results" => results,
         }
 
-        stub_request(:get, "#{LOCATIONS_API_ENDPOINT}/locations?postcode=#{postcode}.json")
+        stub_request(:get, "#{LOCATIONS_API_ENDPOINT}/v1/locations?postcode=#{postcode}")
           .to_return(body: response.to_json, status: 200)
       end
 
       def stub_locations_api_has_no_location(postcode)
-        stub_request(:get, "#{LOCATIONS_API_ENDPOINT}/locations?postcode=#{postcode}.json")
+        stub_request(:get, "#{LOCATIONS_API_ENDPOINT}/v1/locations?postcode=#{postcode}")
           .to_return(body: { "results" => nil }.to_json, status: 200)
       end
 
       def stub_locations_api_does_not_have_a_bad_postcode(postcode)
-        stub_request(:get, "#{LOCATIONS_API_ENDPOINT}/locations?postcode=#{postcode}.json")
+        stub_request(:get, "#{LOCATIONS_API_ENDPOINT}/v1/locations?postcode=#{postcode}")
          .to_return(body: { "code" => 400, "error" => "Postcode '#{postcode}' is not valid." }.to_json, status: 400)
       end
     end

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = "79.1.1".freeze
+  VERSION = "79.1.2".freeze
 end


### PR DESCRIPTION
Locations API should use a `v1` prefix for its API endpoints. It also does not expect a `.json` suffix.

Trello: https://trello.com/c/gPRVvLXh/2848-set-up-remaining-infrastructure-for-locations-api-5