### PR TITLE
Remove specialist topics related code from publishing-api Pact specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+* Update Pact specs to match the publishing-api [PR](https://github.com/alphagov/publishing-api/pull/2669)
+
 # 95.0.0
 
 * BREAKING: Drop 'named contact' API methods from Support app.

--- a/test/pacts/publishing_api/get_content_items_pact_test.rb
+++ b/test/pacts/publishing_api/get_content_items_pact_test.rb
@@ -9,12 +9,12 @@ describe "GdsApi::PublishingApi#get_content_items pact tests" do
 
   it "returns the content items of a certain document_type" do
     publishing_api
-      .given("there is content with document_type 'topic'")
+      .given("there is content with document_type 'taxon'")
       .upon_receiving("a get entries request")
       .with(
         method: :get,
         path: "/v2/content",
-        query: "document_type=topic&fields%5B%5D=title&fields%5B%5D=base_path",
+        query: "document_type=taxon&fields%5B%5D=title&fields%5B%5D=base_path",
       )
       .will_respond_with(
         status: 200,
@@ -23,7 +23,7 @@ describe "GdsApi::PublishingApi#get_content_items pact tests" do
           pages: 1,
           current_page: 1,
           links: [{
-            href: "http://example.org/v2/content?document_type=topic&fields%5B%5D=title&fields%5B%5D=base_path&page=1",
+            href: "http://example.org/v2/content?document_type=taxon&fields%5B%5D=title&fields%5B%5D=base_path&page=1",
             rel: "self",
           }],
           results: [
@@ -34,7 +34,7 @@ describe "GdsApi::PublishingApi#get_content_items pact tests" do
       )
 
     api_client.get_content_items(
-      document_type: "topic",
+      document_type: "taxon",
       fields: %i[title base_path],
     )
   end
@@ -46,7 +46,7 @@ describe "GdsApi::PublishingApi#get_content_items pact tests" do
       .with(
         method: :get,
         path: "/v2/content",
-        query: "document_type=topic&fields%5B%5D=content_id&fields%5B%5D=locale",
+        query: "document_type=taxon&fields%5B%5D=content_id&fields%5B%5D=locale",
       )
       .will_respond_with(
         status: 200,
@@ -55,7 +55,7 @@ describe "GdsApi::PublishingApi#get_content_items pact tests" do
           pages: 1,
           current_page: 1,
           links: [{
-            href: "http://example.org/v2/content?document_type=topic&fields%5B%5D=content_id&fields%5B%5D=locale&page=1",
+            href: "http://example.org/v2/content?document_type=taxon&fields%5B%5D=content_id&fields%5B%5D=locale&page=1",
             rel: "self",
           }],
           results: [
@@ -65,7 +65,7 @@ describe "GdsApi::PublishingApi#get_content_items pact tests" do
       )
 
     api_client.get_content_items(
-      document_type: "topic",
+      document_type: "taxon",
       fields: %i[content_id locale],
     )
   end
@@ -77,7 +77,7 @@ describe "GdsApi::PublishingApi#get_content_items pact tests" do
       .with(
         method: :get,
         path: "/v2/content",
-        query: "document_type=topic&fields%5B%5D=content_id&fields%5B%5D=locale&locale=fr",
+        query: "document_type=taxon&fields%5B%5D=content_id&fields%5B%5D=locale&locale=fr",
       )
       .will_respond_with(
         status: 200,
@@ -86,7 +86,7 @@ describe "GdsApi::PublishingApi#get_content_items pact tests" do
           pages: 1,
           current_page: 1,
           links: [{
-            href: "http://example.org/v2/content?document_type=topic&fields%5B%5D=content_id&fields%5B%5D=locale&locale=fr&page=1",
+            href: "http://example.org/v2/content?document_type=taxon&fields%5B%5D=content_id&fields%5B%5D=locale&locale=fr&page=1",
             rel: "self",
           }],
           results: [
@@ -96,7 +96,7 @@ describe "GdsApi::PublishingApi#get_content_items pact tests" do
       )
 
     api_client.get_content_items(
-      document_type: "topic",
+      document_type: "taxon",
       fields: %i[content_id locale],
       locale: "fr",
     )
@@ -109,7 +109,7 @@ describe "GdsApi::PublishingApi#get_content_items pact tests" do
       .with(
         method: :get,
         path: "/v2/content",
-        query: "document_type=topic&fields%5B%5D=content_id&fields%5B%5D=locale&locale=all",
+        query: "document_type=taxon&fields%5B%5D=content_id&fields%5B%5D=locale&locale=all",
       )
       .will_respond_with(
         status: 200,
@@ -118,7 +118,7 @@ describe "GdsApi::PublishingApi#get_content_items pact tests" do
           pages: 1,
           current_page: 1,
           links: [{
-            href: "http://example.org/v2/content?document_type=topic&fields%5B%5D=content_id&fields%5B%5D=locale&locale=all&page=1",
+            href: "http://example.org/v2/content?document_type=taxon&fields%5B%5D=content_id&fields%5B%5D=locale&locale=all&page=1",
             rel: "self",
           }],
           results: [
@@ -130,7 +130,7 @@ describe "GdsApi::PublishingApi#get_content_items pact tests" do
       )
 
     api_client.get_content_items(
-      document_type: "topic",
+      document_type: "taxon",
       fields: %i[content_id locale],
       locale: "all",
     )
@@ -143,7 +143,7 @@ describe "GdsApi::PublishingApi#get_content_items pact tests" do
       .with(
         method: :get,
         path: "/v2/content",
-        query: "document_type=topic&fields%5B%5D=content_id&fields%5B%5D=details",
+        query: "document_type=taxon&fields%5B%5D=content_id&fields%5B%5D=details",
       )
       .will_respond_with(
         status: 200,
@@ -152,7 +152,7 @@ describe "GdsApi::PublishingApi#get_content_items pact tests" do
           pages: 1,
           current_page: 1,
           links: [{
-            href: "http://example.org/v2/content?document_type=topic&fields%5B%5D=content_id&fields%5B%5D=details&page=1",
+            href: "http://example.org/v2/content?document_type=taxon&fields%5B%5D=content_id&fields%5B%5D=details&page=1",
             rel: "self",
           }],
           results: [
@@ -162,19 +162,19 @@ describe "GdsApi::PublishingApi#get_content_items pact tests" do
       )
 
     api_client.get_content_items(
-      document_type: "topic",
+      document_type: "taxon",
       fields: %i[content_id details],
     )
   end
 
   it "returns the items matching a query" do
     publishing_api
-      .given("there is content with document_type 'topic'")
+      .given("there is content with document_type 'taxon'")
       .upon_receiving("a get entries request with search_in and q parameters")
       .with(
         method: :get,
         path: "/v2/content",
-        query: "document_type=topic&fields%5B%5D=content_id&q=an+internal+name&search_in%5B%5D=details.internal_name",
+        query: "document_type=taxon&fields%5B%5D=content_id&q=an+internal+name&search_in%5B%5D=details.internal_name",
       )
       .will_respond_with(
         status: 200,
@@ -183,7 +183,7 @@ describe "GdsApi::PublishingApi#get_content_items pact tests" do
           pages: 1,
           current_page: 1,
           links: [{
-            href: "http://example.org/v2/content?document_type=topic&fields%5B%5D=content_id&q=an+internal+name&search_in%5B%5D=details.internal_name&page=1",
+            href: "http://example.org/v2/content?document_type=taxon&fields%5B%5D=content_id&q=an+internal+name&search_in%5B%5D=details.internal_name&page=1",
             rel: "self",
           }],
           results: [
@@ -193,7 +193,7 @@ describe "GdsApi::PublishingApi#get_content_items pact tests" do
       )
 
     api_client.get_content_items(
-      document_type: "topic",
+      document_type: "taxon",
       fields: [:content_id],
       q: "an internal name",
       search_in: ["details.internal_name"],

--- a/test/pacts/publishing_api/get_linkables_pact_test.rb
+++ b/test/pacts/publishing_api/get_linkables_pact_test.rb
@@ -26,18 +26,18 @@ describe "GdsApi::PublishingApi#get_linkables pact tests" do
 
   it "returns the content items of a given document_type" do
     publishing_api
-      .given("there is content with document_type 'topic'")
+      .given("there is content with document_type 'taxon'")
       .upon_receiving("a get linkables request")
       .with(
         method: :get,
         path: "/v2/linkables",
-        query: "document_type=topic",
+        query: "document_type=taxon",
       )
       .will_respond_with(
         status: 200,
         body: linkables,
       )
 
-    api_client.get_linkables(document_type: "topic")
+    api_client.get_linkables(document_type: "taxon")
   end
 end

--- a/test/pacts/publishing_api/get_linked_items_pact_test.rb
+++ b/test/pacts/publishing_api/get_linked_items_pact_test.rb
@@ -14,7 +14,7 @@ describe "GdsApi::PublishingApi#get_linked_items pact tests" do
       .with(
         method: :get,
         path: "/v2/linked/#{content_id}",
-        query: "fields%5B%5D=content_id&fields%5B%5D=base_path&link_type=topic",
+        query: "fields%5B%5D=content_id&fields%5B%5D=base_path&link_type=taxon",
       )
       .will_respond_with(
         status: 404,
@@ -32,7 +32,7 @@ describe "GdsApi::PublishingApi#get_linked_items pact tests" do
     assert_raises(GdsApi::HTTPNotFound) do
       api_client.get_linked_items(
         content_id,
-        link_type: "topic",
+        link_type: "taxon",
         fields: %w[content_id base_path],
       )
     end
@@ -57,12 +57,12 @@ describe "GdsApi::PublishingApi#get_linked_items pact tests" do
 
     before do
       publishing_api
-        .given("there are two documents with a 'topic' link to another document")
+        .given("there are two documents with a 'taxon' link to another document")
         .upon_receiving("a get linked request")
         .with(
           method: :get,
           path: "/v2/linked/#{linked_content_id}",
-          query: "fields%5B%5D=content_id&fields%5B%5D=base_path&link_type=topic",
+          query: "fields%5B%5D=content_id&fields%5B%5D=base_path&link_type=taxon",
         )
         .will_respond_with(
           status: 200,
@@ -82,7 +82,7 @@ describe "GdsApi::PublishingApi#get_linked_items pact tests" do
     it "returns the requested fields of linking items" do
       response = api_client.get_linked_items(
         linked_content_id,
-        link_type: "topic",
+        link_type: "taxon",
         fields: %w[content_id base_path],
       )
       assert_equal 200, response.code

--- a/test/pacts/publishing_api/get_paged_content_items_pact_test.rb
+++ b/test/pacts/publishing_api/get_paged_content_items_pact_test.rb
@@ -8,12 +8,12 @@ describe "GdsApi::PublishingApi#get_paged_content_items pact tests" do
 
   it "returns two content items" do
     publishing_api
-      .given("there are four content items with document_type 'topic'")
+      .given("there are four content items with document_type 'taxon'")
       .upon_receiving("get the first page request")
       .with(
         method: :get,
         path: "/v2/content",
-        query: "document_type=topic&fields%5B%5D=title&fields%5B%5D=base_path&page=1&per_page=2",
+        query: "document_type=taxon&fields%5B%5D=title&fields%5B%5D=base_path&page=1&per_page=2",
       )
       .will_respond_with(
         status: 200,
@@ -21,9 +21,9 @@ describe "GdsApi::PublishingApi#get_paged_content_items pact tests" do
           total: 4,
           pages: 2,
           current_page: 1,
-          links: [{ href: "http://example.org/v2/content?document_type=topic&fields%5B%5D=title&fields%5B%5D=base_path&per_page=2&page=2",
+          links: [{ href: "http://example.org/v2/content?document_type=taxon&fields%5B%5D=title&fields%5B%5D=base_path&per_page=2&page=2",
                     rel: "next" },
-                  { href: "http://example.org/v2/content?document_type=topic&fields%5B%5D=title&fields%5B%5D=base_path&per_page=2&page=1",
+                  { href: "http://example.org/v2/content?document_type=taxon&fields%5B%5D=title&fields%5B%5D=base_path&per_page=2&page=1",
                     rel: "self" }],
           results: [
             { title: "title_1", base_path: "/path_1" },
@@ -32,12 +32,12 @@ describe "GdsApi::PublishingApi#get_paged_content_items pact tests" do
         },
       )
     publishing_api
-      .given("there are four content items with document_type 'topic'")
+      .given("there are four content items with document_type 'taxon'")
       .upon_receiving("get the second page request")
       .with(
         method: :get,
         path: "/v2/content",
-        query: "document_type=topic&fields%5B%5D=title&fields%5B%5D=base_path&page=2&per_page=2",
+        query: "document_type=taxon&fields%5B%5D=title&fields%5B%5D=base_path&page=2&per_page=2",
       )
       .will_respond_with(
         status: 200,
@@ -45,9 +45,9 @@ describe "GdsApi::PublishingApi#get_paged_content_items pact tests" do
           total: 4,
           pages: 2,
           current_page: 2,
-          links: [{ href: "http://example.org/v2/content?document_type=topic&fields%5B%5D=title&fields%5B%5D=base_path&per_page=2&page=1",
+          links: [{ href: "http://example.org/v2/content?document_type=taxon&fields%5B%5D=title&fields%5B%5D=base_path&per_page=2&page=1",
                     rel: "previous" },
-                  { href: "http://example.org/v2/content?document_type=topic&fields%5B%5D=title&fields%5B%5D=base_path&per_page=2&page=2",
+                  { href: "http://example.org/v2/content?document_type=taxon&fields%5B%5D=title&fields%5B%5D=base_path&per_page=2&page=2",
                     rel: "self" }],
           results: [
             { title: "title_3", base_path: "/path_3" },
@@ -56,7 +56,7 @@ describe "GdsApi::PublishingApi#get_paged_content_items pact tests" do
         },
       )
     assert_equal(
-      api_client.get_content_items_enum(document_type: "topic", fields: %i[title base_path], per_page: 2).to_a,
+      api_client.get_content_items_enum(document_type: "taxon", fields: %i[title base_path], per_page: 2).to_a,
       [
         { "title" => "title_1", "base_path" => "/path_1" },
         { "title" => "title_2", "base_path" => "/path_2" },

--- a/test/pacts/publishing_api/patch_links_pact_test.rb
+++ b/test/pacts/publishing_api/patch_links_pact_test.rb
@@ -43,13 +43,13 @@ describe "GdsApi::PublishingApi#patch_links pact tests" do
   it "adds the new type of links and responds with the whole link set when setting links of a different type" do
     publishing_api
       .given("organisation links exist for content_id #{content_id}")
-      .upon_receiving("a patch topic links request")
+      .upon_receiving("a patch taxons links request")
       .with(
         method: :patch,
         path: "/v2/links/#{content_id}",
         body: {
           links: {
-            topics: %w[225df4a8-2945-4e9b-8799-df7424a90b69],
+            taxons: %w[225df4a8-2945-4e9b-8799-df7424a90b69],
           },
         },
         headers: {
@@ -60,7 +60,7 @@ describe "GdsApi::PublishingApi#patch_links pact tests" do
         status: 200,
         body: {
           links: {
-            topics: %w[225df4a8-2945-4e9b-8799-df7424a90b69],
+            taxons: %w[225df4a8-2945-4e9b-8799-df7424a90b69],
             organisations: %w[20583132-1619-4c68-af24-77583172c070],
           },
         },
@@ -69,7 +69,7 @@ describe "GdsApi::PublishingApi#patch_links pact tests" do
     api_client.patch_links(
       content_id,
       links: {
-        topics: %w[225df4a8-2945-4e9b-8799-df7424a90b69],
+        taxons: %w[225df4a8-2945-4e9b-8799-df7424a90b69],
       },
     )
   end


### PR DESCRIPTION
This repo is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

## What

Update publishing-api Pact specs in order to match the changes introduced in this Publishing API [PR](https://github.com/alphagov/publishing-api/pull/2683).

## Why

As a dependency of this publishing-api [PR](https://github.com/alphagov/publishing-api/pull/2683).
[Trello ticket](https://trello.com/c/y1ysrube/2493-remove-topic-from-publishing-api-specs)

## Notes

The Pact tests have been run locally from both sides in order to verify they match.