### PR TITLE
Add govuk_request_id to logs when available

### DIFF
--- a/lib/gds_api/json_client.rb
+++ b/lib/gds_api/json_client.rb
@@ -157,7 +157,7 @@ module GdsApi
     end
 
     def do_request(method, url, params = nil, additional_headers = {})
-      loggable = { request_uri: url, start_time: Time.now.to_f }
+      loggable = { request_uri: url, start_time: Time.now.to_f, govuk_request_id: GdsApi::GovukHeaders.headers[:govuk_request_id] }.compact
       start_logging = loggable.merge(action: "start")
       logger.debug start_logging.to_json
 

--- a/test/json_client_test.rb
+++ b/test/json_client_test.rb
@@ -613,6 +613,22 @@ class JsonClientTest < MiniTest::Spec
     assert_same client.logger, custom_logger
   end
 
+  def test_should_log_govuk_request_id_when_available
+    GdsApi::GovukHeaders.set_header(:govuk_request_id, "some-request-id")
+    custom_logger = mock
+    client = GdsApi::JsonClient.new(logger: custom_logger)
+    url = "http://www.example.com/timeout.json"
+    stub_request(:get, url).to_timeout
+
+    expected_string = "\"govuk_request_id\":\"some-request-id\""
+    custom_logger.expects(:debug).with(includes(expected_string))
+    custom_logger.expects(:error).with(includes(expected_string))
+
+    assert_raises do
+      client.get_json(url)
+    end
+  end
+
   def test_should_avoid_content_type_header_on_get_without_body
     url = "http://some.endpoint/some.json"
     stub_request(:any, url)


### PR DESCRIPTION
This pr aims to fix an issue where the gds-api-adapters logs output whenever an error has happened but the output is missing `govuk_request_id`

<img width="1337" alt="image" src="https://github.com/alphagov/gds-api-adapters/assets/297901/133bc02a-8382-44c6-a2ee-5dc51fe295e2">

---

Whenever an error is raised by the api library, the output from the api client now contains govuk_request_id whenever its available.

gds-api-adapters by default sets up a header sniffer for govuk_request_id here: https://github.com/alphagov/gds-api-adapters/blob/main/lib/gds_api/railtie.rb#L7 which allows the code below to just add the header value into log lines.

I looked into if we could make govuk_app_config add the header to these log lines as it does something similar for the default Rails logger, but it looks like the most straightforward way is this.

