### PR TITLE
Write Pact tests for Locations API

### DIFF
--- a/test/locations_api_test.rb
+++ b/test/locations_api_test.rb
@@ -4,29 +4,30 @@ require "gds_api/test_helpers/locations_api"
 
 describe GdsApi::LocationsApi do
   include GdsApi::TestHelpers::LocationsApi
-
-  before do
-    @base_api_url = Plek.current.find("locations-api")
-    @api = GdsApi::LocationsApi.new(@base_api_url)
-    @locations = [
-      {
-        "latitude" => 51.5010096,
-        "longitude" => -0.1415870,
-        "local_custodian_code" => 5900,
-      },
-      {
-        "latitude" => 51.5010097,
-        "longitude" => -0.1415871,
-        "local_custodian_code" => 5901,
-      },
-    ]
-  end
+  include PactTest
 
   describe "Locations API" do
-    it "should return the local custodian codes" do
-      stub_locations_api_has_location("SW1A 1AA", @locations)
+    let(:base_api_url) { Plek.current.find("locations-api") }
+    let(:api) { GdsApi::LocationsApi.new(base_api_url) }
+    let(:locations) do
+      [
+        {
+          "latitude" => 51.5010096,
+          "longitude" => -0.1415870,
+          "local_custodian_code" => 5900,
+        },
+        {
+          "latitude" => 51.5010097,
+          "longitude" => -0.1415871,
+          "local_custodian_code" => 5901,
+        },
+      ]
+    end
 
-      response = @api.local_custodian_code_for_postcode("SW1A 1AA")
+    it "should return the local custodian codes" do
+      stub_locations_api_has_location("SW1A 1AA", locations)
+
+      response = api.local_custodian_code_for_postcode("SW1A 1AA")
       assert_equal [5900, 5901], response
     end
 
@@ -52,28 +53,28 @@ describe GdsApi::LocationsApi do
         ],
       )
 
-      response = @api.local_custodian_code_for_postcode("SW1A 1AA")
+      response = api.local_custodian_code_for_postcode("SW1A 1AA")
       assert_equal [5900, 5901], response
     end
 
     it "should return empty list for postcode with no local custodian codes" do
       stub_locations_api_has_no_location("SW1A 1AA")
 
-      response = @api.local_custodian_code_for_postcode("SW1A 1AA")
+      response = api.local_custodian_code_for_postcode("SW1A 1AA")
       assert_equal response, []
     end
 
     it "should return the coordinates" do
-      stub_locations_api_has_location("SW1A 1AA", @locations)
+      stub_locations_api_has_location("SW1A 1AA", locations)
 
-      response = @api.coordinates_for_postcode("SW1A 1AA")
+      response = api.coordinates_for_postcode("SW1A 1AA")
       assert_equal response, { "latitude" => 51.50100965, "longitude" => -0.14158705 }
     end
 
     it "should return nil for postcode with no coordinates" do
       stub_locations_api_has_no_location("SW1A 1AA")
 
-      response = @api.coordinates_for_postcode("SW1A 1AA")
+      response = api.coordinates_for_postcode("SW1A 1AA")
       assert_nil response
     end
 
@@ -81,7 +82,69 @@ describe GdsApi::LocationsApi do
       stub_locations_api_does_not_have_a_bad_postcode("B4DP05TC0D3")
 
       assert_raises GdsApi::HTTPClientError do
-        @api.coordinates_for_postcode("B4DP05TC0D3")
+        api.coordinates_for_postcode("B4DP05TC0D3")
+      end
+    end
+  end
+
+  describe "contract tests" do
+    let(:api_client) { GdsApi::LocationsApi.new(locations_api_host) }
+
+    describe "#local_custodian_code_for_postcode" do
+      it "responds with a list of local custodian codes" do
+        locations_api
+          .given("a postcode")
+          .upon_receiving("the request to get details about a postcode")
+          .with(
+            method: :get,
+            path: "/v1/locations",
+            headers: GdsApi::JsonClient.default_request_headers,
+            query: { postcode: "SW1A1AA" },
+          )
+          .will_respond_with(
+            status: 200,
+            body: {
+              "average_latitude" => 51.50100965,
+              "average_longitude" => -0.14158705,
+              "results" => [
+                { "local_custodian_code" => 5900 },
+                { "local_custodian_code" => 5901 },
+              ],
+            },
+            headers: {
+              "Content-Type" => "application/json; charset=utf-8",
+            },
+          )
+        api_client.local_custodian_code_for_postcode("SW1A1AA")
+      end
+    end
+
+    describe "#coordinates_for_postcode" do
+      it "responds with average coordinates for postcode" do
+        locations_api
+          .given("a postcode")
+          .upon_receiving("the request to get details about a postcode")
+          .with(
+            method: :get,
+            path: "/v1/locations",
+            headers: GdsApi::JsonClient.default_request_headers,
+            query: { postcode: "SW1A1AA" },
+          )
+          .will_respond_with(
+            status: 200,
+            body: {
+              "average_latitude" => 51.50100965,
+              "average_longitude" => -0.14158705,
+              "results" => [
+                { "local_custodian_code" => 5900 },
+                { "local_custodian_code" => 5901 },
+              ],
+            },
+            headers: {
+              "Content-Type" => "application/json; charset=utf-8",
+            },
+          )
+        api_client.coordinates_for_postcode("SW1A1AA")
       end
     end
   end

--- a/test/test_helpers/pact_helper.rb
+++ b/test/test_helpers/pact_helper.rb
@@ -5,6 +5,7 @@ ACCOUNT_API_PORT = 3004
 LINK_CHECKER_API_PORT = 3005
 IMMINENCE_API_PORT = 3006
 WHITEHALL_API_PORT = 3007
+LOCATIONS_API_PORT = 3008
 
 def publishing_api_host
   "http://localhost:#{PUBLISHING_API_PORT}"
@@ -32,6 +33,10 @@ end
 
 def whitehall_api_host
   "http://localhost:#{WHITEHALL_API_PORT}"
+end
+
+def locations_api_host
+  "http://localhost:#{LOCATIONS_API_PORT}"
 end
 
 Pact.service_consumer "GDS API Adapters" do
@@ -74,6 +79,12 @@ Pact.service_consumer "GDS API Adapters" do
   has_pact_with "Whitehall API" do
     mock_service :whitehall_api do
       port WHITEHALL_API_PORT
+    end
+  end
+
+  has_pact_with "Locations API" do
+    mock_service :locations_api do
+      port LOCATIONS_API_PORT
     end
   end
 end


### PR DESCRIPTION
Trello card: https://trello.com/c/d5yUPZYA/2891-set-up-contract-tests-for-locations-api-3

Locations API needs to [meet the standards](https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#check-api-contract-tests-pass-ie-adapters-work-with-their-apis) required for continuously deployment.
Contract tests have to be set up between Locations API and its API consumer, gds-api-adaptors.