### PR TITLE
Remove `simplecov-rcov` dependency

### DIFF
--- a/gds-api-adapters.gemspec
+++ b/gds-api-adapters.gemspec
@@ -36,7 +36,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake"
   s.add_development_dependency "rubocop-govuk", "4.13.0"
   s.add_development_dependency "simplecov", "~> 0.21"
-  s.add_development_dependency "simplecov-rcov", "~> 0.3"
   s.add_development_dependency "timecop", "~> 0.9"
   s.add_development_dependency "webmock", "~> 3.17"
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,12 +2,10 @@ require "bundler"
 Bundler.setup :default, :development, :test
 
 require "simplecov"
-require "simplecov-rcov"
 
 SimpleCov.start do
   add_filter "/test/"
   add_group "Test Helpers", "lib/gds_api/test_helpers"
-  formatter SimpleCov::Formatter::RcovFormatter
 end
 
 require "minitest/autorun"


### PR DESCRIPTION
This gem is not being used for anything, so can be removed.

This repo is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.
