### PR TITLE
drop ruby 3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 99.0.0
 
 * BREAKING: Drop support for Ruby 3.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* BREAKING: Drop support for Ruby 3.1
+
 ## 98.4.0
 
 * Add 'danger' property support to `link_checker_api_link_report_hash` test method. [PR](https://github.com/alphagov/gds-api-adapters/pull/1330)

--- a/gds-api-adapters.gemspec
+++ b/gds-api-adapters.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.homepage     = "http://github.com/alphagov/gds-api-adapters"
   s.description  = "A set of adapters providing easy access to the GDS GOV.UK APIs"
 
-  s.required_ruby_version = ">= 3.1"
+  s.required_ruby_version = ">= 3.2"
   s.files        = Dir.glob("lib/**/*") + Dir.glob("test/fixtures/**/*") + %w[README.md Rakefile]
   s.require_path = "lib"
   s.add_dependency "addressable"

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = "98.4.0".freeze
+  VERSION = "99.0.0".freeze
 end


### PR DESCRIPTION
Removes support for Ruby 3.1, which is reaching end of life on 31st March 2025.<br><br>[Trello card](https://trello.com/c/jZ6yKJln)