### PR TITLE
[PP-7566] Require `plek` in Publishing API test helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 103.1.1
 
 * Add `plek` as a requirement for Publishing API test helpers
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Add `plek` as a requirement for Publishing API test helpers
+
 ## 103.1.0
 
 * Add Publishing API timeout test helper

--- a/lib/gds_api/test_helpers/publishing_api.rb
+++ b/lib/gds_api/test_helpers/publishing_api.rb
@@ -1,3 +1,4 @@
+require "plek"
 require "gds_api/test_helpers/json_client_helper"
 require "gds_api/test_helpers/content_item_helpers"
 require "json"

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = "103.1.0".freeze
+  VERSION = "103.1.1".freeze
 end


### PR DESCRIPTION
`Plek` is used in the Publishing API test helpers to define some constants, but has not been required.

This has never been an issue before, as all consumers of this helper already required `plek` in their tests. However the pact tests in the `frontend` app do not.

Therefore requiring `plek` to ensure it is always available.