### PR TITLE
Use TLS when fetching gem dependencies.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 # Specify your gem's dependencies in gds-api-adapters.gemspec
 gemspec


### PR DESCRIPTION
This has been the default for new Gemfiles since a major security incident at rubygems.org in 2013[[1]].

[1]: https://venturebeat.com/business/rubygems-org-hacked-interrupting-heroku-services-and-putting-millions-of-sites-using-rails-at-risk/