### PR TITLE
Fix for CI builds failing on pact tests for Dependabot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,12 @@ jobs:
     with:
       pact_artifact: pacts
 
+  frontend_pact:
+    needs: generate_pacts
+    uses: alphagov/frontend/.github/workflows/pact-verify.yml@main
+    with:
+      pact_artifact: pacts
+
   imminence_pact:
     needs: generate_pacts
     uses: alphagov/imminence/.github/workflows/pact-verify.yml@main
@@ -108,6 +114,7 @@ jobs:
       - asset_manager_pact
       - collections_pact
       - email_alert_api_pact
+      - frontend_pact
       - imminence_pact
       - link_checker_api_pact
       - locations_api_pact

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,77 +34,75 @@ jobs:
     steps:
       - run: echo "All matrix tests have passed 🚀"
 
-  generate_and_publish_pacts:
+  generate_pacts:
     needs: test
     runs-on: ubuntu-latest
-    env:
-      PACT_TARGET_BRANCH: branch-${{ github.ref_name }}
-      PACT_BROKER_BASE_URL: https://pact-broker.cloudapps.digital
-      PACT_BROKER_USERNAME: ${{ secrets.GOVUK_PACT_BROKER_USERNAME }}
-      PACT_BROKER_PASSWORD: ${{ secrets.GOVUK_PACT_BROKER_PASSWORD }}
     steps:
       - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
       - run: bundle exec rake pact_test
-      - run: bundle exec rake pact:publish:branch
+      - uses: actions/upload-artifact@v3
+        with:
+          name: pacts
+          path: spec/pacts/*.json
 
   account_api_pact:
-    needs: generate_and_publish_pacts
+    needs: generate_pacts
     uses: alphagov/account-api/.github/workflows/pact-verify.yml@main
     with:
-      pact_consumer_version: branch-${{ github.ref_name }}
+      pact_artifact: pacts
 
   asset_manager_pact:
-    needs: generate_and_publish_pacts
+    needs: generate_pacts
     uses: alphagov/asset-manager/.github/workflows/pact-verify.yml@main
     with:
-      pact_consumer_version: branch-${{ github.ref_name }}
+      pact_artifact: pacts
 
   collections_pact:
-    needs: generate_and_publish_pacts
+    needs: generate_pacts
     uses: alphagov/collections/.github/workflows/pact-verify.yml@main
     with:
-      pact_consumer_version: branch-${{ github.ref_name }}
+      pact_artifact: pacts
 
   email_alert_api_pact:
-    needs: generate_and_publish_pacts
+    needs: generate_pacts
     uses: alphagov/email-alert-api/.github/workflows/pact-verify.yml@main
     with:
-      pact_consumer_version: branch-${{ github.ref_name }}
+      pact_artifact: pacts
 
   imminence_pact:
-    needs: generate_and_publish_pacts
+    needs: generate_pacts
     uses: alphagov/imminence/.github/workflows/pact-verify.yml@main
     with:
-      pact_consumer_version: branch-${{ github.ref_name }}
+      pact_artifact: pacts
 
   link_checker_api_pact:
-    needs: generate_and_publish_pacts
+    needs: generate_pacts
     uses: alphagov/link-checker-api/.github/workflows/pact-verify.yml@main
     with:
-      pact_consumer_version: branch-${{ github.ref_name }}
+      pact_artifact: pacts
 
   locations_api_pact:
-    needs: generate_and_publish_pacts
+    needs: generate_pacts
     uses: alphagov/locations-api/.github/workflows/pact-verify.yml@main
     with:
-      pact_consumer_version: branch-${{ github.ref_name }}
+      pact_artifact: pacts
 
   publishing_api_pact:
-    needs: generate_and_publish_pacts
+    needs: generate_pacts
     uses: alphagov/publishing-api/.github/workflows/pact-verify.yml@main
     with:
-      pact_consumer_version: branch-${{ github.ref_name }}
+      pact_artifact: pacts
 
   whitehall_pact:
-    needs: generate_and_publish_pacts
+    needs: generate_pacts
     uses: alphagov/whitehall/.github/workflows/pact-verify.yml@main
     with:
-      pact_consumer_version: branch-${{ github.ref_name }}
+      pact_artifact: pacts
 
-  publish_gem:
+  publish_pacts:
     needs:
       - account_api_pact
       - asset_manager_pact
@@ -115,6 +113,44 @@ jobs:
       - locations_api_pact
       - publishing_api_pact
       - whitehall_pact
+    if: ${{ github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - uses: actions/download-artifact@v3
+        with:
+          name: pacts
+          path: tmp/pacts
+      - run: bundle exec rake pact:publish
+        env:
+          PACT_CONSUMER_VERSION: branch-${{ github.ref_name }}
+          PACT_BROKER_BASE_URL: https://pact-broker.cloudapps.digital
+          PACT_BROKER_USERNAME: ${{ secrets.GOVUK_PACT_BROKER_USERNAME }}
+          PACT_BROKER_PASSWORD: ${{ secrets.GOVUK_PACT_BROKER_PASSWORD }}
+          PACT_PATTERN: tmp/pacts/*.json
+
+  # We don't use the artifact outside of sharing it for jobs so delete it
+  # at the end of the flow.
+  delete_pact_artifact:
+    needs:
+      - generate_pacts
+      - publish_pacts
+    # Run whenever generate_pacts is a success but wait until publish_pacts
+    # is either ran or skipped to ensure all work with the artifact is complete
+    if: ${{ always() && needs.generate_pacts.result == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      # As of Jan 2023, GitHub doesn't provide a delete artifact equivalent to
+      # their upload / download ones
+      - uses: geekyeggo/delete-artifact@v2
+        with:
+          name: pacts
+
+  publish_gem:
+    needs: publish_pacts
     if: ${{ github.ref == 'refs/heads/main' }}
     permissions:
       contents: write

--- a/Rakefile
+++ b/Rakefile
@@ -29,6 +29,7 @@ PactBroker::Client::PublicationTask.new do |task|
     username: ENV.fetch("PACT_BROKER_USERNAME"),
     password: ENV.fetch("PACT_BROKER_PASSWORD"),
   }
+  task.pattern = ENV["PACT_PATTERN"] if ENV["PACT_PATTERN"]
 end
 
 desc "Run the linter against changed files"

--- a/Rakefile
+++ b/Rakefile
@@ -22,16 +22,13 @@ task default: %i[lint test]
 
 require "pact_broker/client/tasks"
 
-def configure_pact_broker_location(task)
+PactBroker::Client::PublicationTask.new do |task|
+  task.consumer_version = ENV.fetch("PACT_CONSUMER_VERSION")
   task.pact_broker_base_url = ENV.fetch("PACT_BROKER_BASE_URL")
-  if ENV["PACT_BROKER_USERNAME"]
-    task.pact_broker_basic_auth = { username: ENV["PACT_BROKER_USERNAME"], password: ENV["PACT_BROKER_PASSWORD"] }
-  end
-end
-
-PactBroker::Client::PublicationTask.new("branch") do |task|
-  task.consumer_version = ENV.fetch("PACT_TARGET_BRANCH")
-  configure_pact_broker_location(task)
+  task.pact_broker_basic_auth = {
+    username: ENV.fetch("PACT_BROKER_USERNAME"),
+    password: ENV.fetch("PACT_BROKER_PASSWORD"),
+  }
 end
 
 desc "Run the linter against changed files"


### PR DESCRIPTION
I've opened this PR as a draft as it needs the following branches to be merged first:

- https://github.com/alphagov/account-api/pull/598
- https://github.com/alphagov/asset-manager/pull/1077
- https://github.com/alphagov/collections/pull/3167
- https://github.com/alphagov/email-alert-api/pull/1888
- https://github.com/alphagov/frontend/pull/3533
- https://github.com/alphagov/imminence/pull/869
- https://github.com/alphagov/link-checker-api/pull/634
- https://github.com/alphagov/locations-api/pull/200
- https://github.com/alphagov/publishing-api/pull/2281
- https://github.com/alphagov/whitehall/pull/7303

and then it needs to update the references to branches in .github/workflows/ci.yml.

This changes the approach for testing downstream apps against newly generated pact tests. We previously would upload the pact tests to the Pact Broker and then have the apps download these from the Pact broker to test against them. This changes that approach to instead use a GitHub Action Artifact [1] as a place to store these files for testing.

The motivation for this change is because the Pact Broker method requires permission to view GitHub Action secrets, without this the task fail. We feel this pain most noticeably on pull requests opened by Dependabot.

Applications that test against these pacts (consumers) will now operate in two ways depending on the circumstance. When changes are made to them or they are being locally tested they will pull the `branch-main` pacts from the pact-broker as per before. When they test against an iteration of GDS API Adapters they will access the pacts from an artifact.

I've also caught an instance where we weren't previously performing pact tests against Frontend, I missed it in https://github.com/alphagov/gds-api-adapters/pull/1175.

Further info in the commits

[1]: https://docs.github.com/en/actions/using-workflows/storing-workflow-data-as-artifacts