### PR TITLE
[PP-7284] Add support for Publishing API's Content Store-like endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Add support for Publishing API's `/graphql/content/:base_path` endpoint, which behaves like Content Store [PR](https://github.com/alphagov/gds-api-adapters/pull/1360).
+
 ## 99.2.0
 
 * Add support for unpublished editions in `graphql_content_item` method [PR](https://github.com/alphagov/gds-api-adapters/pull/1343).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 99.3.0
 
 * Add support for Publishing API's `/graphql/content/:base_path` endpoint, which behaves like Content Store [PR](https://github.com/alphagov/gds-api-adapters/pull/1360).
 

--- a/lib/gds_api/base.rb
+++ b/lib/gds_api/base.rb
@@ -8,6 +8,12 @@ class GdsApi::Base
   class InvalidAPIURL < StandardError
   end
 
+  class ItemNotFound < GdsApi::HTTPNotFound
+    def self.build_from(http_error)
+      new(http_error.code, http_error.message, http_error.error_details)
+    end
+  end
+
   extend Forwardable
 
   def client

--- a/lib/gds_api/content_store.rb
+++ b/lib/gds_api/content_store.rb
@@ -4,12 +4,6 @@ require_relative "base"
 require_relative "exceptions"
 
 class GdsApi::ContentStore < GdsApi::Base
-  class ItemNotFound < GdsApi::HTTPNotFound
-    def self.build_from(http_error)
-      new(http_error.code, http_error.message, http_error.error_details)
-    end
-  end
-
   def content_item(base_path)
     get_json(content_item_url(base_path))
   rescue GdsApi::HTTPNotFound => e

--- a/lib/gds_api/publishing_api.rb
+++ b/lib/gds_api/publishing_api.rb
@@ -636,6 +636,15 @@ class GdsApi::PublishingApi < GdsApi::Base
     post_json("#{endpoint}/graphql", query:, &create_response)
   end
 
+  # Get the live content item using GraphQL
+  #
+  # @return [GdsApi::Response] A response with the result of the GraphQL query formatted like a Content Store content item.
+  def graphql_live_content_item(base_path)
+    get_json("#{endpoint}/graphql/content#{base_path}")
+  rescue GdsApi::HTTPNotFound => e
+    raise ItemNotFound.build_from(e)
+  end
+
 private
 
   def content_url(content_id, params = {})

--- a/lib/gds_api/test_helpers/publishing_api.rb
+++ b/lib/gds_api/test_helpers/publishing_api.rb
@@ -214,6 +214,31 @@ module GdsApi
         stub_request(:post, url).with(body: { query: }).to_return(response)
       end
 
+      # Stub a GET /graphql/content/:base_path request
+      def stub_publishing_api_graphql_has_item(base_path, body = content_item_for_base_path(base_path), options = {})
+        max_age = options.fetch(:max_age, 900)
+        body = body.to_json unless body.is_a?(String)
+
+        stub_request(:get, "#{PUBLISHING_API_ENDPOINT}/graphql/content#{base_path}").to_return(
+          status: 200,
+          body:,
+          headers: {
+            cache_control: "public, max-age=#{max_age}",
+            date: Time.now.httpdate,
+          },
+        )
+      end
+
+      # Stub a GET /graphql/content/:base_path request returns 404 not found
+      def stub_publishing_api_graphql_does_not_have_item(base_path)
+        stub_request(:get, "#{PUBLISHING_API_ENDPOINT}/graphql/content#{base_path}").to_return(status: 404, headers: {})
+      end
+
+      # Stub a GET /graphql/content/:base_path request returns 410 gone
+      def stub_publishing_api_graphql_has_gone_item(base_path)
+        stub_request(:get, "#{PUBLISHING_API_ENDPOINT}/graphql/content#{base_path}").to_return(status: 410, headers: {})
+      end
+
       # Assert that a draft was saved and published, and links were updated.
       # - PUT /v2/content/:content_id
       # - POST /v2/content/:content_id/publish
@@ -1047,6 +1072,10 @@ module GdsApi
 
       def content_item_for_publishing_api(base_path, publishing_app = "publisher")
         content_item_for_base_path(base_path).merge("publishing_app" => publishing_app)
+      end
+
+      def content_item_for_base_path(base_path)
+        super.merge("base_path" => base_path)
       end
     end
   end

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = "99.2.0".freeze
+  VERSION = "99.3.0".freeze
 end

--- a/test/publishing_api_test.rb
+++ b/test/publishing_api_test.rb
@@ -1,7 +1,10 @@
 require "test_helper"
 require "gds_api/publishing_api"
+require "gds_api/test_helpers/publishing_api"
 
 describe GdsApi::PublishingApi do
+  include GdsApi::TestHelpers::PublishingApi
+
   let(:api_client) { GdsApi::PublishingApi.new(Plek.find("publishing-api")) }
 
   describe "content ID validation" do
@@ -40,6 +43,33 @@ describe GdsApi::PublishingApi do
       api_client.expects(:get_host_content_for_content_id).with(content_id, args)
 
       api_client.get_content_by_embedded_document(content_id, args)
+    end
+  end
+
+  describe "#graphql_live_content_item" do
+    it "returns the item" do
+      base_path = "/test-from-content-store"
+      stub_publishing_api_graphql_has_item(base_path)
+
+      response = api_client.graphql_live_content_item(base_path)
+
+      assert_equal base_path, response["base_path"]
+    end
+
+    it "raises if the item doesn't exist" do
+      stub_publishing_api_graphql_does_not_have_item("/non-existent")
+
+      assert_raises(GdsApi::HTTPNotFound) do
+        api_client.graphql_live_content_item("/non-existent")
+      end
+    end
+
+    it "raises if the item is gone" do
+      stub_publishing_api_graphql_has_gone_item("/it-is-gone")
+
+      assert_raises(GdsApi::HTTPGone) do
+        api_client.graphql_live_content_item("/it-is-gone")
+      end
     end
   end
 end


### PR DESCRIPTION
There is a new endpoint added to Publishing API that behaves like Content Store (see https://github.com/alphagov/publishing-api/pull/3488).

Therefore adding an adapter for this endpoint. The tests have been copied over from the similar adapter in Content Store.

In later work (once the frontend applications have been switched to use this method), we can remove the `graphql_content_item` method.