### PR TITLE
[PP-7606] Update pact tests for Publishing API error responses

### DIFF
--- a/test/pacts/publishing_api/put_content_pact_test.rb
+++ b/test/pacts/publishing_api/put_content_pact_test.rb
@@ -40,12 +40,19 @@ describe "GdsApi::PublishingApi#put_content pact tests" do
       )
       .will_respond_with(
         status: 422,
+        error_code: Pact.like("base_path_already_in_use"),
         body: {
           "error" => {
             "code" => 422,
             "message" => Pact.term(generate: "Conflict", matcher: /\S+/),
             "fields" => {
-              "base_path" => Pact.each_like("is already in use by the 'publisher' app", min: 1),
+              "base_path" => Pact.each_like(
+                {
+                  "error" => Pact.term(generate: "/test-item is already reserved by publisher", matcher: /\S+/),
+                  "code" => Pact.like("base_path_already_in_use"),
+                },
+                min: 1,
+              ),
             },
           },
         },

--- a/test/pacts/publishing_api/put_path_pact_test.rb
+++ b/test/pacts/publishing_api/put_path_pact_test.rb
@@ -53,12 +53,19 @@ describe "GdsApi::PublishingApi#put_path pact tests" do
       )
       .will_respond_with(
         status: 422,
+        error_code: Pact.like("base_path_already_in_use"),
         body: {
           "error" => {
             "code" => 422,
             "message" => Pact.term(generate: "Unprocessable", matcher: /\S+/),
             "fields" => {
-              "base_path" => Pact.each_like("has been reserved", min: 1),
+              "base_path" => Pact.each_like(
+                {
+                  "error" => Pact.term(generate: "/test-item is already reserved by publisher", matcher: /\S+/),
+                  "code" => Pact.like("base_path_already_in_use"),
+                },
+                min: 1,
+              ),
             },
           },
         },


### PR DESCRIPTION
Publishing API will includes error_code in its error responses. It is possible that multiple validation fail simultaneously. In such cases, the top-level error_code would be multiple_validation_errors so the `fields` property is expanded to provide detailed information about each individual failure, with each field represented as a hash containing both a human-readable error and a machine-readable code.

The test is updated to expect this new structure, ensuring it accurately reflects the API’s behaviour.

### Testing
Verified all test passing locally: `govuk-docker-run env PACT_CONSUMER_VERSION=branch-publishing-api-error-codes bundle exec rake pact:verify` in `publishing-api` directory, on `422-error-codes-2` branch. https://github.com/alphagov/publishing-api/pull/4052
