### PR TITLE
Release 95.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 95.0.1
 * Update Pact specs to match the publishing-api [PR](https://github.com/alphagov/publishing-api/pull/2669)
 
 # 95.0.0

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = "95.0.0".freeze
+  VERSION = "95.0.1".freeze
 end


### PR DESCRIPTION
This repo is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

# 95.0.1
* Update Pact specs to match the publishing-api [PR](https://github.com/alphagov/publishing-api/pull/2669)

