### PR TITLE
Update search autocomplete tests

### DIFF
--- a/test/search_api_v2_test.rb
+++ b/test/search_api_v2_test.rb
@@ -51,13 +51,8 @@ describe GdsApi::SearchApiV2 do
       stub_request(:get, /example.com\/autocomplete/).to_return(body: "[]")
     end
 
-    it "should raise an exception if the request is unsuccessful" do
-      stub_request(:get, /example.com\/autocomplete.json/).to_return(
-        status: [500, "Internal Server Error"],
-      )
-      assert_raises(GdsApi::HTTPServerError) do
-        GdsApi::SearchApiV2.new("http://example.com").autocomplete("prime minis")
-      end
+    it "should not raise an error if there are no autocomplete suggestions returned" do
+      GdsApi::SearchApiV2.new("http://example.com").autocomplete("prime minis")
     end
 
     it "should request the autocomplete results in JSON format" do


### PR DESCRIPTION
We no longer raise internal errors in search-api-v2 if GCP times out or itself raises an internal error for an autocomplete request:
https://github.com/alphagov/search-api-v2/pull/677

Jira ticket: https://gov-uk.atlassian.net/browse/SCH-2146
