### PR TITLE
Add a method to fetch a single host content item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Add a method to fetch a single host content item [PR](https://github.com/alphagov/gds-api-adapters/pull/1306)
+
 ## 97.5.0
 
 * Return response to GraphQL endpoint as `GdsApi::Response` instead of `Hash` [PR](https://github.com/alphagov/gds-api-adapters/pull/1304).

--- a/lib/gds_api/publishing_api.rb
+++ b/lib/gds_api/publishing_api.rb
@@ -356,6 +356,23 @@ class GdsApi::PublishingApi < GdsApi::Base
     get_json("#{endpoint}/v2/content/#{content_id}/host-content#{query}")
   end
 
+  # Get a specific content item which embeds a reusable content_id
+  #
+  # @param content_id [UUID]
+  # @param host_content_id [UUID]
+  #
+  #   publishing_api.get_host_content_item_for_content_id(
+  #     "4b148ebc-b2bb-40db-8e48-dd8cff363ff7",
+  #     "10d91dd1-cc9d-4c4c-9540-219ebb8d4501",
+  #   )
+  #
+  # @return [GdsApi::Response] A response containing the content item which embeds the target.
+  #
+  # @see https://github.com/alphagov/publishing-api/blob/main/docs/api.md#get-v2contentcontent_idhost-contenthost_content_id
+  def get_host_content_item_for_content_id(content_id, host_content_id)
+    get_json("#{endpoint}/v2/content/#{content_id}/host-content/#{host_content_id}")
+  end
+
   def get_content_by_embedded_document(content_id, params = {})
     warn "GdsAPI::PublishingApi: #get_content_by_embedded_document deprecated (please use #get_host_content_for_content_id)"
     get_host_content_for_content_id(content_id, params)

--- a/test/pacts/publishing_api/get_host_content_item_for_content_id_pact_test.rb
+++ b/test/pacts/publishing_api/get_host_content_item_for_content_id_pact_test.rb
@@ -1,0 +1,79 @@
+require "test_helper"
+require "gds_api/publishing_api"
+
+describe "GdsApi::PublishingApi#get_host_content_item_for_content_id pact tests" do
+  include PactTest
+
+  let(:api_client) { GdsApi::PublishingApi.new(publishing_api_host) }
+
+  let(:reusable_content_id) { "bed722e6-db68-43e5-9079-063f623335a7" }
+  let(:content_id) { "d66d6552-2627-4451-9dbc-cadbbd2005a1" }
+  let(:publishing_organisation_content_id) { "d1e7d343-9844-4246-a469-1fa4640e12ad" }
+  let(:expected_body) do
+    {
+      "title" => "foo",
+      "base_path" => "/foo",
+      "document_type" => "publication",
+      "publishing_app" => "publisher",
+      "primary_publishing_organisation" => {
+        "content_id" => publishing_organisation_content_id,
+        "title" => "bar",
+        "base_path" => "/bar",
+      },
+    }
+  end
+
+  it "responds with 200 if the target content item exists" do
+    publishing_api
+      .given("a content item exists (content_id: #{content_id}) that embeds the reusable content (content_id: #{reusable_content_id})")
+      .upon_receiving("a get_host_content_item_for_content_id request")
+      .with(
+        method: :get,
+        path: "/v2/content/#{reusable_content_id}/host-content/#{content_id}",
+      )
+      .will_respond_with(
+        status: 200,
+        body: expected_body,
+      )
+
+    response = api_client.get_host_content_item_for_content_id(reusable_content_id, content_id)
+
+    assert_equal(expected_body, response.parsed_content)
+  end
+
+  it "responds with 404 if the content item does not exist" do
+    missing_content_id = "missing-content-id"
+    publishing_api
+      .given("no content exists")
+      .upon_receiving("a get_host_content_item_for_content_id request with a missing content ID")
+      .with(
+        method: :get,
+        path: "/v2/content/#{reusable_content_id}/host-content/#{missing_content_id}",
+      )
+      .will_respond_with(
+        status: 404,
+      )
+
+    assert_raises(GdsApi::HTTPNotFound) do
+      api_client.get_host_content_item_for_content_id(reusable_content_id, missing_content_id)
+    end
+  end
+
+  it "responds with 404 if the host content item does not exist" do
+    missing_content_id = "missing-content-id"
+    publishing_api
+      .given("no content exists")
+      .upon_receiving("a get_host_content_item_for_content_id request with a missing host content ID")
+      .with(
+        method: :get,
+        path: "/v2/content/#{missing_content_id}/host-content/#{content_id}",
+      )
+      .will_respond_with(
+        status: 404,
+      )
+
+    assert_raises(GdsApi::HTTPNotFound) do
+      api_client.get_host_content_item_for_content_id(missing_content_id, content_id)
+    end
+  end
+end


### PR DESCRIPTION
Trello card: https://trello.com/c/WZvzmuMI/763-bug-mainstream-preview-bug-within-guide-chapters

This builds on https://github.com/alphagov/publishing-api/pull/3030 to fetch a single item of embedded content
