### PR TITLE
Release 92.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 92.1.0
+* Add `get_subscriber_list_metrics` method to Email Alert API.
+
 # 92.0.0
 * Alter `snac` field to `gss` in Imminence API `places` method contract.
 * BREAKING: Remove Asset Manager API `whitehall_asset` method and helpers

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = "92.0.0".freeze
+  VERSION = "92.1.0".freeze
 end


### PR DESCRIPTION
Includes:
- Add subscriber list metrics method to Email Alert API: https://github.com/alphagov/gds-api-adapters/pull/1227

This repo is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.
