### PR TITLE
Temporarily remove requirement for places_pact to pass before publishing artefacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,6 @@ jobs:
       - collections_pact
       - email_alert_api_pact
       - frontend_pact
-      - places_manager_pact
       - link_checker_api_pact
       - locations_api_pact
       - publishing_api_pact


### PR DESCRIPTION

- We need to publish the places-manager pact to the pact broker before we can get the tests passing in the provider, but publishing is gated behind the pact tests passing, so we need to temporarily add into the main branch a change that allows us to ignore places_manager pact tests when considering whether to publish to the broker. This PR can be reverted before a release.

This repo is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.
