### PR TITLE
Release 92.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 92.0.0
 * Alter `snac` field to `gss` in Imminence API `places` method contract.
 * BREAKING: Remove Asset Manager API `whitehall_asset` method and helpers
 * Note: These are no longer used by any apps, so should not be breaking in practice.

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = "91.1.0".freeze
+  VERSION = "92.0.0".freeze
 end


### PR DESCRIPTION
Includes:
- https://github.com/alphagov/gds-api-adapters/pull/1220
- https://github.com/alphagov/gds-api-adapters/pull/1219

This repo is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.
