### PR TITLE
(700) Add rollup data to host content endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Add rollup data to host content endpoint [PR](https://github.com/alphagov/gds-api-adapters/pull/1300)
+
 ## 97.4.0
 
 * Update dependencies

--- a/lib/gds_api/test_helpers/publishing_api.rb
+++ b/lib/gds_api/test_helpers/publishing_api.rb
@@ -392,7 +392,7 @@ module GdsApi
         order: nil,
         rollup: {}
       )
-        url = "#{PUBLISHING_API_V2_ENDPOINT}/content/#{content_id}/embedded"
+        url = "#{PUBLISHING_API_V2_ENDPOINT}/content/#{content_id}/host-content"
 
         query = {
           "page" => page_number,
@@ -418,7 +418,7 @@ module GdsApi
         order: nil,
         rollup: {}
       )
-        url = %r{\A#{PUBLISHING_API_V2_ENDPOINT}/content/[0-9a-fA-F-]{36}/embedded}
+        url = %r{\A#{PUBLISHING_API_V2_ENDPOINT}/content/[0-9a-fA-F-]{36}/host-content}
 
         query = {
           "page" => page_number,

--- a/lib/gds_api/test_helpers/publishing_api.rb
+++ b/lib/gds_api/test_helpers/publishing_api.rb
@@ -371,12 +371,27 @@ module GdsApi
       #         "base_path" => "/organisation/bar",
       #       },
       #     }] # an array of content items that embed the target content_id
+      #     rollup: {
+      #       "views" => 1
+      #       "locations" => 1
+      #       "instances" => 1
+      #       "organisations" => 1
+      #     } # metadata with the total counts across all pages
       #   )
-      # @param content_id [UUID, Mocha::ParameterMatchers::Anything]
+      # @param content_id [UUID]
       # @param total Integer
       # @param total_pages Integer
-      # @param results [Hash]
-      def stub_publishing_api_has_embedded_content(content_id:, total: 0, total_pages: 0, results: [], page_number: nil, order: nil)
+      # @param results [Array]
+      # @param rollup [Hash]
+      def stub_publishing_api_has_embedded_content(
+        content_id:,
+        total: 0,
+        total_pages: 0,
+        results: [],
+        page_number: nil,
+        order: nil,
+        rollup: {}
+      )
         url = "#{PUBLISHING_API_V2_ENDPOINT}/content/#{content_id}/embedded"
 
         query = {
@@ -390,11 +405,19 @@ module GdsApi
             "content_id" => content_id,
             "total" => total,
             "total_pages" => total_pages,
+            "rollup" => rollup,
             "results" => results,
           }.to_json)
       end
 
-      def stub_publishing_api_has_embedded_content_for_any_content_id(total: 0, total_pages: 0, results: [], page_number: nil, order: nil)
+      def stub_publishing_api_has_embedded_content_for_any_content_id(
+        total: 0,
+        total_pages: 0,
+        results: [],
+        page_number: nil,
+        order: nil,
+        rollup: {}
+      )
         url = %r{\A#{PUBLISHING_API_V2_ENDPOINT}/content/[0-9a-fA-F-]{36}/embedded}
 
         query = {
@@ -408,6 +431,7 @@ module GdsApi
             "content_id" => SecureRandom.uuid,
             "total" => total,
             "total_pages" => total_pages,
+            "rollup" => rollup,
             "results" => results,
           }.to_json)
       end

--- a/test/pacts/publishing_api/get_embedded_content_pact_test.rb
+++ b/test/pacts/publishing_api/get_embedded_content_pact_test.rb
@@ -22,11 +22,20 @@ describe "GdsApi::PublishingApi#get_host_content_for_content_id pact tests" do
       },
     }
   end
+  let(:rollup) do
+    {
+      "views" => 0,
+      "locations" => 1,
+      "instances" => 1,
+      "organisations" => 1,
+    }
+  end
   let(:expected_body) do
     {
       "content_id" => reusable_content_id,
       "total" => 1,
       "results" => [result],
+      "rollup" => rollup,
     }
   end
 


### PR DESCRIPTION
This adds the rollup data to our host-content endpoint related helpers, as well as updating some of the Pact tests