### PR TITLE
Point pact at new repo name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
 
   places_manager_pact:
     needs: generate_pacts
-    uses: alphagov/imminence/.github/workflows/pact-verify.yml@main
+    uses: alphagov/places-manager/.github/workflows/pact-verify.yml@main
     with:
       pact_artifact: pacts
 


### PR DESCRIPTION
https://trello.com/c/HAEH2bVF/4-rename-imminence

This repo is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.
