### PR TITLE
Remove redirect type from router api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Remove ability to specify "temporary" redirects for Router API.
+
 # 96.0.3
 
 * Add support for getting content with embeds from the Publishing API [PR](https://github.com/alphagov/gds-api-adapters/pull/1283)

--- a/lib/gds_api/content_store.rb
+++ b/lib/gds_api/content_store.rb
@@ -53,7 +53,7 @@ private
               "#{Plek.new.website_root}#{destination_uri}"
             end
 
-      [url, status_code(redirect)]
+      [url, 301]
     end
 
     private_class_method :new
@@ -104,10 +104,6 @@ private
       uri.query = query if uri.query.nil? && !query.empty?
 
       uri.to_s
-    end
-
-    def status_code(redirect)
-      redirect["redirect_type"] == "temporary" ? 302 : 301
     end
   end
 

--- a/lib/gds_api/router.rb
+++ b/lib/gds_api/router.rb
@@ -33,7 +33,7 @@ class GdsApi::Router < GdsApi::Base
     )
   end
 
-  def add_redirect_route(path, type, destination, redirect_type = "permanent", options = {})
+  def add_redirect_route(path, type, destination, options = {})
     put_json(
       "#{endpoint}/routes",
       route: {
@@ -41,7 +41,6 @@ class GdsApi::Router < GdsApi::Base
         route_type: type,
         handler: "redirect",
         redirect_to: destination,
-        redirect_type:,
         segments_mode: options[:segments_mode],
       },
     )

--- a/lib/gds_api/test_helpers/router.rb
+++ b/lib/gds_api/test_helpers/router.rb
@@ -21,8 +21,8 @@ module GdsApi
         stub_router_has_route(path, handler: "backend", backend_id:, disabled:, route_type:)
       end
 
-      def stub_router_has_redirect_route(path, redirect_to:, redirect_type: "permanent", route_type: "exact", disabled: false)
-        stub_router_has_route(path, handler: "redirect", redirect_to:, redirect_type:, disabled:, route_type:)
+      def stub_router_has_redirect_route(path, redirect_to:, route_type: "exact", disabled: false)
+        stub_router_has_route(path, handler: "redirect", redirect_to:, disabled:, route_type:)
       end
 
       def stub_router_has_gone_route(path, route_type: "exact", disabled: false)
@@ -52,14 +52,13 @@ module GdsApi
         })
       end
 
-      def stub_redirect_registration(path, type, destination, redirect_type, segments_mode = nil)
+      def stub_redirect_registration(path, type, destination, segments_mode = nil)
         stub_route_put({
           route: {
             incoming_path: path,
             route_type: type,
             handler: "redirect",
             redirect_to: destination,
-            redirect_type:,
             segments_mode:,
           },
         })

--- a/test/content_store_test.rb
+++ b/test/content_store_test.rb
@@ -46,15 +46,13 @@ describe GdsApi::ContentStore do
       path:,
       destination: "/destination",
       type: "exact",
-      segments_mode: "ignore",
-      redirect_type: "permanent"
+      segments_mode: "ignore"
     )
       {
         "path" => path,
         "destination" => destination,
         "type" => type,
         "segments_mode" => segments_mode,
-        "redirect_type" => redirect_type,
       }
     end
 
@@ -94,22 +92,13 @@ describe GdsApi::ContentStore do
       assert_equal "https://example.com/b", destination
     end
 
-    it "includes a 301 status code for a permanent redirect" do
+    it "includes a 301 status code for a redirect" do
       @content_item["redirects"] = [
-        create_redirect(path: "/a", redirect_type: "permanent"),
+        create_redirect(path: "/a"),
       ]
 
       _, status_code = GdsApi::ContentStore.redirect_for_path(@content_item, "/a")
       assert_equal 301, status_code
-    end
-
-    it "includes a 301 status code for a temporary redirect" do
-      @content_item["redirects"] = [
-        create_redirect(path: "/a", redirect_type: "temporary"),
-      ]
-
-      _, status_code = GdsApi::ContentStore.redirect_for_path(@content_item, "/a")
-      assert_equal 302, status_code
     end
 
     it "returns an absolute URL redirect unmodified" do

--- a/test/router_test.rb
+++ b/test/router_test.rb
@@ -245,7 +245,6 @@ describe GdsApi::Router do
                        "route_type" => "exact",
                        "handler" => "redirect",
                        "redirect_to" => "/bar",
-                       "redirect_type" => "permanent",
                        "segments_mode" => nil }
         req = WebMock.stub_request(:put, "#{@base_api_url}/routes")
           .with(body: { "route" => route_data }.to_json)
@@ -258,36 +257,17 @@ describe GdsApi::Router do
         assert_requested(req)
       end
 
-      it "should allow creating/updating a temporary redirect route" do
-        route_data = { "incoming_path" => "/foo",
-                       "route_type" => "exact",
-                       "handler" => "redirect",
-                       "redirect_to" => "/bar",
-                       "redirect_type" => "temporary",
-                       "segments_mode" => nil }
-        req = WebMock.stub_request(:put, "#{@base_api_url}/routes")
-          .with(body: { "route" => route_data }.to_json)
-          .to_return(status: 201, body: route_data.to_json, headers: { "Content-type" => "application/json" })
-
-        response = @api.add_redirect_route("/foo", "exact", "/bar", "temporary")
-        assert_equal 201, response.code
-        assert_equal "/bar", response["redirect_to"]
-
-        assert_requested(req)
-      end
-
       it "should allow creating/updating a redirect route which preserves segments" do
         route_data = { "incoming_path" => "/foo",
                        "route_type" => "exact",
                        "handler" => "redirect",
                        "redirect_to" => "/bar",
-                       "redirect_type" => "temporary",
                        "segments_mode" => "preserve" }
         req = WebMock.stub_request(:put, "#{@base_api_url}/routes")
           .with(body: { "route" => route_data }.to_json)
           .to_return(status: 201, body: route_data.to_json, headers: { "Content-type" => "application/json" })
 
-        response = @api.add_redirect_route("/foo", "exact", "/bar", "temporary", segments_mode: "preserve")
+        response = @api.add_redirect_route("/foo", "exact", "/bar", segments_mode: "preserve")
         assert_equal 201, response.code
         assert_equal "/bar", response["redirect_to"]
 
@@ -299,7 +279,6 @@ describe GdsApi::Router do
                        "route_type" => "exact",
                        "handler" => "redirect",
                        "redirect_to" => "bar",
-                       "redirect_type" => "permanent",
                        "segments_mode" => nil }
         response_data = route_data.merge("errors" => { "redirect_to" => "is not a valid URL path" })
 


### PR DESCRIPTION
Router API has dropped support for temporary redirects, as they aren't a used feature.

