### PR TITLE
Return GraphQL response as `GdsApi::Response`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 97.5.0
+
+* Return response to GraphQL endpoint as `GdsApi::Response` instead of `Hash` [PR](https://github.com/alphagov/gds-api-adapters/pull/1304).
+
 ## 97.4.1
 
 * Add rollup data to host content endpoint [PR](https://github.com/alphagov/gds-api-adapters/pull/1300)

--- a/lib/gds_api/publishing_api.rb
+++ b/lib/gds_api/publishing_api.rb
@@ -562,9 +562,9 @@ class GdsApi::PublishingApi < GdsApi::Base
   #
   # @param query [String]
   #
-  # @return [Hash] A response with the result of the GraphQL query.
+  # @return [GdsApi::Response] A response with the result of the GraphQL query.
   def graphql_query(query)
-    post_json("#{endpoint}/graphql", query:).to_hash
+    post_json("#{endpoint}/graphql", query:)
   end
 
 private

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = "97.4.1".freeze
+  VERSION = "97.5.0".freeze
 end

--- a/test/test_helpers/publishing_api_test.rb
+++ b/test/test_helpers/publishing_api_test.rb
@@ -632,7 +632,7 @@ describe GdsApi::TestHelpers::PublishingApi do
 
       assert_equal(
         stubbed_response.to_json,
-        api_response.to_json,
+        api_response.raw_response_body,
       )
     end
   end


### PR DESCRIPTION
This is instead of `Hash`.

In Government Frontend, we need some other information from the request response (e.g. the cache control headers) which are not included when the response is converted to a hash.

This is not a breaking change as the new object type accepts the same methods as the hash.

[Trello card](https://trello.com/c/RMkMvY8b)