### PR TITLE
Remove 'create_foi_request' API method & bump to 93.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 93.0.0
+* BREAKING: removed Support app `create_foi_request` method.
+* Note: This is no longer used by any apps, so should not be breaking in practice.
+
 # 92.1.0
 * Add `get_subscriber_list_metrics` method to Email Alert API.
 

--- a/lib/gds_api/support.rb
+++ b/lib/gds_api/support.rb
@@ -1,10 +1,6 @@
 require_relative "base"
 
 class GdsApi::Support < GdsApi::Base
-  def create_foi_request(request_details)
-    post_json("#{base_url}/foi_requests", foi_request: request_details)
-  end
-
   def create_named_contact(request_details)
     post_json("#{base_url}/named_contacts", named_contact: request_details)
   end

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = "92.1.0".freeze
+  VERSION = "93.0.0".freeze
 end

--- a/test/support_test.rb
+++ b/test/support_test.rb
@@ -10,24 +10,6 @@ describe GdsApi::Support do
     @api = GdsApi::Support.new(@base_api_url)
   end
 
-  it "can create an FOI request" do
-    request_details = { "foi_request" => { "requester" => { "name" => "A", "email" => "a@b.com" }, "details" => "abc" } }
-
-    stub_post = stub_request(:post, "#{@base_api_url}/foi_requests")
-      .with(body: { "foi_request" => request_details }.to_json)
-      .to_return(status: 201)
-
-    @api.create_foi_request(request_details)
-
-    assert_requested(stub_post)
-  end
-
-  it "throws an exception when the support app isn't available while creating FOI requests" do
-    stub_support_isnt_available
-
-    assert_raises(GdsApi::HTTPServerError) { @api.create_foi_request({}) }
-  end
-
   it "can create a named contact" do
     request_details = { certain: "details" }
 


### PR DESCRIPTION
This method only appears to be used in gds-api-adapters:
https://github.com/search?q=org%3Aalphagov+create_foi_request&type=code

It was originally added in https://github.com/alphagov/gds-api-adapters/pull/69, to support a feature added to Feedback: https://github.com/alphagov/feedback/pull/65/files ...in 2013.

But this was removed from Feedback in 2019:
https://github.com/alphagov/feedback/commit/9b82531f2dfb2fd1514fe5b09f936b83f73f56d4

The code is being removed from the Support app in this sister PR: https://github.com/alphagov/support/pull/1257

Trello: https://trello.com/c/1UbKFAE5/3400-remove-unused-foi-feature-from-support-app
