### PR TITLE
v88.0: remove no-op "commit" option from Router.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 88.0.0
+
+* BREAKING: `Router::add_route`, `add_gone_route` and `delete_route` methods no longer take an `options` parameter. The change is purely syntactic, as the only recognised option (`commit`) has been a no-op since April 2021. The `stub_*` methods in `TestHelpers::Router` now return the request stub directly instead of returning a pair of stubs (the second of which was never used).
+
 # 87.1.0
 
 * Add support in test helpers for minor change to Local Links Manager API responses.

--- a/lib/gds_api/router.rb
+++ b/lib/gds_api/router.rb
@@ -21,14 +21,20 @@ class GdsApi::Router < GdsApi::Base
     get_json("#{endpoint}/routes?incoming_path=#{CGI.escape(path)}")
   end
 
-  def add_route(path, type, backend_id, options = {})
-    response = put_json("#{endpoint}/routes", route: { incoming_path: path, route_type: type, handler: "backend", backend_id: backend_id })
-    commit_routes if options[:commit]
-    response
+  def add_route(path, type, backend_id)
+    put_json(
+      "#{endpoint}/routes",
+      route: {
+        incoming_path: path,
+        route_type: type,
+        handler: "backend",
+        backend_id: backend_id,
+      },
+    )
   end
 
   def add_redirect_route(path, type, destination, redirect_type = "permanent", options = {})
-    response = put_json(
+    put_json(
       "#{endpoint}/routes",
       route: {
         incoming_path: path,
@@ -39,27 +45,19 @@ class GdsApi::Router < GdsApi::Base
         segments_mode: options[:segments_mode],
       },
     )
-
-    commit_routes if options[:commit]
-    response
   end
 
-  def add_gone_route(path, type, options = {})
-    response = put_json("#{endpoint}/routes", route: { incoming_path: path, route_type: type, handler: "gone" })
-    commit_routes if options[:commit]
-    response
+  def add_gone_route(path, type)
+    put_json(
+      "#{endpoint}/routes",
+      route: { incoming_path: path, route_type: type, handler: "gone" },
+    )
   end
 
-  def delete_route(path, hard_delete: false, commit: false)
+  def delete_route(path, hard_delete: false)
     url = "#{endpoint}/routes?incoming_path=#{CGI.escape(path)}"
     url += "&hard_delete=true" if hard_delete
 
-    response = delete_json(url)
-    commit_routes if commit
-    response
-  end
-
-  def commit_routes
-    post_json("#{endpoint}/routes/commit", {})
+    delete_json(url)
   end
 end

--- a/lib/gds_api/test_helpers/router.rb
+++ b/lib/gds_api/test_helpers/router.rb
@@ -32,7 +32,6 @@ module GdsApi
       def stub_all_router_registration
         stub_request(:put, %r{\A#{ROUTER_API_ENDPOINT}/backends/[a-z0-9-]+\z})
         stub_request(:put, "#{ROUTER_API_ENDPOINT}/routes")
-        stub_request(:post, "#{ROUTER_API_ENDPOINT}/routes/commit")
       end
 
       def stub_router_backend_registration(backend_id, backend_url)
@@ -43,22 +42,18 @@ module GdsApi
       end
 
       def stub_route_registration(path, type, backend_id)
-        route = {
+        stub_route_put({
           route: {
             incoming_path: path,
             route_type: type,
             handler: "backend",
             backend_id: backend_id,
           },
-        }
-
-        register_stub = stub_route_put(route)
-        commit_stub = stub_router_commit
-        [register_stub, commit_stub]
+        })
       end
 
       def stub_redirect_registration(path, type, destination, redirect_type, segments_mode = nil)
-        redirect = {
+        stub_route_put({
           route: {
             incoming_path: path,
             route_type: type,
@@ -67,29 +62,17 @@ module GdsApi
             redirect_type: redirect_type,
             segments_mode: segments_mode,
           },
-        }
-
-        register_stub = stub_route_put(redirect)
-        commit_stub = stub_router_commit
-        [register_stub, commit_stub]
+        })
       end
 
       def stub_gone_route_registration(path, type)
-        route = {
+        stub_route_put({
           route: {
             incoming_path: path,
             route_type: type,
             handler: "gone",
           },
-        }
-
-        register_stub = stub_route_put(route)
-        commit_stub = stub_router_commit
-        [register_stub, commit_stub]
-      end
-
-      def stub_router_commit
-        stub_http_request(:post, "#{ROUTER_API_ENDPOINT}/routes/commit")
+        })
       end
 
     private

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = "87.1.0".freeze
+  VERSION = "88.0.0".freeze
 end

--- a/test/router_test.rb
+++ b/test/router_test.rb
@@ -153,11 +153,6 @@ describe GdsApi::Router do
   end
 
   describe "managing routes" do
-    before :each do
-      @commit_req = WebMock.stub_request(:post, "#{@base_api_url}/routes/commit")
-        .to_return(status: 200, body: "Routers updated")
-    end
-
     describe "fetching a route" do
       it "should return the backend route details" do
         req = stub_router_has_backend_route("/foo", backend_id: "foo")
@@ -167,7 +162,6 @@ describe GdsApi::Router do
         assert_equal "foo", response["backend_id"]
 
         assert_requested(req)
-        assert_not_requested(@commit_req)
       end
 
       it "should raise if nothing found" do
@@ -178,7 +172,6 @@ describe GdsApi::Router do
         end
 
         assert_requested(req)
-        assert_not_requested(@commit_req)
       end
 
       it "should return the gone route details" do
@@ -210,7 +203,6 @@ describe GdsApi::Router do
         end
 
         assert_requested(req)
-        assert_not_requested(@commit_req)
       end
     end
 
@@ -226,17 +218,6 @@ describe GdsApi::Router do
         assert_equal "foo", response["backend_id"]
 
         assert_requested(req)
-        assert_not_requested(@commit_req)
-      end
-
-      it "should commit the routes when asked to" do
-        req = WebMock.stub_request(:put, "#{@base_api_url}/routes")
-          .to_return(status: 201, body: {}.to_json, headers: { "Content-type" => "application/json" })
-
-        @api.add_route("/foo", "exact", "foo", commit: true)
-
-        assert_requested(req)
-        assert_requested(@commit_req)
       end
 
       it "should raise an error if creating/updating the route fails" do
@@ -255,7 +236,6 @@ describe GdsApi::Router do
         assert_equal response_data, e.error_details
 
         assert_requested(req)
-        assert_not_requested(@commit_req)
       end
     end
 
@@ -276,7 +256,6 @@ describe GdsApi::Router do
         assert_equal "/bar", response["redirect_to"]
 
         assert_requested(req)
-        assert_not_requested(@commit_req)
       end
 
       it "should allow creating/updating a temporary redirect route" do
@@ -295,7 +274,6 @@ describe GdsApi::Router do
         assert_equal "/bar", response["redirect_to"]
 
         assert_requested(req)
-        assert_not_requested(@commit_req)
       end
 
       it "should allow creating/updating a redirect route which preserves segments" do
@@ -314,17 +292,6 @@ describe GdsApi::Router do
         assert_equal "/bar", response["redirect_to"]
 
         assert_requested(req)
-        assert_not_requested(@commit_req)
-      end
-
-      it "should commit the routes when asked to" do
-        req = WebMock.stub_request(:put, "#{@base_api_url}/routes")
-          .to_return(status: 201, body: {}.to_json, headers: { "Content-type" => "application/json" })
-
-        @api.add_redirect_route("/foo", "exact", "/bar", "temporary", commit: true)
-
-        assert_requested(req)
-        assert_requested(@commit_req)
       end
 
       it "should raise an error if creating/updating the redirect route fails" do
@@ -348,7 +315,6 @@ describe GdsApi::Router do
         assert_equal response_data, e.error_details
 
         assert_requested(req)
-        assert_not_requested(@commit_req)
       end
     end
 
@@ -364,17 +330,6 @@ describe GdsApi::Router do
         assert_equal "/foo", response["incoming_path"]
 
         assert_requested(req)
-        assert_not_requested(@commit_req)
-      end
-
-      it "should commit the routes when asked to" do
-        req = WebMock.stub_request(:put, "#{@base_api_url}/routes")
-          .to_return(status: 201, body: {}.to_json, headers: { "Content-type" => "application/json" })
-
-        @api.add_gone_route("/foo", "exact", commit: true)
-
-        assert_requested(req)
-        assert_requested(@commit_req)
       end
 
       it "should raise an error if creating/updating the gone route fails" do
@@ -393,7 +348,6 @@ describe GdsApi::Router do
         assert_equal response_data, e.error_details
 
         assert_requested(req)
-        assert_not_requested(@commit_req)
       end
     end
 
@@ -409,18 +363,6 @@ describe GdsApi::Router do
         assert_equal "foo", response["backend_id"]
 
         assert_requested(req)
-        assert_not_requested(@commit_req)
-      end
-
-      it "should commit the routes when asked to" do
-        req = WebMock.stub_request(:delete, "#{@base_api_url}/routes")
-          .with(query: { "incoming_path" => "/foo" })
-          .to_return(status: 200, body: {}.to_json, headers: { "Content-type" => "application/json" })
-
-        @api.delete_route("/foo", commit: true)
-
-        assert_requested(req)
-        assert_requested(@commit_req)
       end
 
       it "should raise HTTPNotFound if nothing found" do
@@ -435,7 +377,6 @@ describe GdsApi::Router do
         assert_equal 404, e.code
 
         assert_requested(req)
-        assert_not_requested(@commit_req)
       end
 
       it "should escape the params" do
@@ -450,26 +391,6 @@ describe GdsApi::Router do
         end
 
         assert_requested(req)
-      end
-    end
-
-    describe "committing the routes" do
-      it "should allow committing the routes" do
-        @api.commit_routes
-
-        assert_requested(@commit_req)
-      end
-
-      it "should raise an error if committing the routes fails" do
-        WebMock.stub_request(:post, "#{@base_api_url}/routes/commit")
-          .to_return(status: 500, body: "Failed to update all routers")
-
-        e = assert_raises(GdsApi::HTTPErrorResponse) do
-          @api.commit_routes
-        end
-
-        assert_equal 500, e.code
-        assert_equal "URL: #{@base_api_url}/routes/commit\nResponse body:\nFailed to update all routers", e.message
       end
     end
   end


### PR DESCRIPTION
This option has had no effect for >2 years. See https://github.com/alphagov/router-api/pull/550

Strictly speaking this is a breaking change, but all of the affected call sites are in content_store so I'll just [fix them](https://github.com/alphagov/content-store/pull/1076) and then it'll be all done.