### PR TITLE
Update `rubocop-govuk` from 4.16.1 to 4.17.1

### DIFF
--- a/gds-api-adapters.gemspec
+++ b/gds-api-adapters.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "pact-mock_service", "~> 3.10"
   s.add_development_dependency "rack-test"
   s.add_development_dependency "rake"
-  s.add_development_dependency "rubocop-govuk", "4.16.1"
+  s.add_development_dependency "rubocop-govuk", "4.17.1"
   s.add_development_dependency "simplecov", "~> 0.21"
   s.add_development_dependency "timecop", "~> 0.9"
   s.add_development_dependency "webmock", "~> 3.17"


### PR DESCRIPTION
Opening this manually to see if it passes the failing step in #1267

Closes #1267

---

This repo is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.
