### PR TITLE
Use canonical name for `search-api` instead of legacy `search`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 84.0.0
+
+* BREAKING: `TestHelpers::Search` now uses `search-api` when constructing URLs for requests stubs.
+* Use the canonical name `search-api` instead of the legacy name `search` when connecting to Search API.
+
 # 83.0.0
 
 * BREAKING: Remove support for `areas_for_type` endpoint for Imminence API. This was last used by the Publishing app in 2017 (and that call is now removed) and has not been used by any other apps, so it should not be breaking in practice.

--- a/lib/gds_api.rb
+++ b/lib/gds_api.rb
@@ -179,7 +179,7 @@ module GdsApi
   #
   # @return [GdsApi::Search]
   def self.search(options = {})
-    GdsApi::Search.new(Plek.find("search"), options)
+    GdsApi::Search.new(Plek.find("search-api"), options)
   end
 
   # Creates a GdsApi::Support adapter

--- a/lib/gds_api/test_helpers/search.rb
+++ b/lib/gds_api/test_helpers/search.rb
@@ -4,7 +4,7 @@ require "gds_api/test_helpers/json_client_helper"
 module GdsApi
   module TestHelpers
     module Search
-      SEARCH_ENDPOINT = Plek.find("search")
+      SEARCH_ENDPOINT = Plek.find("search-api")
 
       def stub_any_search_post(index: nil)
         if index

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = "83.0.0".freeze
+  VERSION = "84.0.0".freeze
 end


### PR DESCRIPTION
This is a breaking change because of the way the test helpers currently work, but I have PRs to fix all the occurrences of the legacy `search` name throughout alphagov ready to go once this is released, so it should be seamless.

Cleaning this up now means there's one less thing to trip over for Replatforming.