### PR TITLE
pin "rack" gem to v2.2

### DIFF
--- a/gds-api-adapters.gemspec
+++ b/gds-api-adapters.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency "link_header"
   s.add_dependency "null_logger"
   s.add_dependency "plek", ">= 1.9.0"
-  s.add_dependency "rack", ">= 2.2.0"
+  s.add_dependency "rack", "~> 2.2.0"
   s.add_dependency "rest-client", "~> 2.0"
 
   s.add_development_dependency "byebug"


### PR DESCRIPTION
The previous config allowed rack to be bumped to a higher version (e.g. 3) which introduced errors when running the tests [1] for CI (https://github.com/alphagov/gds-api-adapters/pull/1276) and for new users running locally.

This sets the version to no greater than 2.2 as a temporary fix to allow tests to pass, until updates can be made to fix the breaking changes.

[1] https://gds.slack.com/archives/C03D792LYJG/p1718295709926239?thread_ts=1718203657.261269&cid=C03D792LYJG

## more context

It looks like the error is thrown by pact_mock-service, which should have introduced compatibility with rack 3+ here https://github.com/pact-foundation/pact-mock_service/pull/146

Stu has raised an issue here https://github.com/pact-foundation/pact-mock_service/issues/151 