### PR TITLE
Replace usages of Plek.current

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Replace use of Plek.current to resolve warnings with Plek >= 4.1
+
 # 82.0.0
 
 * BREAKING: Remove support for `create_message` endpoint for Email Alert API. However, this has been deprecated for 6 months and no apps are using this so it should not be breaking in practice.

--- a/lib/gds_api/test_helpers/asset_manager.rb
+++ b/lib/gds_api/test_helpers/asset_manager.rb
@@ -1,7 +1,7 @@
 module GdsApi
   module TestHelpers
     module AssetManager
-      ASSET_MANAGER_ENDPOINT = Plek.current.find("asset-manager")
+      ASSET_MANAGER_ENDPOINT = Plek.find("asset-manager")
 
       def stub_any_asset_manager_call
         stub_request(:any, %r{\A#{ASSET_MANAGER_ENDPOINT}}).to_return(status: 200)

--- a/lib/gds_api/test_helpers/content_store.rb
+++ b/lib/gds_api/test_helpers/content_store.rb
@@ -8,7 +8,7 @@ module GdsApi
       include ContentItemHelpers
 
       def content_store_endpoint(draft: false)
-        draft ? Plek.current.find("draft-content-store") : Plek.current.find("content-store")
+        draft ? Plek.find("draft-content-store") : Plek.find("content-store")
       end
 
       # Stubs a content item in the content store.

--- a/lib/gds_api/test_helpers/imminence.rb
+++ b/lib/gds_api/test_helpers/imminence.rb
@@ -5,7 +5,7 @@ module GdsApi
     module Imminence
       # Generally true. If you are initializing the client differently,
       # you could redefine/override the constant or stub directly.
-      IMMINENCE_API_ENDPOINT = Plek.current.find("imminence")
+      IMMINENCE_API_ENDPOINT = Plek.find("imminence")
 
       def stub_imminence_has_places(latitude, longitude, details)
         query_hash = { "lat" => latitude, "lng" => longitude, "limit" => "5" }

--- a/lib/gds_api/test_helpers/licence_application.rb
+++ b/lib/gds_api/test_helpers/licence_application.rb
@@ -5,7 +5,7 @@ module GdsApi
     module LicenceApplication
       # Generally true. If you are initializing the client differently,
       # you could redefine/override the constant or stub directly.
-      LICENCE_APPLICATION_ENDPOINT = Plek.current.find("licensify")
+      LICENCE_APPLICATION_ENDPOINT = Plek.find("licensify")
 
       def stub_licence_exists(identifier, licence)
         licence = licence.to_json unless licence.is_a?(String)

--- a/lib/gds_api/test_helpers/link_checker_api.rb
+++ b/lib/gds_api/test_helpers/link_checker_api.rb
@@ -3,7 +3,7 @@ require "gds_api/test_helpers/json_client_helper"
 module GdsApi
   module TestHelpers
     module LinkCheckerApi
-      LINK_CHECKER_API_ENDPOINT = Plek.current.find("link-checker-api")
+      LINK_CHECKER_API_ENDPOINT = Plek.find("link-checker-api")
 
       def link_checker_api_link_report_hash(uri:, status: :ok, checked: nil, errors: [], warnings: [], problem_summary: nil, suggested_fix: nil)
         {

--- a/lib/gds_api/test_helpers/local_links_manager.rb
+++ b/lib/gds_api/test_helpers/local_links_manager.rb
@@ -3,7 +3,7 @@ require "gds_api/test_helpers/json_client_helper"
 module GdsApi
   module TestHelpers
     module LocalLinksManager
-      LOCAL_LINKS_MANAGER_ENDPOINT = Plek.current.find("local-links-manager")
+      LOCAL_LINKS_MANAGER_ENDPOINT = Plek.find("local-links-manager")
 
       def stub_local_links_manager_has_a_link(authority_slug:, lgsl:, lgil:, url:, country_name: "England", status: "ok", snac: "00AG", local_custodian_code: nil)
         response = {

--- a/lib/gds_api/test_helpers/locations_api.rb
+++ b/lib/gds_api/test_helpers/locations_api.rb
@@ -1,7 +1,7 @@
 module GdsApi
   module TestHelpers
     module LocationsApi
-      LOCATIONS_API_ENDPOINT = Plek.current.find("locations-api")
+      LOCATIONS_API_ENDPOINT = Plek.find("locations-api")
 
       def stub_locations_api_has_location(postcode, locations)
         results = []

--- a/lib/gds_api/test_helpers/mapit.rb
+++ b/lib/gds_api/test_helpers/mapit.rb
@@ -1,7 +1,7 @@
 module GdsApi
   module TestHelpers
     module Mapit
-      MAPIT_ENDPOINT = Plek.current.find("mapit")
+      MAPIT_ENDPOINT = Plek.find("mapit")
 
       def stub_mapit_has_a_postcode(postcode, coords)
         response = {

--- a/lib/gds_api/test_helpers/publishing_api.rb
+++ b/lib/gds_api/test_helpers/publishing_api.rb
@@ -8,8 +8,8 @@ module GdsApi
     module PublishingApi
       include ContentItemHelpers
 
-      PUBLISHING_API_V2_ENDPOINT = "#{Plek.current.find('publishing-api')}/v2".freeze
-      PUBLISHING_API_ENDPOINT = Plek.current.find("publishing-api")
+      PUBLISHING_API_V2_ENDPOINT = "#{Plek.find('publishing-api')}/v2".freeze
+      PUBLISHING_API_ENDPOINT = Plek.find("publishing-api")
 
       # Stub a PUT /v2/content/:content_id request with the given content id and request body.
       # if no response_hash is given, a default response as follows is created:

--- a/lib/gds_api/test_helpers/router.rb
+++ b/lib/gds_api/test_helpers/router.rb
@@ -3,7 +3,7 @@ require "gds_api/test_helpers/json_client_helper"
 module GdsApi
   module TestHelpers
     module Router
-      ROUTER_API_ENDPOINT = Plek.current.find("router-api")
+      ROUTER_API_ENDPOINT = Plek.find("router-api")
 
       def stub_router_has_route(path, route, bearer_token = ENV["ROUTER_API_BEARER_TOKEN"])
         stub_get_route(path, bearer_token).to_return(

--- a/lib/gds_api/test_helpers/search.rb
+++ b/lib/gds_api/test_helpers/search.rb
@@ -4,7 +4,7 @@ require "gds_api/test_helpers/json_client_helper"
 module GdsApi
   module TestHelpers
     module Search
-      SEARCH_ENDPOINT = Plek.current.find("search")
+      SEARCH_ENDPOINT = Plek.find("search")
 
       def stub_any_search_post(index: nil)
         if index

--- a/lib/gds_api/test_helpers/support.rb
+++ b/lib/gds_api/test_helpers/support.rb
@@ -1,7 +1,7 @@
 module GdsApi
   module TestHelpers
     module Support
-      SUPPORT_ENDPOINT = Plek.current.find("support")
+      SUPPORT_ENDPOINT = Plek.find("support")
 
       def stub_support_foi_request_creation(request_details = nil)
         post_stub = stub_http_request(:post, "#{SUPPORT_ENDPOINT}/foi_requests")

--- a/lib/gds_api/test_helpers/support_api.rb
+++ b/lib/gds_api/test_helpers/support_api.rb
@@ -4,7 +4,7 @@ require "plek"
 module GdsApi
   module TestHelpers
     module SupportApi
-      SUPPORT_API_ENDPOINT = Plek.current.find("support-api")
+      SUPPORT_API_ENDPOINT = Plek.find("support-api")
 
       def stub_support_api_problem_report_creation(request_details = nil)
         post_stub = stub_http_request(:post, "#{SUPPORT_API_ENDPOINT}/anonymous-feedback/problem-reports")

--- a/test/asset_manager/asset_manager_test.rb
+++ b/test/asset_manager/asset_manager_test.rb
@@ -6,7 +6,7 @@ require "json"
 describe GdsApi::AssetManager do
   include GdsApi::TestHelpers::AssetManager
 
-  let(:base_api_url) { Plek.current.find("asset-manager") }
+  let(:base_api_url) { Plek.find("asset-manager") }
   let(:api) { GdsApi::AssetManager.new(base_api_url) }
 
   let(:file_fixture) { load_fixture_file("hello.txt") }

--- a/test/content_store_test.rb
+++ b/test/content_store_test.rb
@@ -6,7 +6,7 @@ describe GdsApi::ContentStore do
   include GdsApi::TestHelpers::ContentStore
 
   before do
-    @base_api_url = Plek.current.find("content-store")
+    @base_api_url = Plek.find("content-store")
     @api = GdsApi::ContentStore.new(@base_api_url)
   end
 

--- a/test/imminence/imminence_api_test.rb
+++ b/test/imminence/imminence_api_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 require "gds_api/imminence"
 
 class ImminenceApiTest < Minitest::Test
-  ROOT = Plek.current.find("imminence")
+  ROOT = Plek.find("imminence")
   LATITUDE = 52.1327584352089
   LONGITUDE = -0.4702813074674147
 

--- a/test/local_links_manager_api_test.rb
+++ b/test/local_links_manager_api_test.rb
@@ -6,7 +6,7 @@ describe GdsApi::LocalLinksManager do
   include GdsApi::TestHelpers::LocalLinksManager
 
   before do
-    @base_api_url = Plek.current.find("local-links-manager")
+    @base_api_url = Plek.find("local-links-manager")
     @api = GdsApi::LocalLinksManager.new(@base_api_url)
   end
 

--- a/test/locations_api_test.rb
+++ b/test/locations_api_test.rb
@@ -7,7 +7,7 @@ describe GdsApi::LocationsApi do
   include PactTest
 
   describe "Locations API" do
-    let(:base_api_url) { Plek.current.find("locations-api") }
+    let(:base_api_url) { Plek.find("locations-api") }
     let(:api) { GdsApi::LocationsApi.new(base_api_url) }
     let(:locations) do
       [

--- a/test/mapit_test.rb
+++ b/test/mapit_test.rb
@@ -6,7 +6,7 @@ describe GdsApi::Mapit do
   include GdsApi::TestHelpers::Mapit
 
   before do
-    @base_api_url = Plek.current.find("mapit")
+    @base_api_url = Plek.find("mapit")
     @api = GdsApi::Mapit.new(@base_api_url)
   end
 

--- a/test/publishing_api/special_route_publisher_test.rb
+++ b/test/publishing_api/special_route_publisher_test.rb
@@ -21,7 +21,7 @@ describe GdsApi::PublishingApi::SpecialRoutePublisher do
   end
 
   let(:publisher) { GdsApi::PublishingApi::SpecialRoutePublisher.new }
-  let(:endpoint) { Plek.current.find("publishing-api") }
+  let(:endpoint) { Plek.find("publishing-api") }
 
   describe ".publish" do
     before do

--- a/test/support_api_test.rb
+++ b/test/support_api_test.rb
@@ -6,7 +6,7 @@ describe GdsApi::SupportApi do
   include GdsApi::TestHelpers::SupportApi
 
   before do
-    @base_api_url = Plek.current.find("support-api")
+    @base_api_url = Plek.find("support-api")
     @api = GdsApi::SupportApi.new(@base_api_url)
   end
 

--- a/test/support_test.rb
+++ b/test/support_test.rb
@@ -6,7 +6,7 @@ describe GdsApi::Support do
   include GdsApi::TestHelpers::Support
 
   before do
-    @base_api_url = Plek.current.find("support")
+    @base_api_url = Plek.find("support")
     @api = GdsApi::Support.new(@base_api_url)
   end
 

--- a/test/test_helpers/asset_manager_test.rb
+++ b/test/test_helpers/asset_manager_test.rb
@@ -6,7 +6,7 @@ describe GdsApi::TestHelpers::AssetManager do
   include GdsApi::TestHelpers::AssetManager
 
   let(:stub_asset_manager) do
-    GdsApi::AssetManager.new(Plek.current.find("asset-manager"))
+    GdsApi::AssetManager.new(Plek.find("asset-manager"))
   end
 
   describe "#stub_asset_manager_receives_an_asset" do

--- a/test/test_helpers/email_alert_api_test.rb
+++ b/test/test_helpers/email_alert_api_test.rb
@@ -5,7 +5,7 @@ require "gds_api/test_helpers/email_alert_api"
 describe GdsApi::TestHelpers::EmailAlertApi do
   include GdsApi::TestHelpers::EmailAlertApi
 
-  let(:base_api_url) { Plek.current.find("email-alert-api") }
+  let(:base_api_url) { Plek.find("email-alert-api") }
   let(:email_alert_api) { GdsApi::EmailAlertApi.new(base_api_url) }
 
   describe "#assert_email_alert_api_content_change_created" do

--- a/test/test_helpers/publishing_api_test.rb
+++ b/test/test_helpers/publishing_api_test.rb
@@ -4,7 +4,7 @@ require "gds_api/test_helpers/publishing_api"
 
 describe GdsApi::TestHelpers::PublishingApi do
   include GdsApi::TestHelpers::PublishingApi
-  let(:publishing_api) { GdsApi::PublishingApi.new(Plek.current.find("publishing-api")) }
+  let(:publishing_api) { GdsApi::PublishingApi.new(Plek.find("publishing-api")) }
 
   describe "#stub_publishing_api_has_linked_items" do
     it "stubs the get linked items api call" do


### PR DESCRIPTION
This has been deprecated [1] since Plek 4.1 [2]. Instead we can use forego the need for a current method and call find directly.

[1]: https://github.com/alphagov/plek/pull/94
[2]: https://github.com/alphagov/plek/pull/92