### PR TITLE
Add page and order args to embedded content helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## Unreleased
+## 97.3.0
 
+* Add page and order args to get_content_by_embedded_document test helper [PR](https://github.com/alphagov/gds-api-adapters/pull/1295)
 * Add autocomplete endpoint for Search API v2 [PR](https://github.com/alphagov/gds-api-adapters/pull/1292)
 
 ## 97.2.0

--- a/lib/gds_api/test_helpers/publishing_api.rb
+++ b/lib/gds_api/test_helpers/publishing_api.rb
@@ -376,16 +376,36 @@ module GdsApi
       # @param total Integer
       # @param total_pages Integer
       # @param results [Hash]
-      def stub_publishing_api_has_embedded_content(content_id:, total: 0, total_pages: 0, results: [])
-        url = if content_id.is_a?(Mocha::ParameterMatchers::Anything)
-                %r{\A#{PUBLISHING_API_V2_ENDPOINT}/content/[0-9a-fA-F-]{36}/embedded}
-              else
-                "#{PUBLISHING_API_V2_ENDPOINT}/content/#{content_id}/embedded"
-              end
+      def stub_publishing_api_has_embedded_content(content_id:, total: 0, total_pages: 0, results: [], page_number: nil, order: nil)
+        url = "#{PUBLISHING_API_V2_ENDPOINT}/content/#{content_id}/embedded"
+
+        query = {
+          "page" => page_number,
+          "order" => order,
+        }.compact
 
         stub_request(:get, url)
+          .with(query:)
           .to_return(body: {
             "content_id" => content_id,
+            "total" => total,
+            "total_pages" => total_pages,
+            "results" => results,
+          }.to_json)
+      end
+
+      def stub_publishing_api_has_embedded_content_for_any_content_id(total: 0, total_pages: 0, results: [], page_number: nil, order: nil)
+        url = %r{\A#{PUBLISHING_API_V2_ENDPOINT}/content/[0-9a-fA-F-]{36}/embedded}
+
+        query = {
+          "page" => page_number,
+          "order" => order,
+        }.compact
+
+        stub_request(:get, url)
+          .with { |request| WebMock::Util::QueryMapper.query_to_values(request.uri.query) == query }
+          .to_return(body: {
+            "content_id" => SecureRandom.uuid,
             "total" => total,
             "total_pages" => total_pages,
             "results" => results,

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = "97.2.0".freeze
+  VERSION = "97.3.0".freeze
 end


### PR DESCRIPTION
This improves the `stub_publishing_api_has_embedded_content` helper to allow us to mock requests with a query string. I've added a new `stub_publishing_api_has_embedded_content_for_any_content_id` helper rather than checking if `content_id` is `anything`, because the way we match query strings when a url is a regex is slightly different.
