### PR TITLE
Upgrade govuk_dependabot_merger config to use v2

### DIFF
--- a/.govuk_dependabot_merger.yml
+++ b/.govuk_dependabot_merger.yml
@@ -1,14 +1,7 @@
-api_version: 1
-auto_merge:
-  - dependency: govuk_schemas
-    allowed_semver_bumps:
-      - patch
-      - minor
-  - dependency: plek
-    allowed_semver_bumps:
-      - patch
-      - minor
-  - dependency: rubocop-govuk
-    allowed_semver_bumps:
-      - patch
-      - minor
+api_version: 2
+defaults:
+  allowed_semver_bumps:
+    - patch
+    - minor
+  auto_merge: true
+  update_external_dependencies: true


### PR DESCRIPTION
This upgrades the configuration for govuk_dependabot_merger to use v2.

By upgrading to this version, external dependencies will also be merged automatically.

v1 has been deprecated and we are no longer receiving any automated dependency updates until this change is made.
