### PR TITLE
Release 96.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 96.0.1
 
 * Update Pact specs to match the email-alert-api [PR](https://github.com/alphagov/email-alert-api/pull/2136)
 

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = "96.0.0".freeze
+  VERSION = "96.0.1".freeze
 end


### PR DESCRIPTION
* Update Pact specs to match the email-alert-api [PR](https://github.com/alphagov/email-alert-api/pull/2136)

This repo is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.
