### PR TITLE
Return GraphQL responses with underscore keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Changelog
 
-## Unreleased
+## 98.0.0
 
 * BREAKING: Transform keys in Publishing API GraphQL responses to have underscore keys [PR](https://github.com/alphagov/gds-api-adapters/pull/1310).
-* Remove router-api [PR](https://github.com/alphagov/gds-api-adapters/pull/1308)
+* BREAKING: Remove Router API methods [PR](https://github.com/alphagov/gds-api-adapters/pull/1308).
 
 ## 97.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* BREAKING: Transform keys in Publishing API GraphQL responses to have underscore keys [PR](https://github.com/alphagov/gds-api-adapters/pull/1310).
 * Remove router-api [PR](https://github.com/alphagov/gds-api-adapters/pull/1308)
 
 ## 97.6.0

--- a/gds-api-adapters.gemspec
+++ b/gds-api-adapters.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 3.1"
   s.files        = Dir.glob("lib/**/*") + Dir.glob("test/fixtures/**/*") + %w[README.md Rakefile]
   s.require_path = "lib"
+  s.add_dependency "activesupport"
   s.add_dependency "addressable"
   s.add_dependency "link_header"
   s.add_dependency "null_logger"

--- a/lib/gds_api/publishing_api.rb
+++ b/lib/gds_api/publishing_api.rb
@@ -579,9 +579,11 @@ class GdsApi::PublishingApi < GdsApi::Base
   #
   # @param query [String]
   #
-  # @return [GdsApi::Response] A response with the result of the GraphQL query.
+  # @return [GdsApi::Response] A response with the result of the GraphQL query whose keys are changed to be underscored.
   def graphql_query(query)
-    post_json("#{endpoint}/graphql", query:)
+    response = post_json("#{endpoint}/graphql", query:)
+    response.stringify_keys
+    response
   end
 
 private

--- a/lib/gds_api/response.rb
+++ b/lib/gds_api/response.rb
@@ -153,6 +153,19 @@ module GdsApi
       false
     end
 
+    def stringify_keys
+      require "active_support/core_ext/hash/keys"
+      require "active_support/core_ext/string/inflections"
+
+      updated_response = JSON.parse(@http_response.body).dig("data", "edition").deep_transform_keys(&:underscore)
+
+      @http_response = RestClient::Response.create(
+        updated_response.to_json,
+        @http_response.net_http_res,
+        @http_response.request,
+      )
+    end
+
   private
 
     def transform_parsed(value)

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = "97.6.0".freeze
+  VERSION = "98.0.0".freeze
 end

--- a/test/test_helpers/publishing_api_test.rb
+++ b/test/test_helpers/publishing_api_test.rb
@@ -612,15 +612,21 @@ describe GdsApi::TestHelpers::PublishingApi do
   end
 
   describe "#stub_publishing_api_graphql_query" do
-    it "returns the given response" do
+    it "returns the given response with underscored keys" do
       query = "some query"
 
       stubbed_response = {
         data: {
           edition: {
             title: "some title",
+            camelCasedField: "value",
           },
         },
+      }
+
+      expected_response = {
+        title: "some title",
+        camel_cased_field: "value",
       }
 
       stub_publishing_api_graphql_query(
@@ -631,7 +637,7 @@ describe GdsApi::TestHelpers::PublishingApi do
       api_response = publishing_api.graphql_query(query)
 
       assert_equal(
-        stubbed_response.to_json,
+        expected_response.to_json,
         api_response.raw_response_body,
       )
     end


### PR DESCRIPTION
Publishing API returns GraphQL responses with camel cased keys. However we use underscored keys in our applications.

Therefore transforming the keys here, so the same does not need to be duplicated in every consuming application.

[Trello card](https://trello.com/c/RMkMvY8b)