### PR TITLE
Publish pacts for branches other than main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       contents: read
       security-events: write
       actions: read
-  
+
   codeql-sast:
     name: CodeQL SAST scan
     uses: alphagov/govuk-infrastructure/.github/workflows/codeql-analysis.yml@main
@@ -21,7 +21,7 @@ jobs:
   dependency-review:
     name: Dependency Review scan
     uses: alphagov/govuk-infrastructure/.github/workflows/dependency-review.yml@main
-  
+
   # This matrix job runs the test suite against multiple Ruby versions
   test_matrix:
     strategy:
@@ -133,7 +133,6 @@ jobs:
       - link_checker_api_pact
       - locations_api_pact
       - publishing_api_pact
-    if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
In https://github.com/alphagov/gds-api-adapters/pull/1188 we set a restriction to only run `rake:publish_pacts` on builds of the main branch. This was not intentional.

Once this change is merged, it should mean that we can test providers locally against branches of gds-api-adapters as per the [developer docs](https://docs.publishing.service.gov.uk/manual/pact-testing.html#changing-existing-pact-tests). E.g. `env PACT_CONSUMER_VERSION=branch-<branch-of-gds-api-adapters> bundle exec rake pact:verify` 
