### PR TITLE
Release 95.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 95.1.0
 * Added stub for attempting to delete a missing asset from Asset Manager
 
 # 95.0.1

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = "95.0.1".freeze
+  VERSION = "95.1.0".freeze
 end


### PR DESCRIPTION
Includes a new test stub for attempting to delete a missing asset. As this is a new feature available to consumers of the library, I felt it make sense to consider this a new minor version.
