### PR TITLE
Update search index

### DIFF
--- a/test/pacts/search_api_pact_test.rb
+++ b/test/pacts/search_api_pact_test.rb
@@ -154,7 +154,7 @@ private
     {
       "link" => Pact.like("/universal-credit"),
       "title" => Pact.like("Universal credit"),
-      "index" => Pact.like("government_test"),
+      "index" => Pact.like("govuk_test"),
       "_id" => Pact.like("/universal-credit"),
       "elasticsearch_type" => Pact.like("edition"),
       "document_type" => Pact.like("edition"),


### PR DESCRIPTION
The government index is being retired.

This change isn't strictly necessary for the tests to pass, but might make them easier to understand
going forward.

Jira ticket: https://gov-uk.atlassian.net/browse/SCH-1987

This repo is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.
