### PR TITLE
Update email_alert_api.rb to support new params

### DIFF
--- a/lib/gds_api/email_alert_api.rb
+++ b/lib/gds_api/email_alert_api.rb
@@ -11,8 +11,8 @@ class GdsApi::EmailAlertApi < GdsApi::Base
   # @param attributes [Hash] document_type, links, tags used to search existing subscriber lists
   def find_or_create_subscriber_list(attributes)
     present_fields = [attributes["content_id"], attributes["links"], attributes["tags"]].compact.count
-    if present_fields > 1
-      message = "please provide content_id, tags, or links (or none), but not more than one of them"
+    if (present_fields > 1) && (attributes["tags"])
+      message = "Invalid attributes provided. Valid attributes are content_id only, tags only, links only, content_id AND links, or none."
       raise ArgumentError, message
     end
 

--- a/test/email_alert_api_test.rb
+++ b/test/email_alert_api_test.rb
@@ -312,7 +312,7 @@ describe GdsApi::EmailAlertApi do
           {
             "title" => title,
             "content_id" => "fd427f55-7492-440d-ae3f-0fb6c3592b21",
-            "links" => links,
+            "tags" => tags,
           }
         end
 
@@ -321,6 +321,40 @@ describe GdsApi::EmailAlertApi do
             api_client.find_or_create_subscriber_list(params)
           end
         end
+      end
+    end
+
+    describe "when content_id and links are provided" do
+      let(:content_id) { "fd427f55-7492-440d-ae3f-0fb6c3592b21" }
+      let(:slug) { "my-new-list" }
+      let(:links) { { "document_collections" => %w[a_content_id] } }
+      let(:params) do
+        {
+          "title" => title,
+          "content_id" => content_id,
+          "links" => links,
+          "slug" => slug,
+        }
+      end
+
+      before do
+        stub_email_alert_api_creates_subscriber_list(
+          "title" => title,
+          "links" => links,
+          "content_id" => content_id,
+          "slug" => slug,
+        )
+      end
+
+      it "returns the subscriber list attributes" do
+        subscriber_list_attrs = api_client.find_or_create_subscriber_list(params)
+          .to_hash
+          .fetch("subscriber_list")
+
+        assert_equal(
+          "my-new-list",
+          subscriber_list_attrs.fetch("slug"),
+        )
       end
     end
   end


### PR DESCRIPTION
Email Alert API will soon support subscriber lists that have both a content id and links. 

Related work:

- https://github.com/alphagov/email-alert-api/pull/1841 
- https://github.com/alphagov/email-alert-frontend/pull/1438

https://trello.com/c/tJvdhfdd/1455-support-topic-like-subscriptions-for-document-collections-email-alert-api-m