### PR TITLE
Stop pushing to old pact broker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,14 +127,6 @@ jobs:
       - run: bundle exec rake pact:publish
         env:
           PACT_CONSUMER_VERSION: branch-${{ github.ref_name }}
-          PACT_BROKER_BASE_URL: https://pact-broker.cloudapps.digital
-          PACT_BROKER_USERNAME: ${{ secrets.GOVUK_PACT_BROKER_USERNAME }}
-          PACT_BROKER_PASSWORD: ${{ secrets.GOVUK_PACT_BROKER_PASSWORD }}
-          PACT_PATTERN: tmp/pacts/*.json
-      - run: bundle exec rake pact:publish
-        continue-on-error: true
-        env:
-          PACT_CONSUMER_VERSION: branch-${{ github.ref_name }}
           PACT_BROKER_BASE_URL: https://govuk-pact-broker-6991351eca05.herokuapp.com
           PACT_BROKER_USERNAME: ${{ secrets.GOVUK_PACT_BROKER_USERNAME }}
           PACT_BROKER_PASSWORD: ${{ secrets.GOVUK_PACT_BROKER_PASSWORD }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v4
         with:
            repository: alphagov/publishing-api
-           ref: deployed-to-production
+           ref: main
            path: vendor/publishing-api
       - uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
[Trello card](https://trello.com/c/7f3F6Xij/3338-migrate-from-the-old-paas-based-pact-broker-to-the-new-instance-on-heroku)

We are currently migrating our Pact Broker instance from PaaS to Heroku. Our API providers have now been fully migrated to the new Pact Broker instance, so we can now stop publishing pacts to the old one. We should now also begin erroring if the publish to the new instance fails.

Also a drive-by update: The `deployed-to-production` branch is no longer automatically updated on deploy, so it's currently pointing to an old pre-replatforming commit. This PR updates the `checkout` action to point to the `main` branch of Publishing API instead.