### PR TITLE
Release version 91.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 91.1.0
 * Add `media` method to Asset Manager.
 
 # 91.0.0

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = "91.0.0".freeze
+  VERSION = "91.1.0".freeze
 end


### PR DESCRIPTION
Release for https://github.com/alphagov/gds-api-adapters/pull/1211

Add `media` method to Asset Manager

[Trello](https://trello.com/c/LV4TnjlP/176-story-csv-previews-should-work-with-modern-urls)
This repo is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.
