### PR TITLE
Release 99.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 99.1.0
 
 * Support setting link title in the stub_local_links_manager_has_a_link method [PR](https://github.com/alphagov/gds-api-adapters/pull/1344)
 

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = "99.0.0".freeze
+  VERSION = "99.1.0".freeze
 end


### PR DESCRIPTION
* Support setting link title in the stub_local_links_manager_has_a_link method [PR](https://github.com/alphagov/gds-api-adapters/pull/1344)

This repo is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.
