### PR TITLE
Local links manager test support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Add support in test helpers for minor change to Local Links Manager API responses.
+
 # 87.0.0
 
 * BREAKING: Drop support for Ruby 2.7.

--- a/lib/gds_api/test_helpers/local_links_manager.rb
+++ b/lib/gds_api/test_helpers/local_links_manager.rb
@@ -5,11 +5,11 @@ module GdsApi
     module LocalLinksManager
       LOCAL_LINKS_MANAGER_ENDPOINT = Plek.find("local-links-manager")
 
-      def stub_local_links_manager_has_a_link(authority_slug:, lgsl:, lgil:, url:, country_name: "England", status: "ok", snac: "00AG", local_custodian_code: nil)
+      def stub_local_links_manager_has_a_link(authority_slug:, lgsl:, lgil:, url:, country_name: "England", status: "ok", snac: "00AG", gss: "EE06000063", local_custodian_code: nil)
         response = {
           "local_authority" => {
             "name" => authority_slug.capitalize,
-            "snac" => snac,
+            "gss" => gss,
             "tier" => "unitary",
             "homepage_url" => "http://#{authority_slug}.example.com",
             "country_name" => country_name,
@@ -22,6 +22,7 @@ module GdsApi
             "status" => status,
           },
         }
+        response["local_authority"]["snac"] = snac if snac
 
         stub_request(:get, "#{LOCAL_LINKS_MANAGER_ENDPOINT}/api/link")
           .with(query: { authority_slug: authority_slug, lgsl: lgsl, lgil: lgil })
@@ -34,17 +35,18 @@ module GdsApi
         end
       end
 
-      def stub_local_links_manager_has_no_link(authority_slug:, lgsl:, lgil:, country_name: "England", snac: "00AG", local_custodian_code: nil)
+      def stub_local_links_manager_has_no_link(authority_slug:, lgsl:, lgil:, country_name: "England", snac: "00AG", gss: "EE06000063", local_custodian_code: nil)
         response = {
           "local_authority" => {
             "name" => authority_slug.capitalize,
-            "snac" => snac,
+            "gss" => gss,
             "tier" => "unitary",
             "homepage_url" => "http://#{authority_slug}.example.com",
             "country_name" => country_name,
             "slug" => authority_slug,
           },
         }
+        response["local_authority"]["snac"] = snac if snac
 
         stub_request(:get, "#{LOCAL_LINKS_MANAGER_ENDPOINT}/api/link")
           .with(query: { authority_slug: authority_slug, lgsl: lgsl, lgil: lgil })
@@ -57,17 +59,18 @@ module GdsApi
         end
       end
 
-      def stub_local_links_manager_has_no_link_and_no_homepage_url(authority_slug:, lgsl:, lgil:, country_name: "England", snac: "00AG", local_custodian_code: nil)
+      def stub_local_links_manager_has_no_link_and_no_homepage_url(authority_slug:, lgsl:, lgil:, country_name: "England", snac: "00AG", gss: "EE06000063", local_custodian_code: nil)
         response = {
           "local_authority" => {
             "name" => authority_slug.capitalize,
-            "snac" => snac,
+            "gss" => gss,
             "tier" => "unitary",
             "homepage_url" => nil,
             "country_name" => country_name,
             "slug" => authority_slug,
           },
         }
+        response["local_authority"]["snac"] = snac if snac
 
         stub_request(:get, "#{LOCAL_LINKS_MANAGER_ENDPOINT}/api/link")
           .with(query: { authority_slug: authority_slug, lgsl: lgsl, lgil: lgil })
@@ -98,7 +101,7 @@ module GdsApi
         parameters
       end
 
-      def stub_local_links_manager_has_a_local_authority(authority_slug, country_name: "England", snac: "00AG", local_custodian_code: nil)
+      def stub_local_links_manager_has_a_local_authority(authority_slug, country_name: "England", snac: "00AG", gss: "EE06000063", local_custodian_code: nil)
         response = {
           "local_authorities" => [
             {
@@ -107,10 +110,11 @@ module GdsApi
               "country_name" => country_name,
               "tier" => "unitary",
               "slug" => authority_slug,
-              "snac" => snac,
+              "gss" => gss,
             },
           ],
         }
+        response["local_authorities"][0]["snac"] = snac if snac
 
         stub_request(:get, "#{LOCAL_LINKS_MANAGER_ENDPOINT}/api/local-authority")
           .with(query: { authority_slug: authority_slug })
@@ -123,7 +127,7 @@ module GdsApi
         end
       end
 
-      def stub_local_links_manager_has_a_district_and_county_local_authority(district_slug, county_slug, district_snac: "00AG", county_snac: "00LC", local_custodian_code: nil)
+      def stub_local_links_manager_has_a_district_and_county_local_authority(district_slug, county_slug, district_snac: "00AG", county_snac: "00LC", district_gss: "EE06000063", county_gss: "EE06000064", local_custodian_code: nil)
         response = {
           "local_authorities" => [
             {
@@ -132,7 +136,7 @@ module GdsApi
               "country_name" => "England",
               "tier" => "district",
               "slug" => district_slug,
-              "snac" => district_snac,
+              "gss" => district_gss,
             },
             {
               "name" => county_slug.capitalize,
@@ -140,10 +144,12 @@ module GdsApi
               "country_name" => "England",
               "tier" => "county",
               "slug" => county_slug,
-              "snac" => county_snac,
+              "gss" => county_gss,
             },
           ],
         }
+        response["local_authorities"][0]["snac"] = district_snac if district_snac
+        response["local_authorities"][1]["snac"] = county_snac if county_snac
 
         stub_request(:get, "#{LOCAL_LINKS_MANAGER_ENDPOINT}/api/local-authority")
           .with(query: { authority_slug: district_slug })
@@ -180,7 +186,7 @@ module GdsApi
           .to_return(body: {}.to_json, status: 404)
       end
 
-      def stub_local_links_manager_has_a_local_authority_without_homepage(authority_slug, country_name: "England", snac: "00AG", local_custodian_code: nil)
+      def stub_local_links_manager_has_a_local_authority_without_homepage(authority_slug, country_name: "England", snac: "00AG", gss: "EE06000063", local_custodian_code: nil)
         response = {
           "local_authorities" => [
             {
@@ -189,10 +195,11 @@ module GdsApi
               "country_name" => country_name,
               "tier" => "unitary",
               "slug" => authority_slug,
-              "snac" => snac,
+              "gss" => gss,
             },
           ],
         }
+        response["local_authorities"][0]["snac"] = snac if snac
 
         stub_request(:get, "#{LOCAL_LINKS_MANAGER_ENDPOINT}/api/local-authority")
           .with(query: { authority_slug: authority_slug })

--- a/test/local_links_manager_api_test.rb
+++ b/test/local_links_manager_api_test.rb
@@ -26,6 +26,7 @@ describe GdsApi::LocalLinksManager do
           "local_authority" => {
             "name" => "Blackburn",
             "snac" => "00AG",
+            "gss" => "EE06000063",
             "tier" => "unitary",
             "homepage_url" => "http://blackburn.example.com",
             "country_name" => "England",
@@ -56,6 +57,7 @@ describe GdsApi::LocalLinksManager do
           "local_authority" => {
             "name" => "Westminster",
             "snac" => "00BK",
+            "gss" => "EE06000063",
             "tier" => "unitary",
             "homepage_url" => "http://westminster.example.com",
             "country_name" => "England",
@@ -79,6 +81,7 @@ describe GdsApi::LocalLinksManager do
           "local_authority" => {
             "name" => "Blackburn",
             "snac" => "00AG",
+            "gss" => "EE06000063",
             "tier" => "unitary",
             "homepage_url" => nil,
             "country_name" => "England",
@@ -161,6 +164,7 @@ describe GdsApi::LocalLinksManager do
           "local_authority" => {
             "name" => "Blackburn",
             "snac" => "00AG",
+            "gss" => "EE06000063",
             "tier" => "unitary",
             "homepage_url" => "http://blackburn.example.com",
             "country_name" => "England",
@@ -191,6 +195,7 @@ describe GdsApi::LocalLinksManager do
           "local_authority" => {
             "name" => "Blackburn",
             "snac" => "00AG",
+            "gss" => "EE06000063",
             "tier" => "unitary",
             "homepage_url" => "http://blackburn.example.com",
             "country_name" => "England",
@@ -215,6 +220,7 @@ describe GdsApi::LocalLinksManager do
           "local_authority" => {
             "name" => "Blackburn",
             "snac" => "00AG",
+            "gss" => "EE06000063",
             "tier" => "unitary",
             "homepage_url" => nil,
             "country_name" => "England",
@@ -283,7 +289,7 @@ describe GdsApi::LocalLinksManager do
   describe "#local_authority" do
     describe "when making a request for a local authority with a parent" do
       it "should return the local authority and its parent" do
-        stub_local_links_manager_has_a_district_and_county_local_authority("blackburn", "rochester", district_snac: "test1", county_snac: "test2")
+        stub_local_links_manager_has_a_district_and_county_local_authority("blackburn", "rochester", district_snac: "test1", county_snac: "test2", district_gss: "test1gss", county_gss: "test2gss")
 
         expected_response = {
           "local_authorities" => [
@@ -293,6 +299,7 @@ describe GdsApi::LocalLinksManager do
               "country_name" => "England",
               "tier" => "district",
               "slug" => "blackburn",
+              "gss" => "test1gss",
               "snac" => "test1",
             },
             {
@@ -301,6 +308,7 @@ describe GdsApi::LocalLinksManager do
               "country_name" => "England",
               "tier" => "county",
               "slug" => "rochester",
+              "gss" => "test2gss",
               "snac" => "test2",
             },
           ],
@@ -324,6 +332,7 @@ describe GdsApi::LocalLinksManager do
               "tier" => "unitary",
               "slug" => "blackburn",
               "snac" => "00AG",
+              "gss" => "EE06000063",
             },
           ],
         }
@@ -365,6 +374,7 @@ describe GdsApi::LocalLinksManager do
               "country_name" => "England",
               "tier" => "district",
               "slug" => "blackburn",
+              "gss" => "EE06000063",
               "snac" => "00AG",
             },
             {
@@ -373,6 +383,7 @@ describe GdsApi::LocalLinksManager do
               "country_name" => "England",
               "tier" => "county",
               "slug" => "rochester",
+              "gss" => "EE06000064",
               "snac" => "00LC",
             },
           ],
@@ -396,6 +407,7 @@ describe GdsApi::LocalLinksManager do
               "tier" => "unitary",
               "slug" => "blackburn",
               "snac" => "00AG",
+              "gss" => "EE06000063",
             },
           ],
         }

--- a/test/local_links_manager_api_test.rb
+++ b/test/local_links_manager_api_test.rb
@@ -69,6 +69,30 @@ describe GdsApi::LocalLinksManager do
         assert_equal expected_response, response.to_hash
       end
 
+      it "returns the local authority details only without snac if no link present and no SNAC" do
+        stub_local_links_manager_has_no_link(
+          authority_slug: "westminster",
+          lgsl: 461,
+          lgil: 8,
+          country_name: "England",
+          snac: nil,
+        )
+
+        expected_response = {
+          "local_authority" => {
+            "name" => "Westminster",
+            "gss" => "EE06000063",
+            "tier" => "unitary",
+            "homepage_url" => "http://westminster.example.com",
+            "country_name" => "England",
+            "slug" => "westminster",
+          },
+        }
+
+        response = @api.local_link("westminster", 461, 8)
+        assert_equal expected_response, response.to_hash
+      end
+
       it "returns the local authority without a homepage url if no homepage link present" do
         stub_local_links_manager_has_no_link_and_no_homepage_url(
           authority_slug: "blackburn",


### PR DESCRIPTION
An update to local links manager will allow returning the GSS code for a local authority in the API response, and not returning a SNAC code if it isn't present. This doesn't affect any code directly in gds-api-adapters, but ideally would be implemented in the test helpers to allow dependent apps to test the new behaviour.

Trello: https://trello.com/c/i66BCwUl/1978-imminence-cant-perform-local-authority-searches-for-new-local-authorities

Related PR in LLM: https://github.com/alphagov/local-links-manager/pull/1080

This repo is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.
