### PR TITLE
Stop expecting internal Mongo document ID in return from imminence.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Remove expectation that Imminence will return the OID field in the response to #places. This is an internal Mongoid field that we shouldn't be returning anyway, and frontend (the consumer) isn't using it.
+
 # 85.0.0
 
 * BREAKING: Remove Mapit api methods. These are no longer used by any apps, so should not be breaking in practice.

--- a/test/pacts/imminence_api_pact_test.rb
+++ b/test/pacts/imminence_api_pact_test.rb
@@ -21,7 +21,6 @@ describe "GdsApi::Imminence pact tests" do
           status: 200,
           body: Pact.each_like(
             {
-              _id: { "$oid": "60867a0ee90e0703aed18e46" },
               access_notes: nil,
               address1: "Yarrow Road Tower Park",
               address2: nil,


### PR DESCRIPTION
Imminence shouldn't be returning OID (the internal Mongo document ID) through the API endpoint. Frontend (currently the only consumer of this endpoint) doesn't appear to be using the OID. I think technically this isn't a breaking change, since it doesn't materially affect the API, even though it's a pact change.