### PR TITLE
Add "/support-tickets" support-api endpoint

### DIFF
--- a/lib/gds_api/support_api.rb
+++ b/lib/gds_api/support_api.rb
@@ -22,6 +22,24 @@ class GdsApi::SupportApi < GdsApi::Base
     post_json("#{endpoint}/anonymous-feedback/global-export-requests", global_export_request: request_details)
   end
 
+  # Raise a support ticket
+  # Makes a +POST+ request to support-api to create a new support ticket.
+  #
+  # @params params [Hash] Any attributes that relate to creating a new support ticket.
+
+  # @example
+  # SupportApi.raise_support_ticket(
+  #   subject: "Feedback for app",
+  #   tags: ["app_name"]
+  #   body: {
+  #     "User agent": "Safari",
+  #     "Details": "Ticket details go here.",
+  #   }
+  # )
+  def raise_support_ticket(params)
+    post_json("#{endpoint}/support-tickets", params)
+  end
+
   # Create a Page Improvement
   #
   # Makes a +POST+ request to the support api to create a Page Improvement.

--- a/lib/gds_api/test_helpers/support_api.rb
+++ b/lib/gds_api/test_helpers/support_api.rb
@@ -150,6 +150,12 @@ module GdsApi
           .to_return(status: 200, body: response_body.to_json)
       end
 
+      def stub_support_api_raise_support_ticket(params)
+        post_stub = stub_http_request(:post, "#{SUPPORT_API_ENDPOINT}/support-tickets")
+        post_stub.with(body: params)
+        post_stub.to_return(status: 201)
+      end
+
       def stub_any_support_api_call
         stub_request(:any, %r{\A#{SUPPORT_API_ENDPOINT}})
       end

--- a/test/support_api_test.rb
+++ b/test/support_api_test.rb
@@ -240,4 +240,15 @@ describe GdsApi::SupportApi do
       assert_requested(stub_get)
     end
   end
+
+  describe "POST /support-tickets" do
+    it "makes a POST request to the support API" do
+      params = { subject: "Feedback for app", tags: "app_name", details: "Ticket details go here." }
+      stub_post = stub_support_api_raise_support_ticket(params)
+
+      @api.raise_support_ticket(params)
+
+      assert_requested(stub_post)
+    end
+  end
 end


### PR DESCRIPTION
This new support-api endpoint will allow any app to raise a support ticket by passing the necessary parameters.

Trello card: https://trello.com/c/dPTgPUok/3495-add-raise-zendesk-ticket-feature-to-support-api-5

Related PR: https://github.com/alphagov/support-api/pull/956

This repo is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.
