### PR TITLE
content-modelling/550 add publishing app to Host Content

### DIFF
--- a/test/pacts/publishing_api/get_embedded_content_pact_test.rb
+++ b/test/pacts/publishing_api/get_embedded_content_pact_test.rb
@@ -18,6 +18,7 @@ describe "GdsApi::PublishingApi#get_content_by_embedded_document pact tests" do
           "title" => "foo",
           "base_path" => "/foo",
           "document_type" => "publication",
+          "publishing_app" => "publisher",
           "primary_publishing_organisation" => {
             "content_id" => publishing_organisation_content_id,
             "title" => "bar",


### PR DESCRIPTION
This adds the field added in Publishing API here
https://github.com/alphagov/publishing-api/pull/2876

This repo is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.
