### PR TITLE
(783) Add an API adapter for the signon users endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Add support for the the Signon API users endpoint [PR](https://github.com/alphagov/gds-api-adapters/pull/1316)
+
 ## 98.1.0
 
 * Add method to get GraphQL responses in a similar format to Content Store content items [PR](https://github.com/alphagov/gds-api-adapters/pull/1314).

--- a/lib/gds_api.rb
+++ b/lib/gds_api.rb
@@ -16,6 +16,7 @@ require "gds_api/organisations"
 require "gds_api/publishing_api"
 require "gds_api/search"
 require "gds_api/search_api_v2"
+require "gds_api/signon_api"
 require "gds_api/support"
 require "gds_api/support_api"
 require "gds_api/worldwide"
@@ -151,6 +152,19 @@ module GdsApi
     GdsApi::PublishingApi.new(
       Plek.find("publishing-api"),
       { bearer_token: ENV["PUBLISHING_API_BEARER_TOKEN"] }.merge(options),
+    )
+  end
+
+  # Creates a GdsApi::SignonApi adapter
+  #
+  # This will set a bearer token if a PUBLISHING_API_BEARER_TOKEN environment
+  # variable is set
+  #
+  # @return [GdsApi::SignonApi]
+  def self.signon_api(options = {})
+    GdsApi::SignonApi.new(
+      Plek.find("signon"),
+      { bearer_token: ENV["SIGNON_API_BEARER_TOKEN"] }.merge(options),
     )
   end
 

--- a/lib/gds_api/signon_api.rb
+++ b/lib/gds_api/signon_api.rb
@@ -1,0 +1,17 @@
+require_relative "base"
+
+class GdsApi::SignonApi < GdsApi::Base
+  # Get users with specific UUIDs
+  #
+  # @param uuids [Array]
+  #
+  #  signon_api.users(
+  #     ["7ac47b33-c09c-4c1d-a9a7-0cfef99081ac"],
+  #  )
+  #
+  # @return [GdsApi::Response] A response containing a list of users with the specified UUIDs
+  def get_users(uuids:)
+    query = query_string(uuids:)
+    get_json("#{endpoint}/api/users#{query}")
+  end
+end

--- a/test/pacts/signon_api_pact_test.rb
+++ b/test/pacts/signon_api_pact_test.rb
@@ -1,0 +1,52 @@
+require "test_helper"
+require "gds_api/support_api"
+
+describe "GdsApi::SignonApi pact tests" do
+  include PactTest
+
+  describe "#get_users" do
+    let(:bearer_token) { "SOME_BEARER_TOKEN" }
+    let(:api_client) { GdsApi::SignonApi.new(signon_api_host, { bearer_token: }) }
+
+    it "returns a list of users" do
+      uuids = %w[9ef9779f-3cba-481a-9a73-00d39e33eb7b b55873b4-bc83-4efe-bdc9-6b7d381a723e 64c7d994-17e0-44d9-97b0-87b43a581eb9]
+      signon_api
+        .given("users exist with the UUIDs #{uuids[0]}, #{uuids[1]} and #{uuids[2]}")
+        .upon_receiving("a raise ticket request")
+        .with(
+          method: :get,
+          path: "/api/users",
+          headers: GdsApi::JsonClient.default_request_headers.merge("Authorization" => "Bearer #{bearer_token}"),
+          query: "uuids%5B%5D=#{uuids[0]}&uuids%5B%5D=#{uuids[1]}&uuids%5B%5D=#{uuids[2]}",
+        )
+        .will_respond_with(
+          status: 200,
+          body: [
+            {
+              "uid": "9ef9779f-3cba-481a-9a73-00d39e33eb7b",
+              "name": Pact.like("Some user"),
+              "email": Pact.like("user@example.com"),
+              "organisation": nil,
+            },
+            {
+              "uid": "b55873b4-bc83-4efe-bdc9-6b7d381a723e",
+              "name": Pact.like("Some user"),
+              "email": Pact.like("user@example.com"),
+              "organisation": nil,
+            },
+            {
+              "uid": "64c7d994-17e0-44d9-97b0-87b43a581eb9",
+              "name": Pact.like("Some user"),
+              "email": Pact.like("user@example.com"),
+              "organisation": nil,
+            },
+          ],
+          headers: {
+            "Content-Type" => "application/json; charset=utf-8",
+          },
+        )
+
+      api_client.get_users(uuids:)
+    end
+  end
+end

--- a/test/support/pact_helper.rb
+++ b/test/support/pact_helper.rb
@@ -10,6 +10,7 @@ LOCATIONS_API_PORT = 3008
 ASSET_MANAGER_API_PORT = 3009
 EMAIL_ALERT_API_PORT = 3010
 SUPPORT_API_PORT = 3011
+SIGNON_API_PORT = 3012
 
 def publishing_api_host
   "http://localhost:#{PUBLISHING_API_PORT}"
@@ -49,6 +50,10 @@ end
 
 def support_api_host
   "http://localhost:#{SUPPORT_API_PORT}"
+end
+
+def signon_api_host
+  "http://localhost:#{SIGNON_API_PORT}"
 end
 
 Pact.service_consumer "GDS API Adapters" do
@@ -109,6 +114,12 @@ Pact.service_consumer "GDS API Adapters" do
   has_pact_with "Support API" do
     mock_service :support_api do
       port SUPPORT_API_PORT
+    end
+  end
+
+  has_pact_with "Signon API" do
+    mock_service :signon_api do
+      port SIGNON_API_PORT
     end
   end
 end


### PR DESCRIPTION
Trello Card: https://trello.com/c/ifMWZl9n/783-add-api-adapters-for-signon

This also has all the necessary setup for Pact testing as well.
