### PR TITLE
Release 96.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,7 @@
-# UNRELEASED
+# 96.0.0
 
 * BREAKING: Rename imminence endpoints to places_manager [PR](https://github.com/alphagov/gds-api-adapters/pull/1253)
 * Note: This is used in Frontend only, so for other apps should not be breaking in practice.
-
-# 96.0.0
 * BREAKING: Drop support for email-alert-api's bulk migrate endpoint
 
 # 95.1.0

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = "95.1.0".freeze
+  VERSION = "96.0.0".freeze
 end


### PR DESCRIPTION
* BREAKING: Rename imminence endpoints to places_manager [PR](https://github.com/alphagov/gds-api-adapters/pull/1253)
* Note: This is used in Frontend only, so for other apps should not be breaking in practice.
* BREAKING: Drop support for email-alert-api's bulk migrate endpoint [PR](https://github.com/alphagov/gds-api-adapters/pull/1254)

This repo is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.
