### PR TITLE
Add rack as a runtime dependency and loosen the version constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+* Fix rack being only a development dependency as it is used at runtime.
+
 # 94.0.0
 * BREAKING: Drop support for Rails 7.0 and earlier.
 * BREAKING: Drop support for Ruby 3.0. The minimum required Ruby version is now 3.1.4.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 * Fix rack being only a development dependency as it is used at runtime.
+* Fix too strict Ruby version constraint, loosened to Ruby 3.1
 
 # 94.0.0
 * BREAKING: Drop support for Rails 7.0 and earlier.

--- a/gds-api-adapters.gemspec
+++ b/gds-api-adapters.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency "link_header"
   s.add_dependency "null_logger"
   s.add_dependency "plek", ">= 1.9.0"
+  s.add_dependency "rack", "~> 3.0"
   s.add_dependency "rest-client", "~> 2.0"
 
   s.add_development_dependency "byebug"
@@ -31,7 +32,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "pact_broker-client", "~> 1.65"
   s.add_development_dependency "pact-consumer-minitest", "~> 1.0"
   s.add_development_dependency "pact-mock_service", "~> 3.10"
-  s.add_development_dependency "rack", "~> 3.0"
   s.add_development_dependency "rack-test"
   s.add_development_dependency "rake"
   s.add_development_dependency "rubocop-govuk", "4.14.0"

--- a/gds-api-adapters.gemspec
+++ b/gds-api-adapters.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency "link_header"
   s.add_dependency "null_logger"
   s.add_dependency "plek", ">= 1.9.0"
-  s.add_dependency "rack", "~> 3.0"
+  s.add_dependency "rack", ">= 2.2.0"
   s.add_dependency "rest-client", "~> 2.0"
 
   s.add_development_dependency "byebug"

--- a/gds-api-adapters.gemspec
+++ b/gds-api-adapters.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.homepage     = "http://github.com/alphagov/gds-api-adapters"
   s.description  = "A set of adapters providing easy access to the GDS GOV.UK APIs"
 
-  s.required_ruby_version = ">= 3.1.4"
+  s.required_ruby_version = ">= 3.1"
   s.files        = Dir.glob("lib/**/*") + Dir.glob("test/fixtures/**/*") + %w[README.md Rakefile]
   s.require_path = "lib"
   s.add_dependency "addressable"


### PR DESCRIPTION
This repo is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Rack is needed at runtime due to the use of rack/utils in [Search](https://github.com/alphagov/gds-api-adapters/blob/e8ba0e5aa9379e6fb8c11d397832e57b7af4226c/lib/gds_api/search.rb#L2). I expect this hasn't been caught previously as this gem is typically used in an application with rack. I found it out by putting together a standalone script that used this gem and needed to install rack separately.

The version constraint of rack ~> 3 would force any apps that depend on this to use Rack 3 which would likely be problematic as many GOV.UK apps are still using [Rack 2](https://github.com/alphagov/whitehall/blob/14b7c1deb0d1c2ee3209977dac621d3678252a58/Gemfile.lock#L735).

I also hit an issue installing this on Whitehall due to an over strict version constraint on Ruby so I've fixed that too.