### PR TITLE
Update casing of `MiniTest::Spec` and update dependencies

### DIFF
--- a/gds-api-adapters.gemspec
+++ b/gds-api-adapters.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "byebug"
   s.add_development_dependency "climate_control", "~> 1.2"
   s.add_development_dependency "govuk_schemas", "~> 4.4"
-  s.add_development_dependency "minitest", "~> 5.11"
+  s.add_development_dependency "minitest", "~> 5.19"
   s.add_development_dependency "minitest-around", "~> 0.5"
   s.add_development_dependency "mocha", "~> 2.0"
   s.add_development_dependency "pact", "~> 1.62"

--- a/gds-api-adapters.gemspec
+++ b/gds-api-adapters.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "govuk_schemas", "~> 4.4"
   s.add_development_dependency "minitest", "~> 5.19"
   s.add_development_dependency "minitest-around", "~> 0.5"
-  s.add_development_dependency "mocha", "~> 2.0"
+  s.add_development_dependency "mocha", "~> 2.1"
   s.add_development_dependency "pact", "~> 1.62"
   s.add_development_dependency "pact_broker-client", "~> 1.65"
   s.add_development_dependency "pact-consumer-minitest", "~> 1.0"

--- a/test/json_client_test.rb
+++ b/test/json_client_test.rb
@@ -4,7 +4,7 @@ require "gds_api/json_client"
 require "base64"
 require "null_logger"
 
-class JsonClientTest < MiniTest::Spec
+class JsonClientTest < Minitest::Spec
   def setup
     @client = GdsApi::JsonClient.new
 


### PR DESCRIPTION
This was incorrectly included as `MiniTest` when it should be `Minitest`, causing CI to fail, due to a removal of the compatibility layer in `minitest` 5.19.0.  Also requires `mocha` 2.1, as this in the earliest release to not require the compatibility layer.