### PR TITLE
Add see_other? method to GdsApi::Response

### DIFF
--- a/lib/gds_api/response.rb
+++ b/lib/gds_api/response.rb
@@ -133,6 +133,10 @@ module GdsApi
       end
     end
 
+    def see_other?
+      @http_response.history.any? && @http_response.history.first.code == 303
+    end
+
     def cache_control
       @cache_control ||= CacheControl.new(headers[:cache_control])
     end

--- a/test/response_test.rb
+++ b/test/response_test.rb
@@ -100,6 +100,31 @@ describe GdsApi::Response do
     end
   end
 
+  describe "#see_other?" do
+    it "returns false if the content item was not redirected with a 303" do
+      mock_http_response = stub(body: "A Response body", history: [], code: 200, headers: {})
+      response = GdsApi::Response.new(mock_http_response)
+
+      assert !response.see_other?
+    end
+
+    it "returns false if the content item was redirected with a 301" do
+      mock_redirect = stub(code: 301)
+      mock_http_response = stub(body: "A Response body", history: [mock_redirect], code: 200, headers: {})
+      response = GdsApi::Response.new(mock_http_response)
+
+      assert !response.see_other?
+    end
+
+    it "returns true is the content item was redirected with a 303" do
+      mock_redirect = stub(code: 303)
+      mock_http_response = stub(body: "A Response body", history: [mock_redirect], code: 200, headers: {})
+      response = GdsApi::Response.new(mock_http_response)
+
+      assert response.see_other?
+    end
+  end
+
   describe "processing web_urls" do
     def build_response(body_string, relative_to = "https://www.gov.uk")
       GdsApi::Response.new(stub(body: body_string), web_urls_relative_to: relative_to)


### PR DESCRIPTION
To correctly handle some responses from content store, frontend needs to know whether the returned response from content store included following a 303 ("see other") redirect (in which case frontend should also redirect). Content store only returns 303s, so we add a `see_other?` method to the GdsApi::Response method which queries the underlying model's history array (if there's _anything_ with a 303 in there, we have followed a see_other redirect).

We don't want to handle other types of redirect yet (they're probably already okay to ignore), so make this specific to 303.

This repo is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.
