### PR TITLE
Release version 88.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 88.1.0
 
 * Add support for email-alert-api's bulk migrate endpoint
 

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = "88.0.0".freeze
+  VERSION = "88.1.0".freeze
 end


### PR DESCRIPTION
Adds support for email alert api's bulk migrate endpoint

[Trello](https://trello.com/c/REpV5NW7/1714-add-bulk-migrate-endpoint-to-gds-api-adaptors-m)

This repo is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.
