### PR TITLE
Use snake cased GraphQL argument

### DIFF
--- a/test/pacts/publishing_api/graphql_query_pact_test.rb
+++ b/test/pacts/publishing_api/graphql_query_pact_test.rb
@@ -9,7 +9,7 @@ describe "GdsApi::PublishingApi#graphql_query pact tests" do
   it "returns the response to the query" do
     query = <<~QUERY
       {
-        edition(basePath: "/my-document") {
+        edition(base_path: "/my-document") {
           ... on Edition {
             title
           }


### PR DESCRIPTION
Publishing API has switched to use snake cased fields and arguments for GraphQL queries in https://github.com/alphagov/publishing-api/pull/3049.

This updates the pact test to reflect this.

[Trello card](https://trello.com/c/RMkMvY8b)