### PR TITLE
Revert "Revert "Stop pushing to old pact broker""

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v4
         with:
            repository: alphagov/publishing-api
-           ref: deployed-to-production
+           ref: main
            path: vendor/publishing-api
       - uses: ruby/setup-ruby@v1
         with:
@@ -125,14 +125,6 @@ jobs:
           name: pacts
           path: tmp/pacts
       - run: bundle exec rake pact:publish
-        env:
-          PACT_CONSUMER_VERSION: branch-${{ github.ref_name }}
-          PACT_BROKER_BASE_URL: https://pact-broker.cloudapps.digital
-          PACT_BROKER_USERNAME: ${{ secrets.GOVUK_PACT_BROKER_USERNAME }}
-          PACT_BROKER_PASSWORD: ${{ secrets.GOVUK_PACT_BROKER_PASSWORD }}
-          PACT_PATTERN: tmp/pacts/*.json
-      - run: bundle exec rake pact:publish
-        continue-on-error: true
         env:
           PACT_CONSUMER_VERSION: branch-${{ github.ref_name }}
           PACT_BROKER_BASE_URL: https://govuk-pact-broker-6991351eca05.herokuapp.com


### PR DESCRIPTION
[Trello card](https://trello.com/c/7f3F6Xij/3338-migrate-from-the-old-paas-based-pact-broker-to-the-new-instance-on-heroku)

Getting quite meta now 😎 

I have resolved the issue that was causing the new Pact Broker instance to reject the push, so we can un-revert this change now. Please see the original PR (#1215) for more details.

Reverts alphagov/gds-api-adapters#1216