### PR TITLE
Add `media` method to Asset Manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+* Add `media` method to Asset Manager.
+
 # 91.0.0
 
 * BREAKING: Remove Account API `get_email_subscription` method and helpers

--- a/lib/gds_api/asset_manager.rb
+++ b/lib/gds_api/asset_manager.rb
@@ -239,6 +239,18 @@ class GdsApi::AssetManager < GdsApi::Base
     get_raw("#{base_url}/#{uri_encode(legacy_url_path)}")
   end
 
+  # Fetches an asset given the id and filename
+  #
+  # @param id [String] The asset identifier.
+  # @param filename [String] Filename of the asset.
+  # @return [GdsApi::Response] A response object containing the raw asset.
+  #   If the asset cannot be found, +GdsApi::HTTPNotFound+ will be raised.
+  #
+  # @raise [HTTPErrorResponse] if the request returns an error
+  def media(id, filename)
+    get_raw("#{base_url}/media/#{id}/#{filename}")
+  end
+
 private
 
   def base_url

--- a/lib/gds_api/test_helpers/asset_manager.rb
+++ b/lib/gds_api/test_helpers/asset_manager.rb
@@ -21,11 +21,14 @@ module GdsApi
           .to_return(body: body.to_json, status: 200)
       end
 
-      def stub_asset_manager_has_an_asset(id, atts)
+      def stub_asset_manager_has_an_asset(id, atts, filename = "")
         response = atts.merge("_response_info" => { "status" => "ok" })
 
         stub_request(:get, "#{ASSET_MANAGER_ENDPOINT}/assets/#{id}")
           .to_return(body: response.to_json, status: 200)
+
+        stub_request(:get, "#{ASSET_MANAGER_ENDPOINT}/media/#{id}/#{filename}")
+          .to_return(body: "Some file content", status: 200)
       end
 
       def stub_asset_manager_has_a_whitehall_asset(legacy_url_path, atts)

--- a/test/asset_manager_test.rb
+++ b/test/asset_manager_test.rb
@@ -24,9 +24,9 @@ describe GdsApi::AssetManager do
 
   it "creates the asset with a file" do
     req = stub_request(:post, "#{base_api_url}/assets")
-      .with { |request|
-        request.body =~ %r{Content-Disposition: form-data; name="asset\[file\]"; filename="hello\.txt"\r\nContent-Type: text/plain}
-      }.to_return(body: JSON.dump(stub_asset_manager_response), status: 201)
+            .with { |request|
+              request.body =~ %r{Content-Disposition: form-data; name="asset\[file\]"; filename="hello\.txt"\r\nContent-Type: text/plain}
+            }.to_return(body: JSON.dump(stub_asset_manager_response), status: 201)
 
     response = api.create_asset(file: file_fixture)
 
@@ -36,9 +36,9 @@ describe GdsApi::AssetManager do
 
   it "creates a Whitehall asset with a file" do
     req = stub_request(:post, "#{base_api_url}/whitehall_assets")
-      .with { |request|
-        request.body =~ %r{Content-Disposition: form-data; name="asset\[file\]"; filename="hello\.txt"\r\nContent-Type: text/plain}
-      }.to_return(body: JSON.dump(stub_asset_manager_response), status: 201)
+            .with { |request|
+              request.body =~ %r{Content-Disposition: form-data; name="asset\[file\]"; filename="hello\.txt"\r\nContent-Type: text/plain}
+            }.to_return(body: JSON.dump(stub_asset_manager_response), status: 201)
 
     response = api.create_whitehall_asset(file: file_fixture, legacy_url_path: "/government/uploads/path/to/hello.txt")
 
@@ -70,9 +70,12 @@ describe GdsApi::AssetManager do
     before do
       stub_asset_manager_has_an_asset(
         asset_id,
-        "name" => "photo.jpg",
-        "content_type" => "image/jpeg",
-        "file_url" => "http://fooey.gov.uk/media/photo.jpg",
+        {
+          "name" => "photo.jpg",
+          "content_type" => "image/jpeg",
+          "file_url" => "http://fooey.gov.uk/media/photo.jpg",
+        },
+        "photo.jpg",
       )
     end
 
@@ -80,7 +83,7 @@ describe GdsApi::AssetManager do
 
     it "updates the asset with a file" do
       req = stub_request(:put, "#{base_api_url}/assets/test-id")
-        .to_return(body: JSON.dump(stub_asset_manager_response), status: 200)
+              .to_return(body: JSON.dump(stub_asset_manager_response), status: 200)
 
       response = api.update_asset(asset_id, file: file_fixture)
 
@@ -94,6 +97,12 @@ describe GdsApi::AssetManager do
       assert_equal "photo.jpg", asset["name"]
       assert_equal "image/jpeg", asset["content_type"]
       assert_equal "http://fooey.gov.uk/media/photo.jpg", asset["file_url"]
+    end
+
+    it "retrieves the asset from media" do
+      asset = api.media(asset_id, "photo.jpg")
+
+      assert_equal "Some file content", asset.body
     end
   end
 
@@ -135,7 +144,7 @@ describe GdsApi::AssetManager do
 
   it "deletes the asset for the given id" do
     req = stub_request(:delete, "#{base_api_url}/assets/#{asset_id}")
-      .to_return(body: JSON.dump(stub_asset_manager_response), status: 200)
+            .to_return(body: JSON.dump(stub_asset_manager_response), status: 200)
 
     response = api.delete_asset(asset_id)
 
@@ -145,7 +154,7 @@ describe GdsApi::AssetManager do
 
   it "restores the asset for the given id" do
     req = stub_request(:post, "#{base_api_url}/assets/#{asset_id}/restore")
-      .to_return(body: JSON.dump(stub_asset_manager_response), status: 200)
+            .to_return(body: JSON.dump(stub_asset_manager_response), status: 200)
 
     response = api.restore_asset(asset_id)
 

--- a/test/pacts/asset_manager_pact_test.rb
+++ b/test/pacts/asset_manager_pact_test.rb
@@ -81,6 +81,21 @@ describe "GdsApi::AssetManager pact tests" do
       end
     end
 
+    describe "#get asset" do
+      it "gets an asset" do
+        asset_manager
+          .given("an asset exists with id #{content_id} and filename asset.png")
+          .upon_receiving("a get asset request")
+          .with(
+            method: :get,
+            path: "/media/#{content_id}/asset.png",
+          ).will_respond_with(
+            status: 200,
+          )
+
+        api_client.media(content_id, "asset.png")
+      end
+    end
     describe "#update_asset" do
       it "updates an asset" do
         asset_manager


### PR DESCRIPTION
Asset Manager has a `media` route, which returns the actual asset for a given asset-manager-id and the filename.

Adding this method to gds-api-adapters so it can be used in the Frontend application.

This repo is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

[Trello Card](https://trello.com/c/LV4TnjlP/176-story-csv-previews-should-work-with-modern-urls)