### PR TITLE
Release version 87.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 87.1.0
 
 * Add support in test helpers for minor change to Local Links Manager API responses.
 

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = "87.0.0".freeze
+  VERSION = "87.1.0".freeze
 end


### PR DESCRIPTION
Includes:
- https://github.com/alphagov/gds-api-adapters/pull/1194

This repo is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.
