### PR TITLE
Release `96.0.2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Unreleased
+
+# 96.0.2
+
+* Add /schemas publishing api endpoints [PR](https://github.com/alphagov/gds-api-adapters/pull/1275).
 * Add Pact tests for support-api [PR](https://github.com/alphagov/gds-api-adapters/pull/1273).
 
 # 96.0.1

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = "96.0.1".freeze
+  VERSION = "96.0.2".freeze
 end


### PR DESCRIPTION
* Add /schemas publishing api endpoints [PR](https://github.com/alphagov/gds-api-adapters/pull/1275).
* Add Pact tests for support-api [PR](https://github.com/alphagov/gds-api-adapters/pull/1273).
