### PR TITLE
Remove support for the import endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 80.0.0
+
+* BREAKING: Remove support for publishing api import endpoint - a temporary endpoint that has been removed from publishing api. However, no apps are using this so it should not be breaking in practice.
+
 # 79.2.0
 
 Remove cookie and feedback consent attributes from Account API pact tests

--- a/lib/gds_api/publishing_api.rb
+++ b/lib/gds_api/publishing_api.rb
@@ -150,23 +150,6 @@ class GdsApi::PublishingApi < GdsApi::Base
     post_json(republish_url(content_id), params)
   end
 
-  # Import content into the publishing API
-  #
-  # The publishing-api will delete any content which has the content
-  # id provided, and then import the data given.
-  #
-  # @param content_id [UUID]
-  # @param content_items [Array]
-  #
-  # @see https://github.com/alphagov/publishing-api/blob/main/docs/api.md#post-v2contentcontent_idimport
-  def import(content_id, locale, content_items)
-    params = {
-      history: content_items,
-    }
-
-    post_json("#{endpoint}/v2/content/#{content_id}/import?locale=#{locale}", params)
-  end
-
   # Unpublish a content item
   #
   # The publishing API will "unpublish" a live item, to remove it from the public

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = "79.2.0".freeze
+  VERSION = "80.0.0".freeze
 end


### PR DESCRIPTION
This endpoint is being removed from publishing api (it was only ever intended to be temporary) so this PR also removes support for it in gds-api-adaptors.

Related publishing api change: https://github.com/alphagov/publishing-api/pull/2096

I've made this a major change as technically it's a breaking change, although no clients are using this so it should not actually break for anybody in practice.

The main question I have is around what the general release process is. I notice that some changes go in as unreleased, but I assume we want to release this one straightaway. Is there anything else I need to bear in mind given this library is widely used across gov.uk and there are some unreleased changes from before?

[Trello card](https://trello.com/c/FNtolpuM/13-enable-continuous-deployment-for-publishing-api)