### PR TITLE
Add `whitehall_media` method to Asset Manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Add `whitehall_media` method to Asset Manager.
+
 # 88.1.0
 
 * Add support for email-alert-api's bulk migrate endpoint

--- a/lib/gds_api/asset_manager.rb
+++ b/lib/gds_api/asset_manager.rb
@@ -128,7 +128,7 @@ class GdsApi::AssetManager < GdsApi::Base
     post_multipart("#{base_url}/whitehall_assets", asset: asset)
   end
 
-  # Fetches a Whitehall asset given the legacy URL path
+  # Fetches a Whitehall asset's metadata given the legacy URL path
   #
   # @param legacy_url_path [String] The Whitehall asset identifier.
   # @return [GdsApi::Response] A response object containing the parsed JSON
@@ -171,7 +171,7 @@ class GdsApi::AssetManager < GdsApi::Base
     put_multipart("#{base_url}/assets/#{id}", asset: asset)
   end
 
-  # Fetches an asset given the id
+  # Fetches an asset's metadata given the id
   #
   # @param id [String] The asset identifier (a UUID).
   # @return [GdsApi::Response, nil] A response object containing the parsed JSON response. If

--- a/lib/gds_api/asset_manager.rb
+++ b/lib/gds_api/asset_manager.rb
@@ -228,6 +228,17 @@ class GdsApi::AssetManager < GdsApi::Base
     post_json("#{base_url}/assets/#{id}/restore")
   end
 
+  # Fetches a Whitehall asset given the legacy URL path
+  #
+  # @param legacy_url_path [String] The Whitehall asset identifier.
+  # @return [GdsApi::Response] A response object containing the raw asset.
+  #   If the asset cannot be found, +GdsApi::HTTPNotFound+ will be raised.
+  #
+  # @raise [HTTPErrorResponse] if the request returns an error
+  def whitehall_media(legacy_url_path)
+    get_raw("#{base_url}/#{uri_encode(legacy_url_path)}")
+  end
+
 private
 
   def base_url

--- a/lib/gds_api/test_helpers/asset_manager.rb
+++ b/lib/gds_api/test_helpers/asset_manager.rb
@@ -33,6 +33,9 @@ module GdsApi
 
         stub_request(:get, "#{ASSET_MANAGER_ENDPOINT}/whitehall_assets/#{legacy_url_path}")
           .to_return(body: response.to_json, status: 200)
+
+        stub_request(:get, "#{ASSET_MANAGER_ENDPOINT}/#{legacy_url_path}")
+          .to_return(body: "Some file content", status: 200)
       end
 
       def stub_asset_manager_does_not_have_an_asset(id)

--- a/test/asset_manager_test.rb
+++ b/test/asset_manager_test.rb
@@ -22,7 +22,7 @@ describe GdsApi::AssetManager do
     }
   end
 
-  it "creates an asset with a file" do
+  it "creates the asset with a file" do
     req = stub_request(:post, "#{base_api_url}/assets")
       .with { |request|
         request.body =~ %r{Content-Disposition: form-data; name="asset\[file\]"; filename="hello\.txt"\r\nContent-Type: text/plain}
@@ -46,7 +46,7 @@ describe GdsApi::AssetManager do
     assert_requested(req)
   end
 
-  it "returns not found when an asset does not exist" do
+  it "returns not found when the asset does not exist" do
     stub_asset_manager_does_not_have_an_asset("not-really-here")
 
     assert_raises GdsApi::HTTPNotFound do
@@ -66,7 +66,7 @@ describe GdsApi::AssetManager do
     end
   end
 
-  describe "an asset exists" do
+  describe "the asset exists" do
     before do
       stub_asset_manager_has_an_asset(
         asset_id,
@@ -78,7 +78,7 @@ describe GdsApi::AssetManager do
 
     let(:asset_id) { "test-id" }
 
-    it "updates an asset with a file" do
+    it "updates the asset with a file" do
       req = stub_request(:put, "#{base_api_url}/assets/test-id")
         .to_return(body: JSON.dump(stub_asset_manager_response), status: 200)
 
@@ -88,7 +88,7 @@ describe GdsApi::AssetManager do
       assert_requested(req)
     end
 
-    it "retrieves an asset" do
+    it "retrieves the asset's metadata" do
       asset = api.asset(asset_id)
 
       assert_equal "photo.jpg", asset["name"]
@@ -105,7 +105,7 @@ describe GdsApi::AssetManager do
       )
     end
 
-    it "retrieves an asset" do
+    it "retrieves the asset's metadata" do
       asset = api.whitehall_asset("/government/uploads/photo.jpg")
 
       assert_equal "asset-id", asset["id"]
@@ -120,14 +120,14 @@ describe GdsApi::AssetManager do
       )
     end
 
-    it "retrieves an asset" do
+    it "retrieves the asset's metadata" do
       asset = api.whitehall_asset("/government/uploads/photø.jpg")
 
       assert_equal "asset-id", asset["id"]
     end
   end
 
-  it "deletes an asset for the given id" do
+  it "deletes the asset for the given id" do
     req = stub_request(:delete, "#{base_api_url}/assets/#{asset_id}")
       .to_return(body: JSON.dump(stub_asset_manager_response), status: 200)
 
@@ -137,7 +137,7 @@ describe GdsApi::AssetManager do
     assert_requested(req)
   end
 
-  it "restores an asset for the given id" do
+  it "restores the asset for the given id" do
     req = stub_request(:post, "#{base_api_url}/assets/#{asset_id}/restore")
       .to_return(body: JSON.dump(stub_asset_manager_response), status: 200)
 

--- a/test/asset_manager_test.rb
+++ b/test/asset_manager_test.rb
@@ -110,6 +110,12 @@ describe GdsApi::AssetManager do
 
       assert_equal "asset-id", asset["id"]
     end
+
+    it "retrieves the asset" do
+      asset = api.whitehall_media("/government/uploads/photo.jpg")
+
+      assert_equal "Some file content", asset.body
+    end
   end
 
   describe "a Whitehall asset with a legacy_url_path containing non-ascii characters exists" do

--- a/test/pacts/asset_manager_pact_test.rb
+++ b/test/pacts/asset_manager_pact_test.rb
@@ -15,6 +15,9 @@ describe "GdsApi::AssetManager pact tests" do
   let(:json_content_type) do
     { "Content-Type" => "application/json; charset=utf-8" }
   end
+  let(:text_content_type) do
+    { "Content-Type" => "text/plain; charset=utf-8" }
+  end
   let(:asset_details) { "\r\nContent-Disposition: form-data; name=\"asset[file]\"; filename=\"hello.txt\"\r\nContent-Type: text/plain\r\n\r\nHello, world!\n\r\n" }
   let(:asset_details_regex) { /\s+Content-Disposition: form-data; name="asset\[file\]"; filename="hello.txt"\s+Content-Type: text\/plain\s+Hello, world!\s+/ }
 
@@ -203,6 +206,22 @@ describe "GdsApi::AssetManager pact tests" do
           )
 
         api_client.whitehall_asset(legacy_url_path)
+      end
+    end
+
+    describe "#get whitehall asset" do
+      it "gets a whitehall asset" do
+        asset_manager
+          .given("a whitehall asset exists with legacy url path #{legacy_url_path} and id #{content_id}")
+          .upon_receiving("a get whitehall asset request")
+          .with(
+            method: :get,
+            path: legacy_url_path,
+          ).will_respond_with(
+            status: 200,
+          )
+
+        api_client.whitehall_media(legacy_url_path)
       end
     end
 

--- a/test/pacts/asset_manager_pact_test.rb
+++ b/test/pacts/asset_manager_pact_test.rb
@@ -188,11 +188,11 @@ describe "GdsApi::AssetManager pact tests" do
       end
     end
 
-    describe "#get whitehall asset" do
-      it "gets a whitehall asset" do
+    describe "#get whitehall asset metadata" do
+      it "gets a whitehall asset's metadata" do
         asset_manager
           .given("a whitehall asset exists with legacy url path #{legacy_url_path} and id #{content_id}")
-          .upon_receiving("a get whitehall asset request")
+          .upon_receiving("a get whitehall asset metadata request")
           .with(
             method: :get,
             path: "/whitehall_assets/#{legacy_url_path}",


### PR DESCRIPTION
Asset Manager has a `whitehall_media` route, which returns the actual asset for a given Whitehall Legacy URL Path.

Adding this method to gds-api-adapters so it can be used in the Frontend application.

[Trello card](https://trello.com/c/QAgy09Z4)