### PR TITLE
Improve RFC-192 validator method

### DIFF
--- a/lib/gds_api/validators/base_path_validator.rb
+++ b/lib/gds_api/validators/base_path_validator.rb
@@ -1,7 +1,7 @@
 module GdsApi
   module Validators
     class BasePathValidator
-      MAX_PATH_LENGTH = 511
+      MAX_PATH_LENGTH = 512
 
       attr_reader :base_path
 

--- a/lib/gds_api/validators/base_path_validator.rb
+++ b/lib/gds_api/validators/base_path_validator.rb
@@ -14,15 +14,19 @@ module GdsApi
       end
 
       def errors
-        return ["Path cannot be nil"] if base_path.nil?
+        return { base_path_invalid: ["Path cannot be nil"] } if base_path.nil?
 
         errors = []
-        errors << "Path must start with a /" if no_leading_slash?
-        errors << "Path cannot be longer than #{MAX_PATH_LENGTH} characters" if too_long?
-        errors << "Path contains runs of . and or / characters, which could be penetration attempts" if potential_path_traversal?
-        errors << "Path cannot end with a ." if ends_with_a_period?
-        errors << "Path contains characters that are not lowercase letters, numbers, -, ., or /" if invalid_chars?
-        errors
+        errors << [:base_path_invalid, "Path must start with a /"] if no_leading_slash?
+        errors << [:base_path_too_long, "Path cannot be longer than #{MAX_PATH_LENGTH} characters"] if too_long?
+        errors << [:base_path_invalid, "Path contains runs of . and or / characters, which could be penetration attempts"] if potential_path_traversal?
+        errors << [:base_path_invalid, "Path cannot end with a ."] if ends_with_a_period?
+        errors << [:base_path_invalid, "Path contains characters that are not lowercase letters, numbers, -, ., or /"] if invalid_chars?
+
+        errors.each_with_object({}) do |err, memo|
+          memo[err[0]] ||= []
+          memo[err[0]] << err[1]
+        end
       end
 
     private

--- a/lib/gds_api/validators/base_path_validator.rb
+++ b/lib/gds_api/validators/base_path_validator.rb
@@ -43,7 +43,7 @@ module GdsApi
       end
 
       def invalid_chars?
-        base_path !~ /^\/$|^(\/[a-z0-9.-]+)+$/
+        base_path !~ /^([\/a-z0-9.-])+$/
       end
     end
   end

--- a/lib/gds_api/validators/base_path_validator.rb
+++ b/lib/gds_api/validators/base_path_validator.rb
@@ -10,12 +10,13 @@ module GdsApi
       end
 
       def valid?
-        !(base_path.nil? || too_long? || potential_path_traversal? || ends_with_a_period? || invalid_chars?)
+        !(base_path.nil? || no_leading_slash? || too_long? || potential_path_traversal? || ends_with_a_period? || invalid_chars?)
       end
 
       def errors
         errors = []
         errors << "Path cannot be nil" if base_path.nil?
+        errors << "Path must start with a /" if no_leading_slash?
         errors << "Path cannot be longer than #{MAX_PATH_LENGTH} characters" if too_long?
         errors << "Path contains runs of . and or / characters, which could be penetration attempts" if potential_path_traversal?
         errors << "Path cannot end with a ." if ends_with_a_period?
@@ -24,6 +25,10 @@ module GdsApi
       end
 
     private
+
+      def no_leading_slash?
+        base_path[0] != "/"
+      end
 
       def too_long?
         base_path.length > MAX_PATH_LENGTH

--- a/lib/gds_api/validators/base_path_validator.rb
+++ b/lib/gds_api/validators/base_path_validator.rb
@@ -14,14 +14,14 @@ module GdsApi
       end
 
       def errors
-        return { base_path_invalid: ["Path cannot be nil"] } if base_path.nil?
+        return { base_path_invalid: ["must not be nil"] } if base_path.nil?
 
         errors = []
-        errors << [:base_path_invalid, "Path must start with a /"] if no_leading_slash?
-        errors << [:base_path_too_long, "Path cannot be longer than #{MAX_PATH_LENGTH} characters"] if too_long?
-        errors << [:base_path_invalid, "Path contains runs of . and or / characters, which could be penetration attempts"] if potential_path_traversal?
-        errors << [:base_path_invalid, "Path cannot end with a ."] if ends_with_a_period?
-        errors << [:base_path_invalid, "Path contains characters that are not lowercase letters, numbers, -, ., or /"] if invalid_chars?
+        errors << [:base_path_invalid, "must start with a /"] if no_leading_slash?
+        errors << [:base_path_too_long, "must not be longer than #{MAX_PATH_LENGTH} bytes"] if too_long?
+        errors << [:base_path_invalid, "must not include runs of . and or / characters, which could be penetration attempts"] if potential_path_traversal?
+        errors << [:base_path_invalid, "must not end with a ."] if ends_with_a_period?
+        errors << [:base_path_invalid, "must not include characters that are not lowercase letters, numbers, -, ., or /"] if invalid_chars?
 
         errors.each_with_object({}) do |err, memo|
           memo[err[0]] ||= []

--- a/lib/gds_api/validators/base_path_validator.rb
+++ b/lib/gds_api/validators/base_path_validator.rb
@@ -14,8 +14,9 @@ module GdsApi
       end
 
       def errors
+        return ["Path cannot be nil"] if base_path.nil?
+
         errors = []
-        errors << "Path cannot be nil" if base_path.nil?
         errors << "Path must start with a /" if no_leading_slash?
         errors << "Path cannot be longer than #{MAX_PATH_LENGTH} characters" if too_long?
         errors << "Path contains runs of . and or / characters, which could be penetration attempts" if potential_path_traversal?

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,7 @@ Bundler.setup :default, :development, :test
 require "simplecov"
 
 SimpleCov.start do
+  enable_coverage :branch
   add_filter "/test/"
   add_group "Test Helpers", "lib/gds_api/test_helpers"
 end

--- a/test/validators/base_path_validator_test.rb
+++ b/test/validators/base_path_validator_test.rb
@@ -68,7 +68,7 @@ describe GdsApi::Validators::BasePathValidator do
   end
 
   describe "#errors" do
-    it "returns an empty hashs for valid paths" do
+    it "returns an empty hash for valid paths" do
       valid_path_examples.each do |base_path|
         assert_equal({}, GdsApi::Validators::BasePathValidator.new(base_path).errors, "#{base_path} should not return errors")
       end

--- a/test/validators/base_path_validator_test.rb
+++ b/test/validators/base_path_validator_test.rb
@@ -34,22 +34,22 @@ describe GdsApi::Validators::BasePathValidator do
 
   let(:invalid_path_examples_errors) do
     [
-      { base_path_invalid: ["Path cannot be nil"] },
-      { base_path_invalid: ["Path must start with a /"] },
-      { base_path_invalid: ["Path contains runs of . and or / characters, which could be penetration attempts"] },
-      { base_path_invalid: ["Path contains runs of . and or / characters, which could be penetration attempts"] },
-      { base_path_invalid: ["Path contains characters that are not lowercase letters, numbers, -, ., or /"] },
-      { base_path_invalid: ["Path contains characters that are not lowercase letters, numbers, -, ., or /"] },
-      { base_path_invalid: ["Path contains characters that are not lowercase letters, numbers, -, ., or /"] },
-      { base_path_invalid: ["Path contains characters that are not lowercase letters, numbers, -, ., or /"] },
-      { base_path_invalid: ["Path contains characters that are not lowercase letters, numbers, -, ., or /"] },
-      { base_path_invalid: ["Path contains runs of . and or / characters, which could be penetration attempts"] },
-      { base_path_invalid: ["Path contains characters that are not lowercase letters, numbers, -, ., or /"] },
-      { base_path_invalid: ["Path contains characters that are not lowercase letters, numbers, -, ., or /"] },
-      { base_path_invalid: ["Path contains characters that are not lowercase letters, numbers, -, ., or /"] },
-      { base_path_invalid: ["Path contains characters that are not lowercase letters, numbers, -, ., or /"] },
-      { base_path_too_long: ["Path cannot be longer than 512 characters"] },
-      { base_path_invalid: ["Path cannot end with a ."] },
+      { base_path_invalid: ["must not be nil"] },
+      { base_path_invalid: ["must start with a /"] },
+      { base_path_invalid: ["must not include runs of . and or / characters, which could be penetration attempts"] },
+      { base_path_invalid: ["must not include runs of . and or / characters, which could be penetration attempts"] },
+      { base_path_invalid: ["must not include characters that are not lowercase letters, numbers, -, ., or /"] },
+      { base_path_invalid: ["must not include characters that are not lowercase letters, numbers, -, ., or /"] },
+      { base_path_invalid: ["must not include characters that are not lowercase letters, numbers, -, ., or /"] },
+      { base_path_invalid: ["must not include characters that are not lowercase letters, numbers, -, ., or /"] },
+      { base_path_invalid: ["must not include characters that are not lowercase letters, numbers, -, ., or /"] },
+      { base_path_invalid: ["must not include runs of . and or / characters, which could be penetration attempts"] },
+      { base_path_invalid: ["must not include characters that are not lowercase letters, numbers, -, ., or /"] },
+      { base_path_invalid: ["must not include characters that are not lowercase letters, numbers, -, ., or /"] },
+      { base_path_invalid: ["must not include characters that are not lowercase letters, numbers, -, ., or /"] },
+      { base_path_invalid: ["must not include characters that are not lowercase letters, numbers, -, ., or /"] },
+      { base_path_too_long: ["must not be longer than 512 bytes"] },
+      { base_path_invalid: ["must not end with a ."] },
     ]
   end
 

--- a/test/validators/base_path_validator_test.rb
+++ b/test/validators/base_path_validator_test.rb
@@ -7,7 +7,7 @@ describe GdsApi::Validators::BasePathValidator do
       "/",
       "/government/topical-event/heat-wave-2026",
       "/government/topical-event/heat-wave-2026.csv",
-      "#{'/0123456789' * 46}.json",
+      "#{'/0123456789' * 46}.jsonp",
     ]
   end
 
@@ -25,7 +25,7 @@ describe GdsApi::Validators::BasePathValidator do
       "/govermment/news/%0d%0a",
       "/govermment/😊",
       "/gövernment/news",
-      "#{'/0123456789' * 46}x.json",
+      "#{'/0123456789' * 46}x.jsonp",
       "/government/news.",
     ]
   end
@@ -44,7 +44,7 @@ describe GdsApi::Validators::BasePathValidator do
       "Path contains characters that are not lowercase letters, numbers, -, ., or /",
       "Path contains characters that are not lowercase letters, numbers, -, ., or /",
       "Path contains characters that are not lowercase letters, numbers, -, ., or /",
-      "Path cannot be longer than 511 characters",
+      "Path cannot be longer than 512 characters",
       "Path cannot end with a .",
     ]
   end

--- a/test/validators/base_path_validator_test.rb
+++ b/test/validators/base_path_validator_test.rb
@@ -13,6 +13,7 @@ describe GdsApi::Validators::BasePathValidator do
 
   let(:invalid_path_examples) do
     [
+      nil,
       "government/topical-events",
       "//",
       "//govuk",
@@ -33,6 +34,7 @@ describe GdsApi::Validators::BasePathValidator do
 
   let(:invalid_path_examples_errors) do
     [
+      "Path cannot be nil",
       "Path must start with a /",
       "Path contains runs of . and or / characters, which could be penetration attempts",
       "Path contains runs of . and or / characters, which could be penetration attempts",

--- a/test/validators/base_path_validator_test.rb
+++ b/test/validators/base_path_validator_test.rb
@@ -13,6 +13,7 @@ describe GdsApi::Validators::BasePathValidator do
 
   let(:invalid_path_examples) do
     [
+      "government/topical-events",
       "//",
       "//govuk",
       "/Government/topical-events",
@@ -32,6 +33,7 @@ describe GdsApi::Validators::BasePathValidator do
 
   let(:invalid_path_examples_errors) do
     [
+      "Path must start with a /",
       "Path contains runs of . and or / characters, which could be penetration attempts",
       "Path contains runs of . and or / characters, which could be penetration attempts",
       "Path contains characters that are not lowercase letters, numbers, -, ., or /",

--- a/test/validators/base_path_validator_test.rb
+++ b/test/validators/base_path_validator_test.rb
@@ -34,22 +34,22 @@ describe GdsApi::Validators::BasePathValidator do
 
   let(:invalid_path_examples_errors) do
     [
-      "Path cannot be nil",
-      "Path must start with a /",
-      "Path contains runs of . and or / characters, which could be penetration attempts",
-      "Path contains runs of . and or / characters, which could be penetration attempts",
-      "Path contains characters that are not lowercase letters, numbers, -, ., or /",
-      "Path contains characters that are not lowercase letters, numbers, -, ., or /",
-      "Path contains characters that are not lowercase letters, numbers, -, ., or /",
-      "Path contains characters that are not lowercase letters, numbers, -, ., or /",
-      "Path contains characters that are not lowercase letters, numbers, -, ., or /",
-      "Path contains runs of . and or / characters, which could be penetration attempts",
-      "Path contains characters that are not lowercase letters, numbers, -, ., or /",
-      "Path contains characters that are not lowercase letters, numbers, -, ., or /",
-      "Path contains characters that are not lowercase letters, numbers, -, ., or /",
-      "Path contains characters that are not lowercase letters, numbers, -, ., or /",
-      "Path cannot be longer than 512 characters",
-      "Path cannot end with a .",
+      { base_path_invalid: ["Path cannot be nil"] },
+      { base_path_invalid: ["Path must start with a /"] },
+      { base_path_invalid: ["Path contains runs of . and or / characters, which could be penetration attempts"] },
+      { base_path_invalid: ["Path contains runs of . and or / characters, which could be penetration attempts"] },
+      { base_path_invalid: ["Path contains characters that are not lowercase letters, numbers, -, ., or /"] },
+      { base_path_invalid: ["Path contains characters that are not lowercase letters, numbers, -, ., or /"] },
+      { base_path_invalid: ["Path contains characters that are not lowercase letters, numbers, -, ., or /"] },
+      { base_path_invalid: ["Path contains characters that are not lowercase letters, numbers, -, ., or /"] },
+      { base_path_invalid: ["Path contains characters that are not lowercase letters, numbers, -, ., or /"] },
+      { base_path_invalid: ["Path contains runs of . and or / characters, which could be penetration attempts"] },
+      { base_path_invalid: ["Path contains characters that are not lowercase letters, numbers, -, ., or /"] },
+      { base_path_invalid: ["Path contains characters that are not lowercase letters, numbers, -, ., or /"] },
+      { base_path_invalid: ["Path contains characters that are not lowercase letters, numbers, -, ., or /"] },
+      { base_path_invalid: ["Path contains characters that are not lowercase letters, numbers, -, ., or /"] },
+      { base_path_too_long: ["Path cannot be longer than 512 characters"] },
+      { base_path_invalid: ["Path cannot end with a ."] },
     ]
   end
 
@@ -68,15 +68,15 @@ describe GdsApi::Validators::BasePathValidator do
   end
 
   describe "#errors" do
-    it "returns an empty array for valid paths" do
+    it "returns an empty hashs for valid paths" do
       valid_path_examples.each do |base_path|
-        assert_equal([], GdsApi::Validators::BasePathValidator.new(base_path).errors, "#{base_path} should not return errors")
+        assert_equal({}, GdsApi::Validators::BasePathValidator.new(base_path).errors, "#{base_path} should not return errors")
       end
     end
 
     it "returns appropriate errors for valid paths" do
       invalid_path_examples.each_with_index do |base_path, idx|
-        assert_includes(GdsApi::Validators::BasePathValidator.new(base_path).errors, invalid_path_examples_errors[idx], "#{base_path} should include errors")
+        assert_equal(GdsApi::Validators::BasePathValidator.new(base_path).errors, invalid_path_examples_errors[idx], "#{base_path} should include errors")
       end
     end
   end


### PR DESCRIPTION
Mainly this changes the output of `#errors` to be more useful to publishing-api, but it also improves error messages, improves coverage, adjusts max length to conform to the improved RFC, and simplifies the code slightly.

This repo is owned by the Content APIs team. Please let us know in [#govuk-content-apis](https://gds.slack.com/archives/C03D792LYJG) when you raise any PRs.
