### PR TITLE
Add danger links to link-checker-api pacts

### DIFF
--- a/test/pacts/link_checker_api_pact_test.rb
+++ b/test/pacts/link_checker_api_pact_test.rb
@@ -24,6 +24,7 @@ describe "GdsApi::LinkCheckerApi pact tests" do
             checked: nil,
             errors: [],
             warnings: [],
+            danger: [],
             problem_summary: nil,
             suggested_fix: nil,
           },


### PR DESCRIPTION
https://github.com/alphagov/link-checker-api/pull/969 introduces danger links to responses that need reflecting in the pact tests.

This repo is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.
