### PR TITLE
Add local_custodian_code and country_name as optional parameters for local links manager stubs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 81.0.2
+
+* Add `local_custodian_code` and `country_name` as optional parameters for local_links_manager stubs
+
 # 81.0.1
 
 * Add quality of life function to allow retrieval of subscribers to a specific topic

--- a/lib/gds_api/test_helpers/local_links_manager.rb
+++ b/lib/gds_api/test_helpers/local_links_manager.rb
@@ -98,13 +98,13 @@ module GdsApi
         parameters
       end
 
-      def stub_local_links_manager_has_a_local_authority(authority_slug, local_custodian_code: nil)
+      def stub_local_links_manager_has_a_local_authority(authority_slug, country_name: "England", local_custodian_code: nil)
         response = {
           "local_authorities" => [
             {
               "name" => authority_slug.capitalize,
               "homepage_url" => "http://#{authority_slug}.example.com",
-              "country_name" => "England",
+              "country_name" => country_name,
               "tier" => "unitary",
               "slug" => authority_slug,
             },
@@ -177,13 +177,13 @@ module GdsApi
           .to_return(body: {}.to_json, status: 404)
       end
 
-      def stub_local_links_manager_has_a_local_authority_without_homepage(authority_slug)
+      def stub_local_links_manager_has_a_local_authority_without_homepage(authority_slug, country_name: "England", local_custodian_code: nil)
         response = {
           "local_authorities" => [
             {
               "name" => authority_slug.capitalize,
               "homepage_url" => "",
-              "country_name" => "England",
+              "country_name" => country_name,
               "tier" => "unitary",
               "slug" => authority_slug,
             },
@@ -193,6 +193,12 @@ module GdsApi
         stub_request(:get, "#{LOCAL_LINKS_MANAGER_ENDPOINT}/api/local-authority")
           .with(query: { authority_slug: authority_slug })
           .to_return(body: response.to_json, status: 200)
+
+        unless local_custodian_code.nil?
+          stub_request(:get, "#{LOCAL_LINKS_MANAGER_ENDPOINT}/api/local-authority")
+            .with(query: { local_custodian_code: local_custodian_code })
+            .to_return(body: response.to_json, status: 200)
+        end
       end
     end
   end

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = "81.0.1".freeze
+  VERSION = "81.0.2".freeze
 end


### PR DESCRIPTION
These are needed for testing the switch from Mapit to Locations API in frontend controllers.

Trello card: https://trello.com/c/6TO6GDJM/2934-switch-frontend-to-use-locations-api-5