### PR TITLE
Release 97.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 97.4.1
 
 * Add rollup data to host content endpoint [PR](https://github.com/alphagov/gds-api-adapters/pull/1300)
 

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = "97.4.0".freeze
+  VERSION = "97.4.1".freeze
 end


### PR DESCRIPTION
* Add rollup data to host content endpoint [PR](https://github.com/alphagov/gds-api-adapters/pull/1300)