### PR TITLE
Add RFC-192 compliant base path validator

### DIFF
--- a/lib/gds_api.rb
+++ b/lib/gds_api.rb
@@ -1,6 +1,7 @@
 require "addressable"
 require "plek"
 require "time"
+require "gds_api/validators/base_path_validator"
 require "gds_api/account_api"
 require "gds_api/asset_manager"
 require "gds_api/calendars"

--- a/lib/gds_api/validators/base_path_validator.rb
+++ b/lib/gds_api/validators/base_path_validator.rb
@@ -1,0 +1,45 @@
+module GdsApi
+  module Validators
+    class BasePathValidator
+      MAX_PATH_LENGTH = 511
+
+      attr_reader :base_path
+
+      def initialize(base_path)
+        @base_path = base_path
+      end
+
+      def valid?
+        !(base_path.nil? || too_long? || potential_path_traversal? || ends_with_a_period? || invalid_chars?)
+      end
+
+      def errors
+        errors = []
+        errors << "Path cannot be nil" if base_path.nil?
+        errors << "Path cannot be longer than #{MAX_PATH_LENGTH} characters" if too_long?
+        errors << "Path contains runs of . and or / characters, which could be penetration attempts" if potential_path_traversal?
+        errors << "Path cannot end with a ." if ends_with_a_period?
+        errors << "Path contains characters that are not lowercase letters, numbers, -, ., or /" if invalid_chars?
+        errors
+      end
+
+    private
+
+      def too_long?
+        base_path.length > MAX_PATH_LENGTH
+      end
+
+      def potential_path_traversal?
+        base_path =~ /([\/.]{2,})/
+      end
+
+      def ends_with_a_period?
+        base_path[-1] == "."
+      end
+
+      def invalid_chars?
+        base_path !~ /^\/$|^(\/[a-z0-9.-]+)+$/
+      end
+    end
+  end
+end

--- a/test/validators/base_path_validator_test.rb
+++ b/test/validators/base_path_validator_test.rb
@@ -1,0 +1,79 @@
+require "test_helper"
+require "gds_api/validators/base_path_validator"
+
+describe GdsApi::Validators::BasePathValidator do
+  let(:valid_path_examples) do
+    [
+      "/",
+      "/government/topical-event/heat-wave-2026",
+      "/government/topical-event/heat-wave-2026.csv",
+      "#{'/0123456789' * 46}.json",
+    ]
+  end
+
+  let(:invalid_path_examples) do
+    [
+      "//",
+      "//govuk",
+      "/Government/topical-events",
+      "/government/topical_events",
+      "/government/miss-ca$h",
+      "/government/files,",
+      "/government/files:-more-government/",
+      "/values/../../secret-stuff",
+      "/govermment/news/%0D%0A",
+      "/govermment/news/%0d%0a",
+      "/govermment/😊",
+      "/gövernment/news",
+      "#{'/0123456789' * 46}x.json",
+      "/government/news.",
+    ]
+  end
+
+  let(:invalid_path_examples_errors) do
+    [
+      "Path contains runs of . and or / characters, which could be penetration attempts",
+      "Path contains runs of . and or / characters, which could be penetration attempts",
+      "Path contains characters that are not lowercase letters, numbers, -, ., or /",
+      "Path contains characters that are not lowercase letters, numbers, -, ., or /",
+      "Path contains characters that are not lowercase letters, numbers, -, ., or /",
+      "Path contains characters that are not lowercase letters, numbers, -, ., or /",
+      "Path contains characters that are not lowercase letters, numbers, -, ., or /",
+      "Path contains runs of . and or / characters, which could be penetration attempts",
+      "Path contains characters that are not lowercase letters, numbers, -, ., or /",
+      "Path contains characters that are not lowercase letters, numbers, -, ., or /",
+      "Path contains characters that are not lowercase letters, numbers, -, ., or /",
+      "Path contains characters that are not lowercase letters, numbers, -, ., or /",
+      "Path cannot be longer than 511 characters",
+      "Path cannot end with a .",
+    ]
+  end
+
+  describe "#valid?" do
+    it "returns true for valid paths" do
+      valid_path_examples.each do |base_path|
+        assert_equal(true, GdsApi::Validators::BasePathValidator.new(base_path).valid?, "#{base_path} should be accepted")
+      end
+    end
+
+    it "returns false for valid paths" do
+      invalid_path_examples.each do |base_path|
+        assert_equal(false, GdsApi::Validators::BasePathValidator.new(base_path).valid?, "#{base_path} should not be accepted")
+      end
+    end
+  end
+
+  describe "#errors" do
+    it "returns an empty array for valid paths" do
+      valid_path_examples.each do |base_path|
+        assert_equal([], GdsApi::Validators::BasePathValidator.new(base_path).errors, "#{base_path} should not return errors")
+      end
+    end
+
+    it "returns appropriate errors for valid paths" do
+      invalid_path_examples.each_with_index do |base_path, idx|
+        assert_includes(GdsApi::Validators::BasePathValidator.new(base_path).errors, invalid_path_examples_errors[idx], "#{base_path} should include errors")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Implements item 1 of [RFC-192](https://github.com/alphagov/govuk-rfcs/pull/192): "A validation method is added to [gds-api-adapters](https://github.com/alphagov/gds-api-adapters) which tests a base path passed to it against the new restriction. This becomes the source of truth."

Adds the new class GdsApi::Validators::BasePathValidator, which can be used to confirm whether a base path meets the criteria in RFC-192, and provides human-readable errors.

Usage:
```
   > good_validator = GdsApi::Validators::BasePathValidator.new("/government/news/new-validator-rfc-192")
   > good_validator.valid?
   true
   
   > bad_validator = GdsApi::Validators::BasePathValidator.new("/government/news/New-Validator_rfc-192")
   > bad_validator.valid?
   false
  > bad_validator.errors?
  ["Path contains characters that are not lowercase letters, numbers, -, ., or /"]
```

This repo is owned by the Content APIs team. Please let us know in [#govuk-content-apis](https://gds.slack.com/archives/C03D792LYJG) when you raise any PRs.
