### PR TITLE
Release 97.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## Unreleased
+## 97.2.0
 
-*  Add new args to get_content_by_embedded_document [PR](https://github.com/alphagov/gds-api-adapters/pull/1291)
+*  Add page and order args to get_content_by_embedded_document [PR](https://github.com/alphagov/gds-api-adapters/pull/1291)
 
 ## 97.1.0
 

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = "97.1.0".freeze
+  VERSION = "97.2.0".freeze
 end


### PR DESCRIPTION
*  Add new args to get_content_by_embedded_document [PR](https://github.com/alphagov/gds-api-adapters/pull/1291)

