### PR TITLE
Added a new stub for attempting to delete a missing asset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+* Added stub for attempting to delete a missing asset from Asset Manager
+
 # 95.0.1
 * Update Pact specs to match the publishing-api [PR](https://github.com/alphagov/publishing-api/pull/2669)
 

--- a/lib/gds_api/test_helpers/asset_manager.rb
+++ b/lib/gds_api/test_helpers/asset_manager.rb
@@ -92,6 +92,11 @@ module GdsApi
           .to_return(body: body.to_json, status: 200)
       end
 
+      def stub_asset_manager_delete_asset_missing(asset_id)
+        stub_request(:delete, "#{ASSET_MANAGER_ENDPOINT}/assets/#{asset_id}")
+          .to_return(status: 404)
+      end
+
       def stub_asset_manager_delete_asset_failure(asset_id)
         stub_request(:delete, "#{ASSET_MANAGER_ENDPOINT}/assets/#{asset_id}").to_return(status: 500)
       end

--- a/test/test_helpers/asset_manager_test.rb
+++ b/test/test_helpers/asset_manager_test.rb
@@ -64,4 +64,39 @@ describe GdsApi::TestHelpers::AssetManager do
       end
     end
   end
+
+  describe "#stub_asset_manager_delete_asset" do
+    it "returns an ok response and the provided body" do
+      asset_id = "some-asset-id"
+      body = { key: "value" }
+      stub_asset_manager_delete_asset(asset_id, body)
+
+      response = stub_asset_manager.delete_asset(asset_id)
+
+      assert_equal 200, response.code
+      assert_equal body[:key], response["key"]
+    end
+  end
+
+  describe "#stub_asset_manager_delete_asset_missing" do
+    it "raises a not found error" do
+      asset_id = "some-asset-id"
+      stub_asset_manager_delete_asset_missing(asset_id)
+
+      assert_raises GdsApi::HTTPNotFound do
+        stub_asset_manager.delete_asset(asset_id)
+      end
+    end
+  end
+
+  describe "#stub_asset_manager_delete_asset_failure" do
+    it "raises an internal server error" do
+      asset_id = "some-asset-id"
+      stub_asset_manager_delete_asset_failure(asset_id)
+
+      assert_raises GdsApi::HTTPInternalServerError do
+        stub_asset_manager.delete_asset(asset_id)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This is needed for testing how publishing applications react to attempting to delete a missing asset. At the moment some of them are not handling not found errors, meaning that the state of the publishing application remains out of sync with asset manager. This causes other logical issues such as being unable to discard a draft in Specialist Publisher because there is an attachment that can't be deleted.

This commit also adds some test coverage for other asset deletion stubs.
