### PR TITLE
Release version 86.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 86.0.0
 
 * BREAKING: Changes to Imminence API to support split-postcodes. In practice, the only consumer app for this API is Frontend, which is prepared for the change.
 

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = "85.0.1".freeze
+  VERSION = "86.0.0".freeze
 end


### PR DESCRIPTION
Includes:

- https://github.com/alphagov/gds-api-adapters/pull/1183

(Notice breaking change will make imminence pact tests fail, they'll start working again when Imminence is merged, but we cannot do that without frontend support being deployed, which relies on this release)