### PR TITLE
Add Pact tests for Support API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+* Add Pact tests for support-api [PR](https://github.com/alphagov/gds-api-adapters/pull/1273).
+
 # 96.0.1
 
 * Update Pact specs to match the email-alert-api [PR](https://github.com/alphagov/email-alert-api/pull/2136)

--- a/lib/gds_api/support_api.rb
+++ b/lib/gds_api/support_api.rb
@@ -31,10 +31,8 @@ class GdsApi::SupportApi < GdsApi::Base
   # SupportApi.raise_support_ticket(
   #   subject: "Feedback for app",
   #   tags: ["app_name"]
-  #   body: {
-  #     "User agent": "Safari",
-  #     "Details": "Ticket details go here.",
-  #   }
+  #   user_agent: "Safari",
+  #   description: "Ticket details go here.",
   # )
   def raise_support_ticket(params)
     post_json("#{endpoint}/support-tickets", params)

--- a/lib/gds_api/test_helpers/support_api.rb
+++ b/lib/gds_api/test_helpers/support_api.rb
@@ -150,10 +150,16 @@ module GdsApi
           .to_return(status: 200, body: response_body.to_json)
       end
 
-      def stub_support_api_raise_support_ticket(params)
+      def stub_support_api_valid_raise_support_ticket(params)
         post_stub = stub_http_request(:post, "#{SUPPORT_API_ENDPOINT}/support-tickets")
         post_stub.with(body: params)
-        post_stub.to_return(status: 201)
+        post_stub.to_return(status: 201, body: { status: "success" }.to_json)
+      end
+
+      def stub_support_api_invalid_raise_support_ticket(params)
+        post_stub = stub_http_request(:post, "#{SUPPORT_API_ENDPOINT}/support-tickets")
+        post_stub.with(body: params)
+        post_stub.to_return(status: 422, body: { status: "error" }.to_json)
       end
 
       def stub_any_support_api_call

--- a/test/pacts/support_api_pact_test.rb
+++ b/test/pacts/support_api_pact_test.rb
@@ -1,0 +1,67 @@
+require "test_helper"
+require "gds_api/support_api"
+
+describe "GdsApi::SupportApi pact tests" do
+  include PactTest
+
+  describe "#raise_support_ticket" do
+    let(:api_client) { GdsApi::SupportApi.new(support_api_host) }
+
+    it "responds with a 201 Success if the parameters provided are valid" do
+      support_api
+        .given("the parameters are valid")
+        .upon_receiving("a raise ticket request")
+        .with(
+          method: :post,
+          path: "/support-tickets",
+          headers: GdsApi::JsonClient.default_request_with_json_body_headers,
+          body: {
+            subject: "Feedback for app",
+            tags: %w[app_name],
+            user_agent: "Safari",
+            description: "There is something wrong with this page.",
+          },
+        )
+        .will_respond_with(
+          status: 201,
+          body: {
+            status: "success",
+          },
+          headers: {
+            "Content-Type" => "application/json; charset=utf-8",
+          },
+        )
+
+      api_client.raise_support_ticket(
+        subject: "Feedback for app",
+        tags: %w[app_name],
+        user_agent: "Safari",
+        description: "There is something wrong with this page.",
+      )
+    end
+
+    it "responds with 422 Error when required parameters are not provided" do
+      support_api
+      .given("the required parameters are not provided")
+      .upon_receiving("a raise ticket request")
+      .with(
+        method: :post,
+        path: "/support-tickets",
+        headers: GdsApi::JsonClient.default_request_with_json_body_headers,
+        body: {
+          subject: "Ticket without body",
+        },
+      )
+      .will_respond_with(
+        status: 422,
+        body: {
+          status: "error",
+        },
+      )
+
+      assert_raises GdsApi::HTTPUnprocessableEntity do
+        api_client.raise_support_ticket(subject: "Ticket without body")
+      end
+    end
+  end
+end

--- a/test/support/pact_helper.rb
+++ b/test/support/pact_helper.rb
@@ -9,6 +9,7 @@ PLACES_MANAGER_API_PORT = 3006
 LOCATIONS_API_PORT = 3008
 ASSET_MANAGER_API_PORT = 3009
 EMAIL_ALERT_API_PORT = 3010
+SUPPORT_API_PORT = 3011
 
 def publishing_api_host
   "http://localhost:#{PUBLISHING_API_PORT}"
@@ -44,6 +45,10 @@ end
 
 def email_alert_api_host
   "http://localhost:#{EMAIL_ALERT_API_PORT}"
+end
+
+def support_api_host
+  "http://localhost:#{SUPPORT_API_PORT}"
 end
 
 Pact.service_consumer "GDS API Adapters" do
@@ -98,6 +103,12 @@ Pact.service_consumer "GDS API Adapters" do
   has_pact_with "Email Alert API" do
     mock_service :email_alert_api do
       port EMAIL_ALERT_API_PORT
+    end
+  end
+
+  has_pact_with "Support API" do
+    mock_service :support_api do
+      port SUPPORT_API_PORT
     end
   end
 end

--- a/test/support_api_test.rb
+++ b/test/support_api_test.rb
@@ -242,13 +242,28 @@ describe GdsApi::SupportApi do
   end
 
   describe "POST /support-tickets" do
-    it "makes a POST request to the support API" do
-      params = { subject: "Feedback for app", tags: "app_name", details: "Ticket details go here." }
-      stub_post = stub_support_api_raise_support_ticket(params)
+    it "makes a valid POST request to the support API" do
+      params = {
+        subject: "Feedback for app",
+        tags: "app_name",
+        user_agent: "Safari",
+        description: "There is something wrong with this page.",
+      }
+      stub_post = stub_support_api_valid_raise_support_ticket(params)
 
       @api.raise_support_ticket(params)
 
       assert_requested(stub_post)
+    end
+
+    it "makes an invalid POST request to the support API" do
+      params = { subject: "Ticket without body" }
+
+      stub_support_api_invalid_raise_support_ticket(params)
+
+      assert_raises GdsApi::HTTPUnprocessableEntity do
+        @api.raise_support_ticket(params)
+      end
     end
   end
 end


### PR DESCRIPTION
This follows the steps covered in the [Pact testing Developer docs](https://docs.publishing.service.gov.uk/manual/pact-testing.html) and has been tested locally.

Support API Pact provider branch: [add-pact-tests](https://github.com/alphagov/support-api/compare/add-pact-tests)

Provider PR: https://github.com/alphagov/support-api/pull/964

Trello card: https://trello.com/c/QBYirV6S/3494-add-pact-test-for-create-support-tickets-endpoint-5