### PR TITLE
[PP-7588] Update Pact to reflect new base path schema definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 103.3.1
+
+* Update Pact test to reflect new base/absolute path content schema definition ([PR](https://github.com/alphagov/gds-api-adapters/pull/1392))
+
 ## 103.3.0
 
 * Add development dependency "rdoc" to support Ruby 4.0 tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,19 +6,19 @@
 
 ## 103.3.0
 
-* Add development dependency "rdoc" to support Ruby 4.0 tests
+* Add development dependency "rdoc" to support Ruby 4.0 tests ([PR](https://github.com/alphagov/gds-api-adapters/pull/1388))
 
 ## 103.2.0
 
-* Drop support for Ruby 3.2
+* Drop support for Ruby 3.2 ([PR](https://github.com/alphagov/gds-api-adapters/pull/1387))
 
 ## 103.1.1
 
-* Add `plek` as a requirement for Publishing API test helpers
+* Add `plek` as a requirement for Publishing API test helpers ([PR](https://github.com/alphagov/gds-api-adapters/pull/1386))
 
 ## 103.1.0
 
-* Add Publishing API timeout test helper
+* Add Publishing API timeout test helper ([PR](https://github.com/alphagov/gds-api-adapters/pull/1384))
 
 ## 103.0.0
 

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = "103.3.0".freeze
+  VERSION = "103.3.1".freeze
 end

--- a/test/pacts/publishing_api/put_content_pact_test.rb
+++ b/test/pacts/publishing_api/put_content_pact_test.rb
@@ -77,8 +77,8 @@ describe "GdsApi::PublishingApi#put_content pact tests" do
           {
             schema: Pact.like({}),
             fragment: "#/base_path",
-            message: Pact.like("The property '#/base_path' value \"not a url path\" did not match the regex '^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$' in schema 729a13d6-8ddb-5ba8-b116-3b7604dc3d3d#"),
-            failed_attribute: "Pattern",
+            message: Pact.like("The property '#/base_path' of type string did not match all of the required schemas in schema 91ab1054-cf15-5464-b83d-bf8f19abe4b0#"),
+            failed_attribute: "AllOf",
           },
         ],
         headers: {


### PR DESCRIPTION
The absolute path definition used by base paths [is being updated](https://github.com/alphagov/publishing-api/pull/4018) to have multiple requirements via allOf. This test needs updating to reflect that change

I've tested the Publishing API branch locally against the Pacts (per [the guidance](https://docs.publishing.service.gov.uk/manual/pact-testing.html#changing-existing-pact-tests)) on this branch and everything passes