### PR TITLE
Add new args to `get_content_by_embedded_document`

### DIFF
--- a/lib/gds_api/publishing_api.rb
+++ b/lib/gds_api/publishing_api.rb
@@ -339,18 +339,21 @@ class GdsApi::PublishingApi < GdsApi::Base
 
   # Get content items which embed a reusable content_id
   #
-  # No params are currently permitted.
+  # @param content_id [UUID]
+  # @param params [Hash]
   #
-  # @example
-  #
-  #   publishing_api.get_content_by_embedded_document("4b148ebc-b2bb-40db-8e48-dd8cff363ff7")
+  #   publishing_api.get_content_by_embedded_document(
+  #     "4b148ebc-b2bb-40db-8e48-dd8cff363ff7",
+  #     { page: 1, order: '-last_edited_at' }
+  #   )
   #
   # @return [GdsApi::Response] A response containing a summarised list of the content items which embed the target.
   # The content items returned will be in either the draft of published state.
   #
   # @see https://github.com/alphagov/publishing-api/blob/main/docs/api.md#get-v2contentcontent_idembedded
-  def get_content_by_embedded_document(content_id)
-    get_json("#{endpoint}/v2/content/#{content_id}/embedded")
+  def get_content_by_embedded_document(content_id, params = {})
+    query = query_string(params)
+    get_json("#{endpoint}/v2/content/#{content_id}/embedded#{query}")
   end
 
   # Returns an Enumerator of content items for the provided

--- a/test/pacts/publishing_api/get_embedded_content_pact_test.rb
+++ b/test/pacts/publishing_api/get_embedded_content_pact_test.rb
@@ -47,6 +47,44 @@ describe "GdsApi::PublishingApi#get_content_by_embedded_document pact tests" do
     assert_equal(expected_body, response.parsed_content)
   end
 
+  it "supports pagination" do
+    publishing_api
+      .given("a content item exists (content_id: #{content_id}) that embeds the reusable content (content_id: #{reusable_content_id})")
+      .upon_receiving("a get_content_by_embedded_document request with pagination")
+      .with(
+        method: :get,
+        path: "/v2/content/#{reusable_content_id}/embedded",
+        query: "page=2",
+      )
+      .will_respond_with(
+        status: 200,
+        body: expected_body,
+      )
+
+    response = api_client.get_content_by_embedded_document(reusable_content_id, { page: 2 })
+
+    assert_equal(expected_body, response.parsed_content)
+  end
+
+  it "supports sorting" do
+    publishing_api
+      .given("a content item exists (content_id: #{content_id}) that embeds the reusable content (content_id: #{reusable_content_id})")
+      .upon_receiving("a get_content_by_embedded_document request with sorting")
+      .with(
+        method: :get,
+        path: "/v2/content/#{reusable_content_id}/embedded",
+        query: "order=-last_edited_at",
+      )
+      .will_respond_with(
+        status: 200,
+        body: expected_body,
+      )
+
+    response = api_client.get_content_by_embedded_document(reusable_content_id, { order: "-last_edited_at" })
+
+    assert_equal(expected_body, response.parsed_content)
+  end
+
   it "responds with 404 if the content item does not exist" do
     missing_content_id = "missing-content-id"
     publishing_api


### PR DESCRIPTION
This allows the endpoint to support pagination and sorting, as added in https://github.com/alphagov/publishing-api/pull/2975