### PR TITLE
Release 98.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## Unreleased
+## 98.0.0
 
-* Remove router-api [PR](https://github.com/alphagov/gds-api-adapters/pull/1308)
+* BREAKING: Remove Router API methods [PR](https://github.com/alphagov/gds-api-adapters/pull/1308)
 * Add a method to get events for a Content ID [PR](https://github.com/alphagov/gds-api-adapters/pull/1309)
 
 ## 97.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Remove router-api [PR](https://github.com/alphagov/gds-api-adapters/pull/1308)
+* Add a method to get events for a Content ID [PR](https://github.com/alphagov/gds-api-adapters/pull/1309)
 
 ## 97.6.0
 

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = "97.6.0".freeze
+  VERSION = "98.0.0".freeze
 end


### PR DESCRIPTION
* Remove Router API methods [PR](https://github.com/alphagov/gds-api-adapters/pull/1308)
* Add a method to get events for a Content ID [PR](https://github.com/alphagov/gds-api-adapters/pull/1309)

