### PR TITLE
Endpoint for getting content that embeds a target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Add support for getting content with embeds from the Publishing API [PR](https://github.com/alphagov/gds-api-adapters/pull/1283)
+
 # 96.0.2
 
 * Add /schemas publishing api endpoints [PR](https://github.com/alphagov/gds-api-adapters/pull/1275).

--- a/lib/gds_api/publishing_api.rb
+++ b/lib/gds_api/publishing_api.rb
@@ -337,6 +337,22 @@ class GdsApi::PublishingApi < GdsApi::Base
     get_json("#{endpoint}/v2/content#{query}")
   end
 
+  # Get content items which embed a reusable content_id
+  #
+  # No params are currently permitted.
+  #
+  # @example
+  #
+  #   publishing_api.get_content_by_embedded_document("4b148ebc-b2bb-40db-8e48-dd8cff363ff7")
+  #
+  # @return [GdsApi::Response] A response containing a summarised list of the content items which embed the target.
+  # The content items returned will be in either the draft of published state.
+  #
+  # @see https://github.com/alphagov/publishing-api/blob/main/docs/api.md#get-v2contentcontent_idembedded
+  def get_content_by_embedded_document(content_id)
+    get_json("#{endpoint}/v2/content/#{content_id}/embedded")
+  end
+
   # Returns an Enumerator of content items for the provided
   # query string parameters.
   #

--- a/lib/gds_api/test_helpers/publishing_api.rb
+++ b/lib/gds_api/test_helpers/publishing_api.rb
@@ -340,6 +340,43 @@ module GdsApi
           .to_return(status: 200, body: body.to_json, headers: {})
       end
 
+      # Stub GET /v2/content/:content_id/embedded to return a list of content items that embed the target content_id
+      #
+      # @example
+      #
+      #   stub_publishing_api_has_content_(
+      #     content_id: "9faacf5c-f4e6-4bf9-ba90-413e997c1f22" # this is the content_id for a reusable edition
+      #     total: 1 # the number of results returned
+      #     results: [{
+      #       "title" => "foo",
+      #       "document_type" => "document",
+      #       "base_path" => "/foo",
+      #       "content_id" => "e60fae2a-5490-4e2f-9e80-2093c47608d4",
+      #       "primary_publishing_organisation" => {
+      #         "content_id" => "7662e1e7-79f9-4d0a-b754-6232186851f6",
+      #         "title" => "bar",
+      #         "base_path" => "/organisation/bar",
+      #       },
+      #     }] # an array of content items that embed the target content_id
+      #   )
+      # @param content_id [UUID, Mocha::ParameterMatchers::Anything]
+      # @param total Integer
+      # @param params [Hash]
+      def stub_publishing_api_has_embedded_content(content_id:, total: 0, results: [])
+        url = if content_id.is_a?(Mocha::ParameterMatchers::Anything)
+                %r{\A#{PUBLISHING_API_V2_ENDPOINT}/content/[0-9a-fA-F-]{36}/embedded}
+              else
+                "#{PUBLISHING_API_V2_ENDPOINT}/content/#{content_id}/embedded"
+              end
+
+        stub_request(:get, url)
+          .to_return(body: {
+            "content_id" => content_id,
+            "total" => total,
+            "results" => results,
+          }.to_json)
+      end
+
       # This method has been refactored into publishing_api_has_content (above)
       # publishing_api_has_content allows for flexible passing in of arguments, please use instead
       def stub_publishing_api_has_fields_for_document(document_type, items, fields)

--- a/test/pacts/publishing_api/get_embedded_content_pact_test.rb
+++ b/test/pacts/publishing_api/get_embedded_content_pact_test.rb
@@ -1,0 +1,66 @@
+require "test_helper"
+require "gds_api/publishing_api"
+
+describe "GdsApi::PublishingApi#get_content_by_embedded_document pact tests" do
+  include PactTest
+
+  let(:api_client) { GdsApi::PublishingApi.new(publishing_api_host) }
+
+  let(:reusable_content_id) { "bed722e6-db68-43e5-9079-063f623335a7" }
+  let(:content_id) { "d66d6552-2627-4451-9dbc-cadbbd2005a1" }
+  let(:publishing_organisation_content_id) { "d1e7d343-9844-4246-a469-1fa4640e12ad" }
+  let(:expected_body) do
+    {
+      "content_id" => reusable_content_id,
+      "total" => 1,
+      "results" => [
+        {
+          "title" => "foo",
+          "base_path" => "/foo",
+          "document_type" => "publication",
+          "primary_publishing_organisation" => {
+            "content_id" => publishing_organisation_content_id,
+            "title" => "bar",
+            "base_path" => "/bar",
+          },
+        },
+      ],
+    }
+  end
+
+  it "responds with 200 if the target content item exists" do
+    publishing_api
+      .given("a content item exists (content_id: #{content_id}) that embeds the reusable content (content_id: #{reusable_content_id})")
+      .upon_receiving("a get_content_by_embedded_document request")
+      .with(
+        method: :get,
+        path: "/v2/content/#{reusable_content_id}/embedded",
+      )
+      .will_respond_with(
+        status: 200,
+        body: expected_body,
+      )
+
+    response = api_client.get_content_by_embedded_document(reusable_content_id)
+
+    assert_equal(expected_body, response.parsed_content)
+  end
+
+  it "responds with 404 if the content item does not exist" do
+    missing_content_id = "missing-content-id"
+    publishing_api
+      .given("no content exists")
+      .upon_receiving("a get_content_by_embedded_document request")
+      .with(
+        method: :get,
+        path: "/v2/content/#{missing_content_id}/embedded",
+      )
+      .will_respond_with(
+        status: 404,
+      )
+
+    assert_raises(GdsApi::HTTPNotFound) do
+      api_client.get_content_by_embedded_document(missing_content_id)
+    end
+  end
+end


### PR DESCRIPTION
[We follow this guidance to set up some Pact consumer tests](https://docs.publishing.service.gov.uk/manual/pact-testing.html).

## Context 

We recently released this new endpoint in the Publishing API[1]. In order to see if it worked in a minimal way (as the only consumer of this endpoint) made a direct connection without an Adapter method[2]. 

We had hoped to test this endpoint worked with large quantities of data on Integration before introducing it to GDS API Adapters. Sadly we ran into connectivity issues on Integration when using Plek and NET::HTTP. Instead of investing more time in fixing that shortcut we are proposing this instead. In hindsight this should have gone in with the original work.

[1] https://github.com/alphagov/publishing-api/pull/2846
[2] https://github.com/alphagov/whitehall/pull/9378

## Local tests 

These Pact tests have been tested locally against [this branch of the Publishing API](https://github.com/alphagov/publishing-api/pull/2855) (which must be merged first):

![Screenshot 2024-08-28 at 12 32 30](https://github.com/user-attachments/assets/b1b8e912-2839-4482-a2c4-d69f12ed941b)


