### PR TITLE
Don’t require `govuk_request_id` in Email Alert API's #bulk_unsubscribe stubs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 80.0.1
+
+* Fix `bulk_unsubscribe` stubs so `govuk_request_id` is not a required parameter
+
 # 80.0.0
 
 * BREAKING: Remove support for publishing api import endpoint - a temporary endpoint that has been removed from publishing api. However, no apps are using this so it should not be breaking in practice.

--- a/lib/gds_api/email_alert_api.rb
+++ b/lib/gds_api/email_alert_api.rb
@@ -252,7 +252,7 @@ class GdsApi::EmailAlertApi < GdsApi::Base
   # optionally send a notification email explaining the reason
   #
   # @param [string]               slug                  Identifier for the subscription list
-  # @param [string] (optional)    govuk_request_id      An ID allowing us to trace requests across our infra. Required if you want to send an email.
+  # @param [string] (optional)    govuk_request_id      An ID allowing us to trace requests across our infra. Required if you want to send an email by running out-of-band processes via asynchronous workers.
   # @param [string] (optional)    body                  Optional email body to send to alert users they are being unsubscribed. Required if you want to send an email
   # @param [string] (optional)    sender_message_id     A UUID to prevent multiple emails for the same event. Required if you want to send an email.
   def bulk_unsubscribe(slug:, govuk_request_id: nil, body: nil, sender_message_id: nil)

--- a/lib/gds_api/test_helpers/email_alert_api.rb
+++ b/lib/gds_api/test_helpers/email_alert_api.rb
@@ -413,15 +413,15 @@ module GdsApi
           .to_return(status: 202)
       end
 
-      def stub_email_alert_api_bulk_unsubscribe_with_message(slug:, govuk_request_id:, body:, sender_message_id:)
+      def stub_email_alert_api_bulk_unsubscribe_with_message(slug:, body:, sender_message_id:, govuk_request_id: nil)
         stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscriber-lists/#{slug}/bulk-unsubscribe")
-        .with(
+        .with({
           body: {
             body: body,
             sender_message_id: sender_message_id,
           }.to_json,
-          headers: { "Govuk-Request-Id" => govuk_request_id },
-        ).to_return(status: 202)
+        }.tap { |attr| attr[:headers] = { "Govuk-Request-Id" => govuk_request_id } if govuk_request_id })
+        .to_return(status: 202)
       end
 
       def stub_email_alert_api_bulk_unsubscribe_not_found(slug:)
@@ -429,15 +429,15 @@ module GdsApi
           .to_return(status: 404)
       end
 
-      def stub_email_alert_api_bulk_unsubscribe_not_found_with_message(slug:, govuk_request_id:, body:, sender_message_id:)
+      def stub_email_alert_api_bulk_unsubscribe_not_found_with_message(slug:, body:, sender_message_id:, govuk_request_id: nil)
         stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscriber-lists/#{slug}/bulk-unsubscribe")
-        .with(
+        .with({
           body: {
             body: body,
             sender_message_id: sender_message_id,
           }.to_json,
-          headers: { "Govuk-Request-Id" => govuk_request_id },
-        ).to_return(status: 404)
+        }.tap { |attr| attr[:headers] = { "Govuk-Request-Id" => govuk_request_id } if govuk_request_id })
+        .to_return(status: 404)
       end
 
       def stub_email_alert_api_bulk_unsubscribe_conflict(slug:)
@@ -445,15 +445,15 @@ module GdsApi
           .to_return(status: 409)
       end
 
-      def stub_email_alert_api_bulk_unsubscribe_conflict_with_message(slug:, govuk_request_id:, body:, sender_message_id:)
+      def stub_email_alert_api_bulk_unsubscribe_conflict_with_message(slug:, body:, sender_message_id:, govuk_request_id: nil)
         stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscriber-lists/#{slug}/bulk-unsubscribe")
-        .with(
+        .with({
           body: {
             body: body,
             sender_message_id: sender_message_id,
           }.to_json,
-          headers: { "Govuk-Request-Id" => govuk_request_id },
-        ).to_return(status: 409)
+        }.tap { |attr| attr[:headers] = { "Govuk-Request-Id" => govuk_request_id } if govuk_request_id })
+        .to_return(status: 409)
       end
 
       def stub_email_alert_api_bulk_unsubscribe_bad_request(slug:)
@@ -461,15 +461,15 @@ module GdsApi
           .to_return(status: 422)
       end
 
-      def stub_email_alert_api_bulk_unsubscribe_bad_request_with_message(slug:, govuk_request_id:, body:, sender_message_id:)
+      def stub_email_alert_api_bulk_unsubscribe_bad_request_with_message(slug:, body:, sender_message_id:, govuk_request_id: nil)
         stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscriber-lists/#{slug}/bulk-unsubscribe")
-        .with(
+        .with({
           body: {
             body: body,
             sender_message_id: sender_message_id,
           }.to_json,
-          headers: { "Govuk-Request-Id" => govuk_request_id },
-        ).to_return(status: 422)
+        }.tap { |attr| attr[:headers] = { "Govuk-Request-Id" => govuk_request_id } if govuk_request_id })
+        .to_return(status: 422)
       end
 
       def stub_update_subscriber_list_details(slug:, params:)

--- a/test/email_alert_api_test.rb
+++ b/test/email_alert_api_test.rb
@@ -837,6 +837,20 @@ describe GdsApi::EmailAlertApi do
       assert_equal(202, api_response.code)
     end
 
+    it "returns 202 with a message when govuk_request_id is not passed in as a parameter" do
+      stub_email_alert_api_bulk_unsubscribe_with_message(
+        slug: slug,
+        body: body,
+        sender_message_id: sender_message_id,
+      )
+      api_response = api_client.bulk_unsubscribe(
+        slug: slug,
+        body: body,
+        sender_message_id: sender_message_id,
+      )
+      assert_equal(202, api_response.code)
+    end
+
     it "returns 404 if the subscription list is not found" do
       stub_email_alert_api_bulk_unsubscribe_not_found(slug: slug)
       assert_raises GdsApi::HTTPNotFound do


### PR DESCRIPTION
The GOVUK-Request-Id HTTP header is set by Nginx on an initial request and
passed by the apps to the APIs that they call [[1]](https://github.com/alphagov/govuk-puppet/blob/05af1/modules/nginx/templates/proxy-vhost.conf#L7-L25). The gds-api-adapters handle
the header in the middleware [[2]](https://github.com/alphagov/gds-api-adapters/blob/2bb3a/lib/gds_api/railtie.rb#L5-L8).
It is only necessary to explicitly pass the header for out-of-band processes
via asynchronous workers (e.g. Sidekiq).

This still allows to pass it in as a parameter so it's not a breaking change
and also updates the documentation to more accurately describe when the param
is required.

This is only changing the test helpers because the methods doesn't require it already:
```
def bulk_unsubscribe(slug:, govuk_request_id: nil, body: nil, sender_message_id: nil)
```

https://trello.com/c/CQlLYnrF/1038-automate-unsubscribing-from-archived-specialist-topics-m

**Note**
There is a question if setting the header by passing it in the request body should be supported by the gds-api-adapters, given they read the headers in the middleware. There is precedent of the setting the onward GOVUK-Request-Id HTTP header by the apps.
Removing this option would be a breaking change so we may want to consider this as a follow up PR.


