### PR TITLE
Support setting link title in the stub_local_links_manager_has_a_link method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Support setting link title in the stub_local_links_manager_has_a_link method [PR](https://github.com/alphagov/gds-api-adapters/pull/1344)
+
 ## 99.0.0
 
 * BREAKING: Drop support for Ruby 3.1 [PR](https://github.com/alphagov/gds-api-adapters/pull/1333)

--- a/lib/gds_api/test_helpers/local_links_manager.rb
+++ b/lib/gds_api/test_helpers/local_links_manager.rb
@@ -5,7 +5,7 @@ module GdsApi
     module LocalLinksManager
       LOCAL_LINKS_MANAGER_ENDPOINT = Plek.find("local-links-manager")
 
-      def stub_local_links_manager_has_a_link(authority_slug:, lgsl:, lgil:, url:, country_name: "England", status: "ok", snac: "00AG", gss: "EE06000063", local_custodian_code: nil)
+      def stub_local_links_manager_has_a_link(authority_slug:, lgsl:, lgil:, url:, country_name: "England", status: "ok", snac: "00AG", gss: "EE06000063", local_custodian_code: nil, title: nil)
         response = {
           "local_authority" => {
             "name" => authority_slug.capitalize,
@@ -20,6 +20,7 @@ module GdsApi
             "lgil_code" => lgil,
             "url" => url,
             "status" => status,
+            "title" => title,
           },
         }
         response["local_authority"]["snac"] = snac if snac

--- a/test/local_links_manager_api_test.rb
+++ b/test/local_links_manager_api_test.rb
@@ -20,6 +20,7 @@ describe GdsApi::LocalLinksManager do
           url: "http://blackburn.example.com/abandoned-shopping-trolleys/report",
           country_name: "England",
           status: "ok",
+          title: "Shopping Trolley Hub",
         )
 
         expected_response = {
@@ -37,6 +38,7 @@ describe GdsApi::LocalLinksManager do
             "lgil_code" => 4,
             "url" => "http://blackburn.example.com/abandoned-shopping-trolleys/report",
             "status" => "ok",
+            "title" => "Shopping Trolley Hub",
           },
         }
 
@@ -199,6 +201,7 @@ describe GdsApi::LocalLinksManager do
             "lgil_code" => 4,
             "url" => "http://blackburn.example.com/abandoned-shopping-trolleys/report",
             "status" => "ok",
+            "title" => nil,
           },
         }
 


### PR DESCRIPTION
- Following https://github.com/alphagov/local-links-manager/pull/1591, local links manager links can have an optional title. This doesn't affect the adapter methods directly, but we want to allow titles to appear in test suites, so add an optional title parameter into the stub, and add the title into the response.

https://trello.com/c/9POFhvZZ/568-apply-to-foster-pages-request

This repo is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.
