### PR TITLE
Add an adapter for email-alert-api's bulk migrate endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Add support for email-alert-api's bulk migrate endpoint
+
 # 88.0.0
 
 * BREAKING: `Router::add_route`, `add_gone_route` and `delete_route` methods no longer take an `options` parameter. The change is purely syntactic, as the only recognised option (`commit`) has been a no-op since April 2021. The `stub_*` methods in `TestHelpers::Router` now return the request stub directly instead of returning a pair of stubs (the second of which was never used).

--- a/lib/gds_api/email_alert_api.rb
+++ b/lib/gds_api/email_alert_api.rb
@@ -260,6 +260,19 @@ class GdsApi::EmailAlertApi < GdsApi::Base
     )
   end
 
+  # Migrate all users from one existing subscriber list to another existing subscriber list
+  #
+  # @param [string]               to_slug        Identifier for the successor subscription list
+  # @param [string]               from_slug      Identifier for the source subscription list
+
+  def bulk_migrate(from_slug:, to_slug:)
+    post_json(
+      "#{endpoint}/subscriber-lists/bulk-migrate",
+      from_slug: from_slug,
+      to_slug: to_slug,
+    )
+  end
+
   # Update subscriber list details, such as title
   # @param [Hash]         params        A hash of detail paramaters that can be updated. For example title.
   #                                     For allowed parameters see:

--- a/lib/gds_api/test_helpers/email_alert_api.rb
+++ b/lib/gds_api/test_helpers/email_alert_api.rb
@@ -456,6 +456,24 @@ module GdsApi
         .to_return(status: 422)
       end
 
+      def stub_email_alert_api_bulk_migrate(from_slug:, to_slug:)
+        stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscriber-lists/bulk-migrate")
+        .with(body: { from_slug: from_slug, to_slug: to_slug }.to_json)
+        .to_return(status: 202)
+      end
+
+      def stub_email_alert_api_bulk_migrate_bad_request(from_slug:, to_slug:)
+        stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscriber-lists/bulk-migrate")
+          .with(body: { from_slug: from_slug, to_slug: to_slug }.to_json)
+          .to_return(status: 422)
+      end
+
+      def stub_email_alert_api_bulk_migrate_not_found(from_slug:, to_slug:)
+        stub_request(:post, "#{EMAIL_ALERT_API_ENDPOINT}/subscriber-lists/bulk-migrate")
+          .with(body: { from_slug: from_slug, to_slug: to_slug }.to_json)
+          .to_return(status: 404)
+      end
+
       def stub_update_subscriber_list_details(slug:, params:)
         stub_request(:patch, "#{EMAIL_ALERT_API_ENDPOINT}/subscriber-lists/#{slug}")
         .with(body: params.to_json)

--- a/test/email_alert_api_test.rb
+++ b/test/email_alert_api_test.rb
@@ -933,6 +933,52 @@ describe GdsApi::EmailAlertApi do
     end
   end
 
+  describe "bulk_migrate" do
+    let(:from_slug) { "i_am_a_subscriber_list_slug" }
+    let(:to_slug) { "i_am_another_subscriber_list_slug" }
+
+    it "returns 202 if valid to_slug and from_slug are provided" do
+      stub_email_alert_api_bulk_migrate(
+        from_slug: from_slug,
+        to_slug: to_slug,
+      )
+      api_response = api_client.bulk_migrate(from_slug: from_slug, to_slug: to_slug)
+
+      assert_equal(202, api_response.code)
+    end
+
+    it "returns 404 if the subscription list is not found" do
+      stub_email_alert_api_bulk_migrate_not_found(
+        from_slug: from_slug,
+        to_slug: to_slug,
+      )
+
+      assert_raises GdsApi::HTTPNotFound do
+        api_client.bulk_migrate(from_slug: from_slug, to_slug: to_slug)
+      end
+    end
+
+    it "returns 422 if either from_slug or to_slug are missing" do
+      stub_email_alert_api_bulk_migrate_bad_request(
+        from_slug: from_slug,
+        to_slug: "",
+      )
+
+      assert_raises GdsApi::HTTPUnprocessableEntity do
+        api_client.bulk_migrate(from_slug: from_slug, to_slug: "")
+      end
+
+      stub_email_alert_api_bulk_migrate_bad_request(
+        from_slug: "",
+        to_slug: to_slug,
+      )
+
+      assert_raises GdsApi::HTTPUnprocessableEntity do
+        api_client.bulk_migrate(from_slug: "", to_slug: to_slug)
+      end
+    end
+  end
+
   describe "update_subscriber_list_details" do
     let(:slug) { "i_am_a_subscriber_list_slug" }
 

--- a/test/pacts/email_alert_api_pact_test.rb
+++ b/test/pacts/email_alert_api_pact_test.rb
@@ -309,6 +309,123 @@ describe "GdsApi::EmailAlertApi pact tests" do
     end
   end
 
+  describe "#bulk-migrate" do
+    it "responds with a 202" do
+      email_alert_api
+        .given("subscriber lists exist with 'source_list_slug' and 'destination_list_slug'")
+        .upon_receiving("the request to bulk migrate users from source list to destination list")
+        .with(
+          method: :post,
+          path: "/subscriber-lists/bulk-migrate",
+          body: {
+            from_slug: "source_list_slug",
+            to_slug: "destination_list_slug",
+          },
+          headers: GdsApi::JsonClient.default_request_with_json_body_headers,
+        )
+        .will_respond_with(
+          status: 202,
+        )
+
+      api_client.bulk_migrate(from_slug: "source_list_slug", to_slug: "destination_list_slug")
+    end
+
+    it "responds with a 404" do
+      email_alert_api
+        .given("a subscriber list exists for 'source_slug'")
+        .upon_receiving("the request to bulk migrate users to a subscriber list with slug:'destination_list_slug' which does not exist")
+        .with(
+          method: :post,
+          path: "/subscriber-lists/bulk-migrate",
+          body: {
+            from_slug: "source_list_slug",
+            to_slug: "destination_list_slug",
+          },
+          headers: GdsApi::JsonClient.default_request_with_json_body_headers,
+        )
+        .will_respond_with(
+          status: 404,
+        )
+
+      begin
+        api_client.bulk_migrate(from_slug: "source_list_slug", to_slug: "destination_list_slug")
+      rescue GdsApi::HTTPNotFound
+        # This is expected
+      end
+    end
+
+    it "responds with a 404" do
+      email_alert_api
+        .given("a subscriber list exists for 'destination_slug'")
+        .upon_receiving("the request to bulk migrate users from a subscriber list with slug:'source_list_slug' which does not exist")
+        .with(
+          method: :post,
+          path: "/subscriber-lists/bulk-migrate",
+          body: {
+            from_slug: "source_list_slug",
+            to_slug: "destination_list_slug",
+          },
+          headers: GdsApi::JsonClient.default_request_with_json_body_headers,
+        )
+        .will_respond_with(
+          status: 404,
+        )
+
+      begin
+        api_client.bulk_migrate(from_slug: "source_list_slug", to_slug: "destination_list_slug")
+      rescue GdsApi::HTTPNotFound
+        # this is expected
+      end
+    end
+
+    it "responds with a 422" do
+      email_alert_api
+        .given("subscriber lists exist with 'source_list_slug' and 'destination_list_slug'")
+        .upon_receiving("the request to bulk migrate without from_slug")
+        .with(
+          method: :post,
+          path: "/subscriber-lists/bulk-migrate",
+          body: {
+            from_slug: "",
+            to_slug: "destination_list_slug",
+          },
+          headers: GdsApi::JsonClient.default_request_with_json_body_headers,
+        )
+        .will_respond_with(
+          status: 422,
+        )
+      begin
+        api_client.bulk_migrate(from_slug: "", to_slug: "destination_list_slug")
+      rescue GdsApi::HTTPUnprocessableEntity
+        # this is expected
+      end
+    end
+
+    it "responds with a 422" do
+      email_alert_api
+        .given("subscriber lists exist with 'source_list_slug' and 'destination_list_slug'")
+        .upon_receiving("the request to bulk migrate without to_slug")
+        .with(
+          method: :post,
+          path: "/subscriber-lists/bulk-migrate",
+          body: {
+            from_slug: "source_list_slug",
+            to_slug: "",
+          },
+          headers: GdsApi::JsonClient.default_request_with_json_body_headers,
+        )
+        .will_respond_with(
+          status: 422,
+        )
+
+      begin
+        api_client.bulk_migrate(from_slug: "source_list_slug", to_slug: "")
+      rescue GdsApi::HTTPUnprocessableEntity
+        # this is expected
+      end
+    end
+  end
+
   describe "#unsubscribe" do
     it "responds with a 404" do
       email_alert_api


### PR DESCRIPTION
Equivalent PR in email-alert-api: https://github.com/alphagov/email-alert-api/pull/1919

This repo is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

https://trello.com/c/REpV5NW7/1714-add-bulk-migrate-endpoint-to-gds-api-adaptors-m