### PR TITLE
Release 97.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# UNRELEASED
+# 97.0.0
 
 * BREAKING: Rename imminence endpoints to places_manager [PR](https://github.com/alphagov/gds-api-adapters/pull/1253)
 * Note: This is used in Frontend only, so for other apps should not be breaking in practice.

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = "95.1.0".freeze
+  VERSION = "97.0.0".freeze
 end


### PR DESCRIPTION
* BREAKING: Rename imminence endpoints to places_manager [PR](https://github.com/alphagov/gds-api-adapters/pull/1253)
* Note: This is used in Frontend only, so for other apps should not be breaking in practice.


https://trello.com/c/sNzNEMVV/107-release-new-version-of-the-gds-api-adaptor-gem
