### PR TITLE
Update data source for World Location methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Change source for `GdsApi.worldwide.world_location` method (the response is backwards compatible).
+
 # 88.2.0
 
 * Add `whitehall_media` method to Asset Manager.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 89.0.0
 
 * BREAKING: Change source for `GdsApi.worldwide.world_locations` method and remove pagination.
 * Change source for `GdsApi.worldwide.world_location` method (the response is backwards compatible).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* BREAKING: Change source for `GdsApi.worldwide.world_locations` method and remove pagination.
 * Change source for `GdsApi.worldwide.world_location` method (the response is backwards compatible).
 
 # 88.2.0

--- a/lib/gds_api/test_helpers/worldwide.rb
+++ b/lib/gds_api/test_helpers/worldwide.rb
@@ -8,11 +8,6 @@ module GdsApi
 
       WORLDWIDE_API_ENDPOINT = Plek.new.website_root
 
-      # Sets up the index endpoints for the given country slugs
-      # The stubs are setup to paginate in chunks of 20
-      #
-      # This also sets up the individual endpoints for each slug
-      # by calling stub_worldwide_api_has_location below
       def stub_worldwide_api_has_locations(location_slugs)
         international_delegation_slugs = location_slugs.select do |slug|
           slug =~ /(delegation|mission)/
@@ -51,48 +46,10 @@ module GdsApi
 
         stub_request(:get, "#{WORLDWIDE_API_ENDPOINT}/api/content/world")
             .to_return(status: 200, body: content_item.to_json)
-
-        location_slugs.each { |s| stub_worldwide_api_has_location(s) }
-        pages = []
-        location_slugs.each_slice(20) do |slugs|
-          pages << slugs.map { |s| stub_worldwide_api_has_locations(s) }
-        end
-
-        pages.each_with_index do |page, i|
-          page_details = plural_response_base.merge(
-            "results" => page,
-            "total" => location_slugs.size,
-            "pages" => pages.size,
-            "current_page" => i + 1,
-            "page_size" => 20,
-            "start_index" => i * 20 + 1,
-          )
-
-          links = { self: "#{WORLDWIDE_API_ENDPOINT}/api/world-locations?page=#{i + 1}" }
-          links[:next] = "#{WORLDWIDE_API_ENDPOINT}/api/world-locations?page=#{i + 2}" if pages[i + 1]
-          links[:previous] = "#{WORLDWIDE_API_ENDPOINT}/api/world-locations?page=#{i}" unless i.zero?
-          page_details["_response_info"]["links"] = []
-          link_headers = []
-          links.each do |rel, href|
-            page_details["_response_info"]["links"] << { "rel" => rel, "href" => href }
-            link_headers << "<#{href}>; rel=\"#{rel}\""
-          end
-
-          stub_request(:get, links[:self])
-            .to_return(status: 200, body: page_details.to_json, headers: { "Link" => link_headers.join(", ") })
-
-          next unless i.zero?
-
-          # First page exists at URL with and without page param
-          stub_request(:get, links[:self].sub(/\?page=1/, ""))
-            .to_return(status: 200, body: page_details.to_json, headers: { "Link" => link_headers.join(", ") })
-        end
       end
 
-      def stub_worldwide_api_has_location(location_slug, details = nil)
-        details ||= world_location_for_slug(location_slug)
-        stub_request(:get, "#{WORLDWIDE_API_ENDPOINT}/api/world-locations/#{location_slug}")
-          .to_return(status: 200, body: details.to_json)
+      def stub_worldwide_api_has_location(location_slug)
+        stub_worldwide_api_has_locations([location_slug])
       end
 
       def stub_worldwide_api_has_organisations_for_location(location_slug, json_or_hash)
@@ -107,33 +64,6 @@ module GdsApi
         url = "#{WORLDWIDE_API_ENDPOINT}/api/world-locations/#{location_slug}/organisations"
         stub_request(:get, url)
           .to_return(status: 200, body: details.to_json, headers: { "Link" => "<#{url}; rel\"self\"" })
-      end
-
-      def world_location_for_slug(slug)
-        singular_response_base.merge(stub_worldwide_api_has_locations(slug))
-      end
-
-      # Constructs a sample world_location
-      #
-      # if the slug contains 'delegation' or 'mission' the format will be set to 'International delegation'
-      # othersiwe it will be set to 'World location'
-      def stub_worldwide_api_has_locations(slug)
-        {
-          "id" => "https://www.gov.uk/api/world-locations/#{slug}",
-          "title" => titleize_slug(slug, title_case: true),
-          "format" => (slug =~ /(delegation|mission)/ ? "International delegation" : "World location"),
-          "updated_at" => "2013-03-25T13:06:42+00:00",
-          "web_url" => "https://www.gov.uk/government/world/#{slug}",
-          "details" => {
-            "slug" => slug,
-            "iso2" => slug[0..1].upcase,
-          },
-          "organisations" => {
-            "id" => "https://www.gov.uk/api/world-locations/#{slug}/organisations",
-            "web_url" => "https://www.gov.uk/government/world/#{slug}#organisations",
-          },
-          "content_id" => "content_id_for_#{slug}",
-        }
       end
     end
   end

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = "88.2.0".freeze
+  VERSION = "89.0.0".freeze
 end

--- a/lib/gds_api/worldwide.rb
+++ b/lib/gds_api/worldwide.rb
@@ -2,7 +2,7 @@ require_relative "base"
 
 class GdsApi::Worldwide < GdsApi::Base
   def world_locations
-    get_list("#{base_url}/world-locations")
+    all_world_locations
   end
 
   def world_location(location_slug)

--- a/lib/gds_api/worldwide.rb
+++ b/lib/gds_api/worldwide.rb
@@ -6,7 +6,13 @@ class GdsApi::Worldwide < GdsApi::Base
   end
 
   def world_location(location_slug)
-    get_json("#{base_url}/world-locations/#{location_slug}")
+    world_location = all_world_locations.find do |location|
+      location.dig("details", "slug") == location_slug
+    end
+
+    raise GdsApi::HTTPNotFound, 404 unless world_location
+
+    world_location
   end
 
   def organisations_for_world_location(location_slug)
@@ -17,5 +23,36 @@ private
 
   def base_url
     "#{endpoint}/api"
+  end
+
+  def all_world_locations
+    content_item = JSON.parse(get_raw("#{base_url}/content/world"))
+
+    world_locations = format_locations(content_item.dig("details", "world_locations"), "World location")
+    international_delegations = format_locations(content_item.dig("details", "international_delegations"), "International delegation")
+
+    Array(world_locations) + Array(international_delegations)
+  end
+
+  def format_locations(locations, type)
+    locations&.map do |location|
+      {
+        "id" => "#{Plek.new.website_root}/world/#{location['slug']}",
+        "title" => location["name"],
+        "format" => type,
+        "updated_at" => location["updated_at"],
+        "web_url" => "#{Plek.new.website_root}/world/#{location['slug']}",
+        "analytics_identifier" => location["analytics_identifier"],
+        "details" => {
+          "slug" => location["slug"],
+          "iso2" => location["iso2"],
+        },
+        "organisations" => {
+          "id" => "#{Plek.new.website_root}/world/#{location['slug']}#organisations",
+          "web_url" => "#{Plek.new.website_root}/world/#{location['slug']}#organisations",
+        },
+        "content_id" => location["content_id"],
+      }
+    end
   end
 end

--- a/test/pacts/worldwide_api_pact_test.rb
+++ b/test/pacts/worldwide_api_pact_test.rb
@@ -6,48 +6,6 @@ describe "GdsApi::Worldwide pact tests" do
 
   let(:api_client) { GdsApi::Worldwide.new(whitehall_api_host) }
 
-  describe "#world_locations" do
-    it "responds with 200 and all world locations" do
-      whitehall_api
-        .given("a world location exists")
-        .upon_receiving("a request to return all world locations")
-        .with(
-          method: :get,
-          path: "/api/world-locations",
-          headers: GdsApi::JsonClient.default_request_headers,
-        )
-        .will_respond_with(
-          status: 200,
-          body: {
-            results: [
-              Pact.like(
-                id: "https://www.gov.uk/api/world-locations/france",
-                title: "France",
-                format: "World location",
-                updated_at: "2020-09-02T06:47:34.000+01:00",
-                web_url: "https://www.gov.uk/world/france",
-                analytics_identifier: "WL1",
-                details: {
-                  slug: "france",
-                  iso2: nil,
-                },
-                organisations: {
-                  id: "https://www.gov.uk/api/world-locations/france/organisations",
-                  web_url: "https://www.gov.uk/world/france#organisations",
-                },
-                content_id: "5e9ecbce-7706-11e4-a3cb-005056011aef",
-              ),
-            ],
-          },
-          headers: {
-            "Content-Type" => "application/json; charset=utf-8",
-          },
-        )
-
-      api_client.world_locations
-    end
-  end
-
   describe "#world_location" do
     describe "#organisations_for_world_location" do
       it "responds with 200 and all worldwide organisations" do

--- a/test/pacts/worldwide_api_pact_test.rb
+++ b/test/pacts/worldwide_api_pact_test.rb
@@ -49,42 +49,6 @@ describe "GdsApi::Worldwide pact tests" do
   end
 
   describe "#world_location" do
-    it "responds with 200 and requested world location" do
-      whitehall_api
-        .given("a world location exists")
-        .upon_receiving("a request to return a specific world location")
-        .with(
-          method: :get,
-          path: "/api/world-locations/france",
-          headers: GdsApi::JsonClient.default_request_headers,
-        )
-        .will_respond_with(
-          status: 200,
-          body: {
-            id: Pact.like("https://www.gov.uk/api/world-locations/france"),
-            title: "France",
-            format: "World location",
-            updated_at: Pact.like("2020-09-02T06:47:34.000+01:00"),
-            web_url: Pact.like("https://www.gov.uk/world/france"),
-            analytics_identifier: Pact.like("WL1"),
-            details: {
-              slug: "france",
-              iso2: nil,
-            },
-            organisations: Pact.like(
-              id: "https://www.gov.uk/api/world-locations/france/organisations",
-              web_url: "https://www.gov.uk/world/france#organisations",
-            ),
-            content_id: Pact.like("5e9ecbce-7706-11e4-a3cb-005056011aef"),
-          },
-          headers: {
-            "Content-Type" => "application/json; charset=utf-8",
-          },
-        )
-
-      api_client.world_location("france")
-    end
-
     describe "#organisations_for_world_location" do
       it "responds with 200 and all worldwide organisations" do
         whitehall_api

--- a/test/worldwide_api_test.rb
+++ b/test/worldwide_api_test.rb
@@ -42,14 +42,14 @@ describe GdsApi::Worldwide do
 
   describe "fetching a world location" do
     it "should return the details" do
-      stub_worldwide_api_has_location("rohan")
+      stub_worldwide_api_has_locations(%w[rohan])
 
       response = @api.world_location("rohan")
       assert_equal "Rohan", response["title"]
     end
 
     it "raises for a non-existent location" do
-      stub_worldwide_api_does_not_have_location("non-existent")
+      stub_worldwide_api_has_locations(%w[rohan])
 
       assert_raises(GdsApi::HTTPNotFound) do
         @api.world_location("non-existent")

--- a/test/worldwide_api_test.rb
+++ b/test/worldwide_api_test.rb
@@ -17,26 +17,7 @@ describe GdsApi::Worldwide do
       stub_worldwide_api_has_locations(country_slugs)
 
       response = @api.world_locations
-      assert_equal(country_slugs, response.map { |r| r["details"]["slug"] })
-      assert_equal "Rohan", response["results"][2]["title"]
-    end
-
-    it "should handle the pagination" do
-      country_slugs = (1..50).map { |n| "country-#{n}" }
-      stub_worldwide_api_has_locations(country_slugs)
-
-      response = @api.world_locations
-      assert_equal(
-        country_slugs,
-        response.with_subsequent_pages.map { |r| r["details"]["slug"] },
-      )
-    end
-
-    it "should raise error if endpoint 404s" do
-      stub_request(:get, "#{@base_api_url}/api/world-locations").to_return(status: 404)
-      assert_raises GdsApi::HTTPNotFound do
-        @api.world_locations
-      end
+      assert_equal(country_slugs, response.map { |r| r.dig("details", "slug") })
     end
   end
 


### PR DESCRIPTION
These methods currently returns data retrieved from the Whitehall API, which is being deprecated.

Therefore updating the method to get the data from the World Content Item.

We need to transform the response to ensure the output remains as backwards compatible with previous versions of this gem as possible.  However a breaking change has been introduced, as pagination of the World Locations endpoint has been removed.

The following applications use the affected methods and will be updated in the following PRs (once this a new version of this gem has been released):
- https://github.com/alphagov/smart-answers/pull/6463
- https://github.com/alphagov/finder-frontend/pull/3113
- https://github.com/alphagov/contacts-admin/pull/1204

[Trello card](https://trello.com/c/4r5uSD2R)