### PR TITLE
Add support for unpublished editions in `graphql_content_item` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Add support for unpublished editions in `graphql_content_item` method [PR](https://github.com/alphagov/gds-api-adapters/pull/1343).
+* Raise `GdsApi::HTTPGone` when a GraphQL response indicates the edition has been marked as 'gone' and has no 'details' [PR](https://github.com/alphagov/gds-api-adapters/pull/1343).
 
 ## 99.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 99.2.0
 
 * Add support for unpublished editions in `graphql_content_item` method [PR](https://github.com/alphagov/gds-api-adapters/pull/1343).
 * Raise `GdsApi::HTTPGone` when a GraphQL response indicates the edition has been marked as 'gone' and has no 'details' [PR](https://github.com/alphagov/gds-api-adapters/pull/1343).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Add support for unpublished editions in `graphql_content_item` method [PR](https://github.com/alphagov/gds-api-adapters/pull/1343).
+
 ## 99.1.0
 
 * Support setting link title in the stub_local_links_manager_has_a_link method [PR](https://github.com/alphagov/gds-api-adapters/pull/1344)

--- a/lib/gds_api/publishing_api.rb
+++ b/lib/gds_api/publishing_api.rb
@@ -615,6 +615,11 @@ class GdsApi::PublishingApi < GdsApi::Base
       parsed_body = JSON.parse(r.body)
 
       updated_body = if parsed_body["errors"] && (unpublished_error = parsed_body["errors"].find { |error| error["message"] == "Edition has been unpublished" })
+                       if unpublished_error.dig("extensions", "schema_name") == "gone" &&
+                           (unpublished_error.dig("extensions", "details").nil? || unpublished_error.dig("extensions", "details").values.compact.reject(&:empty?).empty?)
+                         raise GdsApi::HTTPGone.new(410, nil, unpublished_error["extensions"])
+                       end
+
                        unpublished_error["extensions"]
                      else
                        parsed_body.dig("data", "edition")

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = "99.1.0".freeze
+  VERSION = "99.2.0".freeze
 end

--- a/test/test_helpers/publishing_api_test.rb
+++ b/test/test_helpers/publishing_api_test.rb
@@ -665,6 +665,42 @@ describe GdsApi::TestHelpers::PublishingApi do
         api_response.raw_response_body,
       )
     end
+
+    it "returns the error data when the edition has been unpublished" do
+      query = "some query"
+
+      stubbed_response = {
+        data: {
+          edition: nil,
+        },
+        errors: [
+          {
+            message: "Edition has been unpublished",
+            extensions: {
+              "document_type": "gone",
+              "schema_name": "gone",
+            },
+          },
+        ],
+      }
+
+      expected_response = {
+        "document_type": "gone",
+        "schema_name": "gone",
+      }
+
+      stub_publishing_api_graphql_content_item(
+        query,
+        stubbed_response,
+      )
+
+      api_response = publishing_api.graphql_content_item(query)
+
+      assert_equal(
+        expected_response.to_json,
+        api_response.raw_response_body,
+      )
+    end
   end
 
   describe "#request_json_matching predicate" do

--- a/test/test_helpers/publishing_api_test.rb
+++ b/test/test_helpers/publishing_api_test.rb
@@ -677,16 +677,146 @@ describe GdsApi::TestHelpers::PublishingApi do
           {
             message: "Edition has been unpublished",
             extensions: {
-              "document_type": "gone",
-              "schema_name": "gone",
+              some_key: "some_value",
             },
           },
         ],
       }
 
       expected_response = {
-        "document_type": "gone",
-        "schema_name": "gone",
+        some_key: "some_value",
+      }
+
+      stub_publishing_api_graphql_content_item(
+        query,
+        stubbed_response,
+      )
+
+      api_response = publishing_api.graphql_content_item(query)
+
+      assert_equal(
+        expected_response.to_json,
+        api_response.raw_response_body,
+      )
+    end
+
+    it "raises a 410 when the edition is marked as 'gone' and the details are not present" do
+      query = "some query"
+
+      stubbed_response = {
+        data: {
+          edition: nil,
+        },
+        errors: [
+          {
+            message: "Edition has been unpublished",
+            extensions: {
+              document_type: "gone",
+              schema_name: "gone",
+            },
+          },
+        ],
+      }
+
+      stub_publishing_api_graphql_content_item(
+        query,
+        stubbed_response,
+      )
+
+      assert_raises(GdsApi::HTTPGone) do
+        publishing_api.graphql_content_item(query)
+      end
+    end
+
+    it "raises a 410 when the edition is marked as 'gone' and the details are blank" do
+      query = "some query"
+
+      stubbed_response = {
+        data: {
+          edition: nil,
+        },
+        errors: [
+          {
+            message: "Edition has been unpublished",
+            extensions: {
+              details: {
+                some_key: "",
+              },
+              document_type: "gone",
+              schema_name: "gone",
+            },
+          },
+        ],
+      }
+
+      stub_publishing_api_graphql_content_item(
+        query,
+        stubbed_response,
+      )
+
+      assert_raises(GdsApi::HTTPGone) do
+        publishing_api.graphql_content_item(query)
+      end
+    end
+
+    it "raises a 410 when the edition is marked as 'gone' and the details are nil" do
+      query = "some query"
+
+      stubbed_response = {
+        data: {
+          edition: nil,
+        },
+        errors: [
+          {
+            message: "Edition has been unpublished",
+            extensions: {
+              details: {
+                some_key: nil,
+              },
+              document_type: "gone",
+              schema_name: "gone",
+            },
+          },
+        ],
+      }
+
+      stub_publishing_api_graphql_content_item(
+        query,
+        stubbed_response,
+      )
+
+      assert_raises(GdsApi::HTTPGone) do
+        publishing_api.graphql_content_item(query)
+      end
+    end
+
+    it "returns the error data and does not raise a 410 when the edition is marked as 'gone' and the details are present" do
+      query = "some query"
+
+      stubbed_response = {
+        data: {
+          edition: nil,
+        },
+        errors: [
+          {
+            message: "Edition has been unpublished",
+            extensions: {
+              details: {
+                some_key: "some value",
+              },
+              document_type: "gone",
+              schema_name: "gone",
+            },
+          },
+        ],
+      }
+
+      expected_response = {
+        details: {
+          some_key: "some value",
+        },
+        document_type: "gone",
+        schema_name: "gone",
       }
 
       stub_publishing_api_graphql_content_item(


### PR DESCRIPTION
The `graphql_content_item` method is intended to transform Publishing API's GraphQL response to make it look like a content item returned from Content Store. This is so we can implement GraphQL whilst making as few changes to the frontend applications as possible.

As part of this, we need to handle unpublished editions correctly, by returning the content of the error in the response, so the frontend application can handle it.

[Trello card](https://trello.com/c/oD9MDupC)