### PR TITLE
Remove cookie and feedback consent attributes from account-api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+Remove cookie and feedback consent attributes from Account API pact tests
+
 # 79.1.2
 
 * Fix the Locations API endpoints

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 79.2.0
 
 Remove cookie and feedback consent attributes from Account API pact tests
 

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = "79.1.2".freeze
+  VERSION = "79.2.0".freeze
 end

--- a/test/account_api_test.rb
+++ b/test/account_api_test.rb
@@ -60,18 +60,6 @@ describe GdsApi::AccountApi do
       api_client.validate_auth_response(**params)
     end
 
-    it "responds with 200 OK and includes the cookie_consent in the response, if saved" do
-      response_body = response_body_with_session_identifier.merge(cookie_consent: true)
-
-      account_api
-        .given("there is a valid OAuth response, with cookie consent 'true'")
-        .upon_receiving("a validation request")
-        .with(method: :post, path: path, headers: headers_with_json_body, body: params)
-        .will_respond_with(status: 200, headers: json_response_headers, body: response_body)
-
-      api_client.validate_auth_response(**params)
-    end
-
     it "responds with 401 Unauthorized if the parameters are not valid" do
       account_api
         .upon_receiving("a validation request")
@@ -291,7 +279,7 @@ describe GdsApi::AccountApi do
       let(:path) { "/api/attributes" }
 
       describe "#get_attributes" do
-        let(:attribute_name) { "feedback_consent" }
+        let(:attribute_name) { "local_attribute" }
 
         it "responds with 200 OK and no attributes, if none exist" do
           response_body = response_body_with_session_identifier.merge(values: {})
@@ -319,7 +307,7 @@ describe GdsApi::AccountApi do
       end
 
       describe "#set_attributes" do
-        let(:attributes) { { feedback_consent: true } }
+        let(:attributes) { { local_attribute: true } }
 
         it "responds with 200 OK" do
           account_api


### PR DESCRIPTION
We've removed the first time sign in page which asked users to consent
to cookies and sending them emails for feedback [[1]] and the form to
see and manage these attributes in the account home area [[2]].

Now we can remove them from the API, which first means any mention of
them needs to be removed from the pact tests.

These changes have been tested locally against https://github.com/alphagov/account-api/pull/408

---

Requires https://github.com/alphagov/account-api/pull/410 before merging

---
[Trello](https://trello.com/c/XGmG7Jav/1371-tidy-up-database-after-cookies-and-feedback)

[1]: https://github.com/alphagov/frontend/pull/3234
[2]: https://github.com/alphagov/frontend/pull/3225