### PR TITLE
Remove email-alert-api#create_message

### DIFF
--- a/lib/gds_api/email_alert_api.rb
+++ b/lib/gds_api/email_alert_api.rb
@@ -34,14 +34,6 @@ class GdsApi::EmailAlertApi < GdsApi::Base
     post_json("#{endpoint}/content-changes", content_change, headers)
   end
 
-  # Post a message
-  #
-  # @param message [Hash] Valid message attributes
-  def create_message(message, headers = {})
-    warn "#create_message is deprecated and will be removed in a future version."
-    post_json("#{endpoint}/messages", message, headers)
-  end
-
   # Get topic matches
   #
   # @param attributes [Hash] tags, links, document_type,

--- a/lib/gds_api/test_helpers/email_alert_api.rb
+++ b/lib/gds_api/test_helpers/email_alert_api.rb
@@ -155,11 +155,6 @@ module GdsApi
           .to_return(status: 202, body: {}.to_json)
       end
 
-      def stub_email_alert_api_accepts_message
-        stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/messages")
-          .to_return(status: 202, body: {}.to_json)
-      end
-
       def stub_email_alert_api_accepts_email
         stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/emails")
           .to_return(status: 202, body: {}.to_json)
@@ -178,17 +173,6 @@ module GdsApi
         end
 
         assert_requested(:post, "#{EMAIL_ALERT_API_ENDPOINT}/content-changes", times: 1, &matcher)
-      end
-
-      def assert_email_alert_api_message_created(attributes = nil)
-        if attributes
-          matcher = lambda do |request|
-            payload = JSON.parse(request.body)
-            payload.select { |k, _| attributes.key?(k) } == attributes
-          end
-        end
-
-        assert_requested(:post, "#{EMAIL_ALERT_API_ENDPOINT}/messages", times: 1, &matcher)
       end
 
       def stub_email_alert_api_unsubscribes_a_subscription(uuid)

--- a/test/email-alert-api/email_alert_api_pact_test.rb
+++ b/test/email-alert-api/email_alert_api_pact_test.rb
@@ -221,10 +221,6 @@ describe GdsApi::EmailAlertApi do
     end
   end
 
-  # describe create_message
-  #   TODO: method is DEPRECATED, so remove this when removed
-  # end
-
   # describe "topic_matches" do
   #   Not currently used by anything, so not a priority
   # end

--- a/test/email-alert-api/email_alert_api_test.rb
+++ b/test/email-alert-api/email_alert_api_test.rb
@@ -48,31 +48,6 @@ describe GdsApi::EmailAlertApi do
     end
   end
 
-  describe "messages" do
-    let(:subject) { "Email subject" }
-    let(:message_params) do
-      {
-        "subject" => subject,
-        "body" => "Body",
-        "tags" => tags,
-      }
-    end
-
-    before do
-      stub_email_alert_api_accepts_message
-    end
-
-    it "posts a new message" do
-      assert api_client.create_message(message_params)
-
-      assert_requested(:post, "#{base_url}/messages", body: message_params.to_json)
-    end
-
-    it "returns the an empty response" do
-      assert api_client.create_message(message_params).to_hash.empty?
-    end
-  end
-
   describe "subscriptions" do
     describe "URI encoding ids" do
       it "encodes the id for #get_subscription" do

--- a/test/test_helpers/email_alert_api_test.rb
+++ b/test/test_helpers/email_alert_api_test.rb
@@ -22,20 +22,6 @@ describe GdsApi::TestHelpers::EmailAlertApi do
     end
   end
 
-  describe "#assert_email_alert_api_message_created" do
-    before { stub_any_email_alert_api_call }
-
-    it "matches a post request with any empty attributes by default" do
-      email_alert_api.create_message("foo" => "bar")
-      assert_email_alert_api_message_created
-    end
-
-    it "matches a post request subset of attributes" do
-      email_alert_api.create_message("foo" => "bar", "baz" => "qux")
-      assert_email_alert_api_message_created("foo" => "bar")
-    end
-  end
-
   describe "#stub_email_alert_api_has_subscriber_subscriptions" do
     let(:id) { SecureRandom.uuid }
     let(:address) { "test@example.com" }


### PR DESCRIPTION
This api call has been marked as deprecated for 6 months, and it appears that there are no longer any calls to it in non-archived repos, so we should remove the code here (where it's easy to replace if it turns out there's a surprise user), then if nothing turns up in a couple of weeks we can remove the code supporting the call from email-alert-api itself.