### PR TITLE
Gift week email alert api

### DIFF
--- a/lib/gds_api/email_alert_api.rb
+++ b/lib/gds_api/email_alert_api.rb
@@ -94,6 +94,19 @@ class GdsApi::EmailAlertApi < GdsApi::Base
     get_json("#{endpoint}/subscriber-lists/#{uri_encode(slug)}")
   end
 
+  # Get a Subscriber List
+  #
+  # @param [path] path of page for subscriber list
+  #
+  # @return [Hash] {
+  #  subscriber_list_count
+  #  all_notify_count
+  # }
+
+  def get_subscriber_list_metrics(path:)
+    get_json("#{endpoint}/subscriber-lists/metrics#{path}")
+  end
+
   # Get a Subscription
   #
   # @return [Hash] subscription: {

--- a/lib/gds_api/test_helpers/email_alert_api.rb
+++ b/lib/gds_api/test_helpers/email_alert_api.rb
@@ -164,6 +164,16 @@ module GdsApi
         stub_request(:any, %r{\A#{EMAIL_ALERT_API_ENDPOINT}})
       end
 
+      def stub_get_subscriber_list_metrics(path:, response:)
+        stub_request(:get, "#{EMAIL_ALERT_API_ENDPOINT}/subscriber-lists/metrics#{path}")
+          .to_return(status: 200, body: response)
+      end
+
+      def stub_get_subscriber_list_metrics_not_found(path:)
+        stub_request(:get, "#{EMAIL_ALERT_API_ENDPOINT}/subscriber-lists/metrics#{path}")
+          .to_return(status: 404)
+      end
+
       def assert_email_alert_api_content_change_created(attributes = nil)
         if attributes
           matcher = lambda do |request|

--- a/test/email_alert_api_test.rb
+++ b/test/email_alert_api_test.rb
@@ -549,6 +549,28 @@ describe GdsApi::EmailAlertApi do
     end
   end
 
+  describe "get_subscribe_list_metrics" do
+    it "returns the parsed json" do
+      stub_get_subscriber_list_metrics(path: "/the/path", response: {
+        subscriber_list_count: 5,
+        all_notify_count: 12,
+      }.to_json)
+
+      api_response = api_client.get_subscriber_list_metrics(path: "/the/path")
+      assert_equal(200, api_response.code)
+      parsed_body = api_response.to_h
+      assert_equal({ "subscriber_list_count" => 5, "all_notify_count" => 12 }, parsed_body)
+    end
+
+    it "raises 404 when not found" do
+      stub_get_subscriber_list_metrics_not_found(path: "/the/path")
+
+      assert_raises GdsApi::HTTPNotFound do
+        api_client.get_subscriber_list_metrics(path: "/the/path")
+      end
+    end
+  end
+
   describe "change_subscriber with an id that needs URI encoding" do
     it "encodes the id" do
       request = stub_email_alert_api_has_updated_subscriber("string%20id", "test2@example.com")

--- a/test/test_helpers/email_alert_api_test.rb
+++ b/test/test_helpers/email_alert_api_test.rb
@@ -49,4 +49,24 @@ describe GdsApi::TestHelpers::EmailAlertApi do
       assert_equal(2, result["subscriptions"].count)
     end
   end
+
+  describe "#stub_get_subscriber_list_metrics_not_found" do
+    it "raises 404" do
+      stub_get_subscriber_list_metrics_not_found(path: "/some/path")
+      assert_raises(GdsApi::HTTPNotFound) do
+        email_alert_api.get_subscriber_list_metrics(path: "/some/path")
+      end
+    end
+  end
+
+  describe "#stub_get_subscriber_list_metrics" do
+    it "returns the stubbed data" do
+      json = { subscriber_list_count: 3, all_notify_count: 10 }.to_json
+      stub_get_subscriber_list_metrics(path: "/some/path", response: json)
+      response = email_alert_api.get_subscriber_list_metrics(path: "/some/path")
+      expected = { "subscriber_list_count" => 3, "all_notify_count" => 10 }
+      assert_equal 200, response.code
+      assert_equal expected, response.to_h
+    end
+  end
 end


### PR DESCRIPTION

* Add a wrapper for the `email-alert-api` `GET /subscriber-lists/metrics/path/to/content` endpoint
* Add a test helper to the above