### PR TITLE
(783) Add the Signon API Pact to the workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,12 @@ jobs:
     with:
       pact_artifact: pacts
 
+  signon_api_pact:
+    needs: generate_pacts
+    uses: alphagov/signon/.github/workflows/pact-verify.yml@main
+    with:
+      pact_artifact: pacts
+
   support_api_pact:
     needs: generate_pacts
     uses: alphagov/support-api/.github/workflows/pact-verify.yml@main
@@ -130,6 +136,7 @@ jobs:
       - locations_api_pact
       - publishing_api_pact
       - support_api_pact
+      - signon_api_pact
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Trello Card: https://trello.com/c/ifMWZl9n/783-add-api-adapters-for-signon

This can't be merged until the following PRs are in:

- [x] https://github.com/alphagov/gds-api-adapters/pull/1316
- [x] https://github.com/alphagov/signon/pull/3458