### PR TITLE
Revert "Temporarily remove requirement for places_pact to pass before publishing artefacts"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,7 @@ jobs:
       - collections_pact
       - email_alert_api_pact
       - frontend_pact
+      - places_manager_pact
       - link_checker_api_pact
       - locations_api_pact
       - publishing_api_pact


### PR DESCRIPTION
Reverts alphagov/gds-api-adapters#1258