### PR TITLE
Fix Mocha deprecation warning

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -52,7 +52,3 @@ require "test_helpers/pact_helper"
 
 require "webmock/minitest"
 WebMock.disable_net_connect!
-
-Mocha.configure do |c|
-  c.reinstate_undocumented_behaviour_from_v1_9 = false
-end


### PR DESCRIPTION
`Mocha::Configuration#reinstate_undocumented_behaviour_from_v1_9` is deprecated and will be removed in Mocha v2.

For more context, see: alphagov/whitehall#6927 and alphagov/whitehall#6925.