### PR TITLE
Update pact test to reflect that Publishing API publish endpoint is now idempotent

### DIFF
--- a/test/pacts/publishing_api/publish_pact_test.rb
+++ b/test/pacts/publishing_api/publish_pact_test.rb
@@ -77,7 +77,7 @@ describe "GdsApi::PublishingApi#publish pact tests" do
     end
   end
 
-  it "responds with 409 if the content item is already published" do
+  it "responds with 200 if the content item is already published" do
     publishing_api
       .given("a published content item exists with content_id: #{content_id}")
       .upon_receiving("a publish request")
@@ -90,17 +90,10 @@ describe "GdsApi::PublishingApi#publish pact tests" do
         headers: GdsApi::JsonClient.default_request_with_json_body_headers,
       )
       .will_respond_with(
-        status: 409,
-        body: {
-          "error" => {
-            "code" => 409, "message" => Pact.term(generate: "Cannot publish an already published content item", matcher: /\S+/)
-          },
-        },
+        status: 200,
       )
 
-    assert_raises(GdsApi::HTTPConflict) do
-      api_client.publish(content_id, "major")
-    end
+    api_client.publish(content_id, "major")
   end
 
   it "responds with 200 if the update information contains a locale" do


### PR DESCRIPTION
The Publishing API publish endpoint used to return HTTP 409 Conflict error responses if a publishing app attempted to publish a content item which already had a published edition and no draft edition.

These errors are rarely very useful to the Publishing apps as they are usually caused by a duplicate request due to dependency resolution behaviour or Sidekiq's "at least once" guarantee.

We therefore updated Publishing API to return a 200 OK HTTP response is such cases, as the system is still in a perfectly valid state.

Relevant Publishing API PR: https://github.com/alphagov/publishing-api/pull/3068
