### PR TITLE
Release 98.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 98.2.0
 
 * Add support for the the Signon API users endpoint [PR](https://github.com/alphagov/gds-api-adapters/pull/1316)
 

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = "98.1.0".freeze
+  VERSION = "98.2.0".freeze
 end


### PR DESCRIPTION
* Add support for the the Signon API users endpoint [PR](https://github.com/alphagov/gds-api-adapters/pull/1316)