### PR TITLE
Search API v2: Add adapter for autocomplete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Add autocomplete endpoint for Search API v2 [PR](https://github.com/alphagov/gds-api-adapters/pull/1292)
+
 ## 97.2.0
 
 *  Add page and order args to get_content_by_embedded_document [PR](https://github.com/alphagov/gds-api-adapters/pull/1291)

--- a/lib/gds_api/search_api_v2.rb
+++ b/lib/gds_api/search_api_v2.rb
@@ -4,5 +4,11 @@ module GdsApi
       request_url = "#{endpoint}/search.json?#{Rack::Utils.build_nested_query(args)}"
       get_json(request_url, additional_headers)
     end
+
+    def autocomplete(query)
+      args = { q: query }
+      request_url = "#{endpoint}/autocomplete.json?#{Rack::Utils.build_nested_query(args)}"
+      get_json(request_url)
+    end
   end
 end

--- a/test/search_api_v2_test.rb
+++ b/test/search_api_v2_test.rb
@@ -2,79 +2,74 @@ require "test_helper"
 require "gds_api/search_api_v2"
 
 describe GdsApi::SearchApiV2 do
-  before(:each) do
-    stub_request(:get, /example.com\/search/).to_return(body: "[]")
-  end
+  describe "#search" do
+    before(:each) do
+      stub_request(:get, /example.com\/search/).to_return(body: "[]")
+    end
 
-  it "#search should raise an exception if the service at the search URI returns a 500" do
-    stub_request(:get, /example.com\/search.json/).to_return(status: [500, "Internal Server Error"])
-    assert_raises(GdsApi::HTTPServerError) do
+    it "should raise an exception if the request is unsuccessful" do
+      stub_request(:get, /example.com\/search.json/).to_return(status: [500, "Internal Server Error"])
+      assert_raises(GdsApi::HTTPServerError) do
+        GdsApi::SearchApiV2.new("http://example.com").search(q: "query")
+      end
+    end
+
+    it "should return the search deserialized from json" do
+      search_results = [{ "title" => "document-title" }]
+      stub_request(:get, /example.com\/search/).to_return(body: search_results.to_json)
+      results = GdsApi::SearchApiV2.new("http://example.com").search(q: "query")
+      assert_equal search_results, results.to_hash
+    end
+
+    it "should request the search results in JSON format" do
       GdsApi::SearchApiV2.new("http://example.com").search(q: "query")
+
+      assert_requested :get, /.*/, headers: { "Accept" => "application/json" }
+    end
+
+    it "should issue a request for all the params supplied" do
+      GdsApi::SearchApiV2.new("http://example.com").search(
+        q: "query & stuff",
+        filter_topics: %w[1 2],
+        order: "-public_timestamp",
+      )
+
+      assert_requested :get, /q=query%20%26%20stuff/
+      assert_requested :get, /filter_topics\[\]=1&filter_topics\[\]=2/
+      assert_requested :get, /order=-public_timestamp/
+    end
+
+    it "can pass additional headers" do
+      GdsApi::SearchApiV2.new("http://example.com").search({ q: "query" }, "authorization" => "token")
+
+      assert_requested :get, /.*/, headers: { "authorization" => "token" }
     end
   end
 
-  it "#search should raise an exception if the service at the search URI returns a 404" do
-    stub_request(:get, /example.com\/search/).to_return(status: [404, "Not Found"])
-    assert_raises(GdsApi::HTTPNotFound) do
-      GdsApi::SearchApiV2.new("http://example.com").search(q: "query")
+  describe "#autocomplete" do
+    before(:each) do
+      stub_request(:get, /example.com\/autocomplete/).to_return(body: "[]")
     end
-  end
 
-  it "#search should raise an exception if the service at the search URI returns a 400" do
-    stub_request(:get, /example.com\/search/).to_return(
-      status: [400, "Bad Request"],
-      body: '"error":"Filtering by \"coffee\" is not allowed"',
-    )
-    assert_raises(GdsApi::HTTPClientError) do
-      GdsApi::SearchApiV2.new("http://example.com").search(q: "query", filter_coffee: "tea")
+    it "should raise an exception if the request is unsuccessful" do
+      stub_request(:get, /example.com\/autocomplete.json/).to_return(
+        status: [500, "Internal Server Error"],
+      )
+      assert_raises(GdsApi::HTTPServerError) do
+        GdsApi::SearchApiV2.new("http://example.com").autocomplete("prime minis")
+      end
     end
-  end
 
-  it "#search should raise an exception if the service at the search URI returns a 422" do
-    stub_request(:get, /example.com\/search/).to_return(
-      status: [422, "Bad Request"],
-      body: '"error":"Filtering by \"coffee\" is not allowed"',
-    )
-    assert_raises(GdsApi::HTTPUnprocessableEntity) do
-      GdsApi::SearchApiV2.new("http://example.com").search(q: "query", filter_coffee: "tea")
+    it "should request the autocomplete results in JSON format" do
+      GdsApi::SearchApiV2.new("http://example.com").autocomplete("prime minis")
+
+      assert_requested :get, /.*/, headers: { "Accept" => "application/json" }
     end
-  end
 
-  it "#search should raise an exception if the service at the search URI times out" do
-    stub_request(:get, /example.com\/search/).to_timeout
-    assert_raises(GdsApi::TimedOutException) do
-      GdsApi::SearchApiV2.new("http://example.com").search(q: "query")
+    it "should issue a request for the correct query" do
+      GdsApi::SearchApiV2.new("http://example.com").autocomplete("prime minis")
+
+      assert_requested :get, /q=prime%20minis/
     end
-  end
-
-  it "#search should return the search deserialized from json" do
-    search_results = [{ "title" => "document-title" }]
-    stub_request(:get, /example.com\/search/).to_return(body: search_results.to_json)
-    results = GdsApi::SearchApiV2.new("http://example.com").search(q: "query")
-    assert_equal search_results, results.to_hash
-  end
-
-  it "#search should request the search results in JSON format" do
-    GdsApi::SearchApiV2.new("http://example.com").search(q: "query")
-
-    assert_requested :get, /.*/, headers: { "Accept" => "application/json" }
-  end
-
-  it "#search should issue a request for all the params supplied" do
-    GdsApi::SearchApiV2.new("http://example.com").search(
-      q: "query & stuff",
-      filter_topics: %w[1 2],
-      order: "-public_timestamp",
-    )
-
-    assert_requested :get, /q=query%20%26%20stuff/
-    assert_requested :get, /filter_topics\[\]=1&filter_topics\[\]=2/
-    assert_requested :get, /order=-public_timestamp/
-  end
-
-  it "#search can pass additional headers" do
-    GdsApi::SearchApiV2.new("http://example.com").search({ q: "query" }, "authorization" => "token")
-
-    assert_requested :get, /.*/, headers: { "authorization" => "token" }
   end
 end


### PR DESCRIPTION
This brings #1282 back around now that we have decided not to expose Search API v2's autocomplete endpoint publicly, and need to access it from Finder Frontend.

This adds a method for the new autocomplete functionality to Search API v2's API adapter.

- Add `SearchApiV2#autocomplete`
- Remove redundant error scenario tests to avoid tests bloating up too much