### PR TITLE
Complete contract tests for email-alert-api

### DIFF
--- a/test/email-alert-api/email_alert_api_pact_test.rb
+++ b/test/email-alert-api/email_alert_api_pact_test.rb
@@ -391,7 +391,63 @@ describe GdsApi::EmailAlertApi do
   end
 
   describe "#subscribe" do
-    # TODO: implement pact, used by email-alert-frontend
+    it "responds with a 422" do
+      email_alert_api
+        .given("a subscriber list with id 1 exists")
+        .upon_receiving("request to subscribe with an invalid frequency")
+        .with(
+          method: :post,
+          path: "/subscriptions",
+          body: {
+            subscriber_list_id: 1,
+            address: "test@example.com",
+            frequency: "thrice-fortnightly",
+            skip_confirmation_email: true,
+          },
+          headers: GdsApi::JsonClient.default_request_with_json_body_headers,
+        )
+        .will_respond_with(
+          status: 422,
+        )
+
+      begin
+        api_client.subscribe(
+          subscriber_list_id: 1,
+          address: "test@example.com",
+          frequency: "thrice-fortnightly",
+          skip_confirmation_email: true,
+        )
+      rescue GdsApi::HTTPUnprocessableEntity
+        # This is expected
+      end
+    end
+
+    it "responds with a 200" do
+      email_alert_api
+        .given("a subscriber list with id 1 exists")
+        .upon_receiving("request to subscribe with a valid frequency")
+        .with(
+          method: :post,
+          path: "/subscriptions",
+          body: {
+            subscriber_list_id: 1,
+            address: "test@example.com",
+            frequency: "daily",
+            skip_confirmation_email: true,
+          },
+          headers: GdsApi::JsonClient.default_request_with_json_body_headers,
+        )
+        .will_respond_with(
+          status: 200,
+        )
+
+      api_client.subscribe(
+        subscriber_list_id: 1,
+        address: "test@example.com",
+        frequency: "daily",
+        skip_confirmation_email: true,
+      )
+    end
   end
 
   describe "#get_subscriber_list" do

--- a/test/email-alert-api/email_alert_api_pact_test.rb
+++ b/test/email-alert-api/email_alert_api_pact_test.rb
@@ -354,7 +354,40 @@ describe GdsApi::EmailAlertApi do
   end
 
   describe "#unsubscribe_subscriber" do
-    # TODO: implement pact, used by account-api
+    it "responds with a 404" do
+      email_alert_api
+        .upon_receiving("the request to unsubscribe a missing subscriber")
+        .with(
+          method: :delete,
+          path: "/subscribers/1",
+          headers: GdsApi::JsonClient.default_request_headers,
+        )
+        .will_respond_with(
+          status: 404,
+        )
+
+      begin
+        api_client.unsubscribe_subscriber(1)
+      rescue GdsApi::HTTPNotFound
+        # This is expected
+      end
+    end
+
+    it "responds with a 204" do
+      email_alert_api
+        .given("a subscriber exists")
+        .upon_receiving("the request to unsubscribe that subscriber")
+        .with(
+          method: :delete,
+          path: "/subscribers/1",
+          headers: GdsApi::JsonClient.default_request_headers,
+        )
+        .will_respond_with(
+          status: 204,
+        )
+
+      api_client.unsubscribe_subscriber(1)
+    end
   end
 
   describe "#subscribe" do

--- a/test/email-alert-api/email_alert_api_pact_test.rb
+++ b/test/email-alert-api/email_alert_api_pact_test.rb
@@ -802,7 +802,7 @@ describe GdsApi::EmailAlertApi do
 
     it "responds with the subscriber" do
       email_alert_api
-        .given("a verified govuk_account_session exists with a matching subscriber")
+        .given("a verified govuk_account_session exists with a linked subscriber")
         .upon_receiving("a request to authenticate by the govuk_account_session")
         .with(
           method: :post,
@@ -813,7 +813,7 @@ describe GdsApi::EmailAlertApi do
         .will_respond_with(
           status: 200,
           body: {
-            subscriber: example_subscriber,
+            subscriber: example_subscriber.merge("govuk_account_id": "internal-user-id"),
           },
           headers: {
             "Content-Type" => "application/json; charset=utf-8",


### PR DESCRIPTION
Contract tests exist for the popular methods of email-alert-api, this PR will complete the contract by adding tests for the less popular methods.

To add:
- [x] bulk_unsubscribe
- [x] unsubscribe_subscriber
- [x] subscribe
- [x] change_subscription
- [x] update_subscriber_list_details
- [x] find_subscriber_by_govuk_account
- [x] link_subscriber_to_govuk_account
- [x] send_subscriber_verification_email
- [x] send_subscription_verification_email

https://trello.com/c/a2xnyjGW/1447-complete-contract-tests-for-email-alert-api