### PR TITLE
Allow locale when getting host content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Allow locale to be specified when getting host content [PR](https://github.com/alphagov/gds-api-adapters/pull/1326)
+
 ## 98.2.0
 
 * Add support for the the Signon API users endpoint [PR](https://github.com/alphagov/gds-api-adapters/pull/1316)

--- a/lib/gds_api/publishing_api.rb
+++ b/lib/gds_api/publishing_api.rb
@@ -360,17 +360,20 @@ class GdsApi::PublishingApi < GdsApi::Base
   #
   # @param content_id [UUID]
   # @param host_content_id [UUID]
+  # @param params [Hash]
   #
   #   publishing_api.get_host_content_item_for_content_id(
   #     "4b148ebc-b2bb-40db-8e48-dd8cff363ff7",
   #     "10d91dd1-cc9d-4c4c-9540-219ebb8d4501",
+  #     { locale: "en" }
   #   )
   #
   # @return [GdsApi::Response] A response containing the content item which embeds the target.
   #
   # @see https://github.com/alphagov/publishing-api/blob/main/docs/api.md#get-v2contentcontent_idhost-contenthost_content_id
-  def get_host_content_item_for_content_id(content_id, host_content_id)
-    get_json("#{endpoint}/v2/content/#{content_id}/host-content/#{host_content_id}")
+  def get_host_content_item_for_content_id(content_id, host_content_id, params = {})
+    query = query_string(params)
+    get_json("#{endpoint}/v2/content/#{content_id}/host-content/#{host_content_id}#{query}")
   end
 
   def get_content_by_embedded_document(content_id, params = {})

--- a/test/pacts/publishing_api/get_host_content_item_for_content_id_pact_test.rb
+++ b/test/pacts/publishing_api/get_host_content_item_for_content_id_pact_test.rb
@@ -41,6 +41,25 @@ describe "GdsApi::PublishingApi#get_host_content_item_for_content_id pact tests"
     assert_equal(expected_body, response.parsed_content)
   end
 
+  it "allows a locale to be specified" do
+    publishing_api
+      .given("a content item exists (content_id: #{content_id}) that embeds the reusable content (content_id: #{reusable_content_id})")
+      .upon_receiving("a get_host_content_item_for_content_id request with a locale")
+      .with(
+        method: :get,
+        path: "/v2/content/#{reusable_content_id}/host-content/#{content_id}",
+        query: "locale=en",
+      )
+      .will_respond_with(
+        status: 200,
+        body: expected_body,
+      )
+
+    response = api_client.get_host_content_item_for_content_id(reusable_content_id, content_id, locale: "en")
+
+    assert_equal(expected_body, response.parsed_content)
+  end
+
   it "responds with 404 if the content item does not exist" do
     missing_content_id = "missing-content-id"
     publishing_api


### PR DESCRIPTION
Trello card: https://trello.com/c/8SRwSAUh/968-bug-defer-payment-welsh-guide-preview-in-edit-journey-leads-to-server-error-published-state

This optionally allows the locale to be specified when getting a single host content item, which will allow for fetching content items with multiple translations.