### PR TITLE
Add method to get GraphQL responses in content item format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 98.1.0
 
 * Add method to get GraphQL responses in a similar format to Content Store content items [PR](https://github.com/alphagov/gds-api-adapters/pull/1314).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Add method to get GraphQL responses in a similar format to Content Store content items [PR](https://github.com/alphagov/gds-api-adapters/pull/1314).
+
 ## 98.0.0
 
 * BREAKING: Remove Router API methods [PR](https://github.com/alphagov/gds-api-adapters/pull/1308)

--- a/lib/gds_api/json_client.rb
+++ b/lib/gds_api/json_client.rb
@@ -52,8 +52,8 @@ module GdsApi
       do_json_request(:get, url, nil, additional_headers, &create_response)
     end
 
-    def post_json(url, params = {}, additional_headers = {})
-      do_json_request(:post, url, params, additional_headers)
+    def post_json(url, params = {}, additional_headers = {}, &create_response)
+      do_json_request(:post, url, params, additional_headers, &create_response)
     end
 
     def put_json(url, params, additional_headers = {})

--- a/lib/gds_api/publishing_api.rb
+++ b/lib/gds_api/publishing_api.rb
@@ -602,6 +602,25 @@ class GdsApi::PublishingApi < GdsApi::Base
     post_json("#{endpoint}/graphql", query:)
   end
 
+  # Make a GraphQL query and return the response in the same format as a Content Store content item
+  #
+  # @param query [String]
+  #
+  # @return [GdsApi::Response] A response with the result of the GraphQL query formatted like a Content Store content item.
+  def graphql_content_item(query)
+    create_response = proc do |r|
+      updated_body = JSON.parse(r.body).dig("data", "edition")
+      updated_response = RestClient::Response.create(
+        updated_body.to_json,
+        r.net_http_res,
+        r.request,
+      )
+      GdsApi::Response.new(updated_response)
+    end
+
+    post_json("#{endpoint}/graphql", query:, &create_response)
+  end
+
 private
 
   def content_url(content_id, params = {})

--- a/lib/gds_api/test_helpers/publishing_api.rb
+++ b/lib/gds_api/test_helpers/publishing_api.rb
@@ -201,6 +201,19 @@ module GdsApi
         stub_request(:post, url).with(body: { query: }).to_return(response)
       end
 
+      # Stub a POST /graphql content item request
+      #
+      # @param query [String]
+      def stub_publishing_api_graphql_content_item(query, response_hash = {})
+        url = "#{PUBLISHING_API_ENDPOINT}/graphql"
+        response = {
+          status: 200,
+          body: response_hash.to_json,
+          headers: { "Content-Type" => "application/json; charset=utf-8" },
+        }
+        stub_request(:post, url).with(body: { query: }).to_return(response)
+      end
+
       # Assert that a draft was saved and published, and links were updated.
       # - PUT /v2/content/:content_id
       # - POST /v2/content/:content_id/publish

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = "98.0.0".freeze
+  VERSION = "98.1.0".freeze
 end

--- a/test/test_helpers/publishing_api_test.rb
+++ b/test/test_helpers/publishing_api_test.rb
@@ -637,6 +637,36 @@ describe GdsApi::TestHelpers::PublishingApi do
     end
   end
 
+  describe "#stub_publishing_api_graphql_content_item" do
+    it "returns the given response" do
+      query = "some query"
+
+      stubbed_response = {
+        data: {
+          edition: {
+            title: "some title",
+          },
+        },
+      }
+
+      expected_response = {
+        title: "some title",
+      }
+
+      stub_publishing_api_graphql_content_item(
+        query,
+        stubbed_response,
+      )
+
+      api_response = publishing_api.graphql_content_item(query)
+
+      assert_equal(
+        expected_response.to_json,
+        api_response.raw_response_body,
+      )
+    end
+  end
+
   describe "#request_json_matching predicate" do
     describe "nested required attribute" do
       let(:matcher) { request_json_matching("a" => { "b" => 1 }) }


### PR DESCRIPTION
This will allow us to use GraphQL responses in Government Frontend with few changes to the frontend application, as it expects a `GdsApi::Response` object in the format of a content item.

[Trello card](https://trello.com/c/RMkMvY8b)