### PR TITLE
Release 97.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## Unreleased
+## 97.4.0
 
+* Update dependencies
 * Rename `get_content_by_embedded_document` and call renamed endpoint [PR](https://github.com/alphagov/gds-api-adapters/pull/1298)
 
 ## 97.3.0

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = "97.3.0".freeze
+  VERSION = "97.4.0".freeze
 end


### PR DESCRIPTION
* Update dependencies
* Rename `get_content_by_embedded_document` and call renamed endpoint [PR](https://github.com/alphagov/gds-api-adapters/pull/1298)