### PR TITLE
[PP-7732] Allow skipping schema validation in patch links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 103.4.0
+
+* Support skipping validation in patch links requests ([PR](https://github.com/alphagov/gds-api-adapters/pull/1401))
+
 ## 103.3.1
 
 * Update Pact test to reflect new base/absolute path content schema definition ([PR](https://github.com/alphagov/gds-api-adapters/pull/1392))

--- a/lib/gds_api/publishing_api.rb
+++ b/lib/gds_api/publishing_api.rb
@@ -277,8 +277,8 @@ class GdsApi::PublishingApi < GdsApi::Base
   # @param content_id [UUID]
   # @param params [Hash]
   # @option params [Hash] links A "links hash"
+  # @option params [Boolean] bulk_publishing Set to true to indicate that this is part of a mass-republish. Allows the publishing-api to prioritise human-initiated publishing
   # @option params [Integer] previous_version The previous version (returned by `get_links`). If this version is not the current version, the publishing-api will reject the change and return 409 Conflict. (optional)
-  # @option params [Boolean] bulk_publishing Set to true to indicate that this is part of a mass-republish. Allows the publishing-api to prioritise human-initiated publishing (optional, default false)
   # @option params [Boolean] validate_schema Set to false to skip validation of links against the content schema for the latest edition. After changing a document's document type, allows for removal of links of types unsupported by the new type.
   #
   # @example

--- a/lib/gds_api/publishing_api.rb
+++ b/lib/gds_api/publishing_api.rb
@@ -279,6 +279,8 @@ class GdsApi::PublishingApi < GdsApi::Base
   # @option params [Hash] links A "links hash"
   # @option params [Integer] previous_version The previous version (returned by `get_links`). If this version is not the current version, the publishing-api will reject the change and return 409 Conflict. (optional)
   # @option params [Boolean] bulk_publishing Set to true to indicate that this is part of a mass-republish. Allows the publishing-api to prioritise human-initiated publishing (optional, default false)
+  # @option params [Boolean] validate_schema Set to false to skip validation of links against the content schema for the latest edition. After changing a document's document type, allows for removal of links of types unsupported by the new type.
+  #
   # @example
   #
   #   publishing_api.patch_links(
@@ -291,13 +293,24 @@ class GdsApi::PublishingApi < GdsApi::Base
   #     bulk_publishing: true
   #   )
   #
+  # @example
+  #
+  #   publishing_api.patch_links(
+  #     '86963c13-1f57-4005-b119-e7cf3cb92ecf',
+  #     links: {
+  #       topics: [],
+  #     },
+  #     previous_version: 10,
+  #     validate_schema: false
+  #   )
+  #
   # @see https://github.com/alphagov/publishing-api/blob/main/docs/api.md#patch-v2linkscontent_id
   def patch_links(content_id, params)
     payload = {
       links: params.fetch(:links),
     }
 
-    payload = merge_optional_keys(payload, params, %i[previous_version bulk_publishing])
+    payload = merge_optional_keys(payload, params, %i[previous_version bulk_publishing validate_schema])
 
     patch_json(links_url(content_id), payload)
   end

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = "103.3.1".freeze
+  VERSION = "103.4.0".freeze
 end


### PR DESCRIPTION
This option is being added to Publishing API to allow patch links requests to skip validation, which should enable removal of old now-invalid links when a document's type changes. More:
- https://github.com/alphagov/publishing-api/pull/4100
- https://github.com/alphagov/publishing-api/commit/8ee0b6a061e98e27c215f0054448538f10677f4d