### PR TITLE
Update local_links_manager stub for local_authority to return snac value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 81.0.4
+
+* Return `snac` in local_links_manager stubs for local_authority
+
 # 81.0.3
 
 * Make `snac` customizable in local_links_manager stubs

--- a/lib/gds_api/test_helpers/local_links_manager.rb
+++ b/lib/gds_api/test_helpers/local_links_manager.rb
@@ -98,7 +98,7 @@ module GdsApi
         parameters
       end
 
-      def stub_local_links_manager_has_a_local_authority(authority_slug, country_name: "England", local_custodian_code: nil)
+      def stub_local_links_manager_has_a_local_authority(authority_slug, country_name: "England", snac: "00AG", local_custodian_code: nil)
         response = {
           "local_authorities" => [
             {
@@ -107,6 +107,7 @@ module GdsApi
               "country_name" => country_name,
               "tier" => "unitary",
               "slug" => authority_slug,
+              "snac" => snac,
             },
           ],
         }
@@ -122,7 +123,7 @@ module GdsApi
         end
       end
 
-      def stub_local_links_manager_has_a_district_and_county_local_authority(district_slug, county_slug, local_custodian_code: nil)
+      def stub_local_links_manager_has_a_district_and_county_local_authority(district_slug, county_slug, district_snac: "00AG", county_snac: "00LC", local_custodian_code: nil)
         response = {
           "local_authorities" => [
             {
@@ -131,6 +132,7 @@ module GdsApi
               "country_name" => "England",
               "tier" => "district",
               "slug" => district_slug,
+              "snac" => district_snac,
             },
             {
               "name" => county_slug.capitalize,
@@ -138,6 +140,7 @@ module GdsApi
               "country_name" => "England",
               "tier" => "county",
               "slug" => county_slug,
+              "snac" => county_snac,
             },
           ],
         }
@@ -177,7 +180,7 @@ module GdsApi
           .to_return(body: {}.to_json, status: 404)
       end
 
-      def stub_local_links_manager_has_a_local_authority_without_homepage(authority_slug, country_name: "England", local_custodian_code: nil)
+      def stub_local_links_manager_has_a_local_authority_without_homepage(authority_slug, country_name: "England", snac: "00AG", local_custodian_code: nil)
         response = {
           "local_authorities" => [
             {
@@ -186,6 +189,7 @@ module GdsApi
               "country_name" => country_name,
               "tier" => "unitary",
               "slug" => authority_slug,
+              "snac" => snac,
             },
           ],
         }

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = "81.0.3".freeze
+  VERSION = "81.0.4".freeze
 end

--- a/test/local_links_manager_api_test.rb
+++ b/test/local_links_manager_api_test.rb
@@ -283,7 +283,7 @@ describe GdsApi::LocalLinksManager do
   describe "#local_authority" do
     describe "when making a request for a local authority with a parent" do
       it "should return the local authority and its parent" do
-        stub_local_links_manager_has_a_district_and_county_local_authority("blackburn", "rochester")
+        stub_local_links_manager_has_a_district_and_county_local_authority("blackburn", "rochester", district_snac: "test1", county_snac: "test2")
 
         expected_response = {
           "local_authorities" => [
@@ -293,6 +293,7 @@ describe GdsApi::LocalLinksManager do
               "country_name" => "England",
               "tier" => "district",
               "slug" => "blackburn",
+              "snac" => "test1",
             },
             {
               "name" => "Rochester",
@@ -300,6 +301,7 @@ describe GdsApi::LocalLinksManager do
               "country_name" => "England",
               "tier" => "county",
               "slug" => "rochester",
+              "snac" => "test2",
             },
           ],
         }
@@ -321,6 +323,7 @@ describe GdsApi::LocalLinksManager do
               "country_name" => "England",
               "tier" => "unitary",
               "slug" => "blackburn",
+              "snac" => "00AG",
             },
           ],
         }
@@ -362,6 +365,7 @@ describe GdsApi::LocalLinksManager do
               "country_name" => "England",
               "tier" => "district",
               "slug" => "blackburn",
+              "snac" => "00AG",
             },
             {
               "name" => "Rochester",
@@ -369,6 +373,7 @@ describe GdsApi::LocalLinksManager do
               "country_name" => "England",
               "tier" => "county",
               "slug" => "rochester",
+              "snac" => "00LC",
             },
           ],
         }
@@ -390,6 +395,7 @@ describe GdsApi::LocalLinksManager do
               "country_name" => "England",
               "tier" => "unitary",
               "slug" => "blackburn",
+              "snac" => "00AG",
             },
           ],
         }


### PR DESCRIPTION
`snac` is now returned in the `/local_authority` response (added [here](https://github.com/alphagov/local-links-manager/pull/939))
