### PR TITLE
Skip publishing pact tests if actor is dependabot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,7 @@ jobs:
       pact_artifact: pacts
 
   publish_pacts:
+    if: ${{ github.actor != 'dependabot[bot]' }}
     needs:
       - account_api_pact
       - asset_manager_pact


### PR DESCRIPTION
Dependabot does not have access to the secrets needed to publish pact tests, nor is there any need for pact tests to be published after a dependabot PR, as the tests won't have changed.

Therefore skipping this step when dependabot raises a PR.

[Trello card](https://trello.com/c/MHnkSggV)