### PR TITLE
Bump to version 87.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-## Unreleased
+# 87.0.0
 
-* Drop support for Ruby 2.7.
+* BREAKING: Drop support for Ruby 2.7.
 
 # 86.0.0
 

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = "86.0.0".freeze
+  VERSION = "87.0.0".freeze
 end


### PR DESCRIPTION
Following #1191, in which we dropped support for Ruby 2.7 due to it reaching EOL on 31st March 2023.

This repo is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.
