### PR TITLE
Configure CI to run Pact tests with Support API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,12 @@ jobs:
     with:
       pact_artifact: pacts
 
+  support_api_pact:
+    needs: generate_pacts
+    uses: alphagov/support-api/.github/workflows/pact-verify.yml@main
+    with:
+      pact_artifact: pacts
+
   publish_pacts:
     if: ${{ github.actor != 'dependabot[bot]' }}
     needs:
@@ -123,6 +129,7 @@ jobs:
       - link_checker_api_pact
       - locations_api_pact
       - publishing_api_pact
+      - support_api_pact
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The GitHub action has been configured in the provider (support-api) and can now be called as part of CI to verify the provider contract when the consumer builds.

Depends on https://github.com/alphagov/support-api/pull/967, which defines the pact-verify workflow that this uses.

Related PRS:

- https://github.com/alphagov/support-api/pull/967
- https://github.com/alphagov/gds-api-adapters/pull/1273
- https://github.com/alphagov/support-api/pull/964

Trello card: https://trello.com/c/QBYirV6S/3494-add-pact-test-for-create-support-tickets-endpoint-5
