### PR TITLE
Begin publishing pacts to new broker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,14 @@ jobs:
           PACT_BROKER_USERNAME: ${{ secrets.GOVUK_PACT_BROKER_USERNAME }}
           PACT_BROKER_PASSWORD: ${{ secrets.GOVUK_PACT_BROKER_PASSWORD }}
           PACT_PATTERN: tmp/pacts/*.json
+      - run: bundle exec rake pact:publish
+        continue-on-error: true
+        env:
+          PACT_CONSUMER_VERSION: branch-${{ github.ref_name }}
+          PACT_BROKER_BASE_URL: https://govuk-pact-broker-6991351eca05.herokuapp.com
+          PACT_BROKER_USERNAME: ${{ secrets.GOVUK_PACT_BROKER_USERNAME }}
+          PACT_BROKER_PASSWORD: ${{ secrets.GOVUK_PACT_BROKER_PASSWORD }}
+          PACT_PATTERN: tmp/pacts/*.json
 
   # We don't use the artifact outside of sharing it for jobs so delete it
   # at the end of the flow.


### PR DESCRIPTION
[Trello card](https://trello.com/c/7f3F6Xij/3338-migrate-from-the-old-paas-based-pact-broker-to-the-new-instance-on-heroku)

We are working on migrating our Pact Broker instance from PaaS to Heroku. As a first step, this PR updates our CI to begin publishing pacts to both instances simultaneously. We (temporarily) use the `continue-on-error: true` option to ensure that CI does not fail if the push to the new instance fails for any reason.

The credentials for both instances are the same, so we shouldn't need to update any secrets for this to work.

<!-- This repo is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs. -->