### PR TITLE
Release 103.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 103.4.0
+
+* Improve RFC-192 validator method ([PR](https://github.com/alphagov/gds-api-adapters/pull/1411))
+* Add RFC-192 compliant base path validator ([PR](https://github.com/alphagov/gds-api-adapters/pull/1406))
+
 ## 103.3.1
 
 * Update Pact test to reflect new base/absolute path content schema definition ([PR](https://github.com/alphagov/gds-api-adapters/pull/1392))

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = "103.3.1".freeze
+  VERSION = "103.4.0".freeze
 end


### PR DESCRIPTION
* Improve RFC-192 validator method ([PR](https://github.com/alphagov/gds-api-adapters/pull/1411))
* Add RFC-192 compliant base path validator ([PR](https://github.com/alphagov/gds-api-adapters/pull/1406))

This repo is owned by the Content APIs team. Please let us know in [#govuk-content-apis](https://gds.slack.com/archives/C03D792LYJG) when you raise any PRs.
