### PR TITLE
Add support for local_authority_slug disambiguator for Imminence places endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* BREAKING: Changes to Imminence API to support split-postcodes. In practice, the only consumer app for this API is Frontend, which is prepared for the change.
+
 # 85.0.1
 
 * Remove expectation that Imminence will return the OID field in the response to #places. This is an internal Mongoid field that we shouldn't be returning anyway, and frontend (the consumer) isn't using it.

--- a/lib/gds_api/imminence.rb
+++ b/lib/gds_api/imminence.rb
@@ -2,55 +2,24 @@ require_relative "base"
 
 class GdsApi::Imminence < GdsApi::Base
   def api_url(type, params)
-    vals = %i[limit lat lng postcode].select { |p| params.include? p }
+    vals = %i[limit lat lng postcode local_authority_slug].select { |p| params.include? p }
     querystring = URI.encode_www_form(vals.map { |p| [p, params[p]] })
     "#{@endpoint}/places/#{type}.json?#{querystring}"
   end
 
   def places(type, lat, lon, limit = 5)
     url = api_url(type, lat: lat, lng: lon, limit: limit)
-    places = get_json(url) || []
-    places.map { |p| self.class.parse_place_hash(p) }
+    get_json(url)
   end
 
-  def places_for_postcode(type, postcode, limit = 5)
-    url = api_url(type, postcode: postcode, limit: limit)
-    places = get_json(url) || []
-    places.map { |p| self.class.parse_place_hash(p) }
-  end
-
-  def self.parse_place_hash(place_hash)
-    location = extract_location_hash(place_hash["location"])
-    address = extract_address_hash(place_hash)
-
-    place_hash.merge(location).merge(address)
+  def places_for_postcode(type, postcode, limit = 5, local_authority_slug = nil)
+    options = { postcode: postcode, limit: limit }
+    options.merge!(local_authority_slug: local_authority_slug) if local_authority_slug
+    url = api_url(type, options)
+    get_json(url) || []
   end
 
   def places_kml(type)
     get_raw("#{@endpoint}/places/#{type}.kml").body
-  end
-
-  # @private
-  def self.extract_location_hash(location)
-    # Deal with all known location formats:
-    #   Old style: [latitude, longitude]; empty array for no location
-    #   New style: hash with keys "longitude", "latitude"; nil for no location
-    case location
-    when Array
-      { "latitude" => location[0], "longitude" => location[1] }
-    when Hash
-      location
-    when nil
-      { "latitude" => nil, "longitude" => nil }
-    end
-  end
-
-  # @private
-  def self.extract_address_hash(place_hash)
-    address_fields = [
-      place_hash["address1"],
-      place_hash["address2"],
-    ].reject { |a| a.nil? || a == "" }
-    { "address" => address_fields.map(&:strip).join(", ") }
   end
 end

--- a/lib/gds_api/test_helpers/imminence.rb
+++ b/lib/gds_api/test_helpers/imminence.rb
@@ -9,12 +9,33 @@ module GdsApi
 
       def stub_imminence_has_places(latitude, longitude, details)
         query_hash = { "lat" => latitude, "lng" => longitude, "limit" => "5" }
-        stub_imminence_places_request(details["slug"], query_hash, details["details"])
+        response_data = {
+          status: "ok",
+          content: "places",
+          places: details["details"],
+        }
+        stub_imminence_places_request(details["slug"], query_hash, response_data)
       end
 
-      def stub_imminence_has_places_for_postcode(places, slug, postcode, limit)
+      def stub_imminence_has_multiple_authorities_for_postcode(addresses, slug, postcode, limit)
         query_hash = { "postcode" => postcode, "limit" => limit }
-        stub_imminence_places_request(slug, query_hash, places)
+        response_data = {
+          status: "address-information-required",
+          content: "addresses",
+          addresses: addresses,
+        }
+        stub_imminence_places_request(slug, query_hash, response_data)
+      end
+
+      def stub_imminence_has_places_for_postcode(places, slug, postcode, limit, local_authority_slug)
+        query_hash = { "postcode" => postcode, "limit" => limit }
+        query_hash.merge!(local_authority_slug: local_authority_slug) if local_authority_slug
+        response_data = {
+          status: "ok",
+          content: "places",
+          places: places,
+        }
+        stub_imminence_places_request(slug, query_hash, response_data)
       end
 
       def stub_imminence_places_request(slug, query_hash, return_data, status_code = 200)

--- a/test/pacts/imminence_api_pact_test.rb
+++ b/test/pacts/imminence_api_pact_test.rb
@@ -10,7 +10,7 @@ describe "GdsApi::Imminence pact tests" do
     it "responds with all responses for the given dataset" do
       imminence_api
         .given("a service exists called number-plate-supplier with places")
-        .upon_receiving("the request to retrieve all places for the current dataset")
+        .upon_receiving("the request to retrieve relevant places for the current dataset for a lat/lon")
         .with(
           method: :get,
           path: "/places/number-plate-supplier.json",
@@ -19,36 +19,70 @@ describe "GdsApi::Imminence pact tests" do
         )
         .will_respond_with(
           status: 200,
-          body: Pact.each_like(
-            {
-              access_notes: nil,
-              address1: "Yarrow Road Tower Park",
-              address2: nil,
-              data_set_version: 473,
-              email: nil,
-              fax: nil,
-              general_notes: nil,
-              geocode_error: nil,
-              location: { longitude: -1.9552618901330387, latitude: 50.742754933617285 },
-              name: "Breeze Motor Co Ltd",
-              override_lat: nil,
-              override_lng: nil,
-              phone: "01202 713000",
-              postcode: "BH12 4QY",
-              service_slug: "number-plate-supplier",
-              snac: nil,
-              source_address: "Yarrow Road Tower Park Poole  BH12 4QY",
-              text_phone: nil,
-              town: "Yarrow",
-              url: nil,
-            },
-          ),
+          body: {
+            status: "ok",
+            contents: "places",
+            places: Pact.each_like(
+              {
+                access_notes: nil,
+                address1: "Yarrow Road Tower Park",
+                address2: nil,
+                data_set_version: 473,
+                email: nil,
+                fax: nil,
+                general_notes: nil,
+                geocode_error: nil,
+                location: { longitude: -1.9552618901330387, latitude: 50.742754933617285 },
+                name: "Breeze Motor Co Ltd",
+                override_lat: nil,
+                override_lng: nil,
+                phone: "01202 713000",
+                postcode: "BH12 4QY",
+                service_slug: "number-plate-supplier",
+                snac: nil,
+                source_address: "Yarrow Road Tower Park Poole  BH12 4QY",
+                text_phone: nil,
+                town: "Yarrow",
+                url: nil,
+              },
+            ),
+          },
           headers: {
             "Content-Type" => "application/json; charset=utf-8",
           },
         )
 
       api_client.places("number-plate-supplier", "-2.01", "53.1", "5")
+    end
+
+    it "responds with a choice of addresses for disambiguation of split postcodes" do
+      imminence_api
+        .given("a service exists called register office exists with places, and CH25 9BJ is a split postcode")
+        .upon_receiving("the request to retrieve relevant places for the current dataset for CH25 9BJ")
+        .with(
+          method: :get,
+          path: "/places/register-office.json",
+          headers: GdsApi::JsonClient.default_request_headers,
+          query: { postcode: "CH25 9BJ", limit: "5" },
+        )
+        .will_respond_with(
+          status: 200,
+          body: {
+            status: "address-information-required",
+            contents: "addresses",
+            addresses: Pact.each_like(
+              {
+                address: "HOUSE 1",
+                local_authority_slug: "achester",
+              },
+            ),
+          },
+          headers: {
+            "Content-Type" => "application/json; charset=utf-8",
+          },
+        )
+
+      api_client.places_for_postcode("register-office", "CH25 9BJ")
     end
   end
 end


### PR DESCRIPTION
To support split postcode disambiguation for places items in Frontend, Imminence's place endpoint has to be able to take a local authority slug in addition to a postcode.

https://trello.com/c/C4nLJyVO/1778-add-split-postcode-support-for-places-in-frontend