### PR TITLE
[PNP-10125] Add RFC-192 compliance to ContentStore#content_item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Add RFC-192 Validation to ContentStore#content_item ([PR](https://github.com/alphagov/gds-api-adapters/pull/1414))
+
 ## 103.4.4
 
 * Remove `stub_asset_manager_restore_asset_conflict` test helper ([PR](https://github.com/alphagov/gds-api-adapters/pull/XXXX))

--- a/gds-api-adapters.gemspec
+++ b/gds-api-adapters.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "govuk_schemas", "~> 6.0"
   s.add_development_dependency "minitest", "~> 6.0"
   s.add_development_dependency "minitest-around", "~> 0.5"
+  s.add_development_dependency "minitest-mock"
   s.add_development_dependency "mocha", "~> 3.0"
   s.add_development_dependency "pact", "~> 1.62"
   s.add_development_dependency "pact_broker-client", "~> 1.65"

--- a/lib/gds_api/content_store.rb
+++ b/lib/gds_api/content_store.rb
@@ -5,6 +5,9 @@ require_relative "exceptions"
 
 class GdsApi::ContentStore < GdsApi::Base
   def content_item(base_path)
+    validator = GdsApi::Validators::BasePathValidator.new(base_path)
+    raise GdsApi::HTTPBadRequest, validator.errors unless validator.valid?
+
     get_json(content_item_url(base_path))
   rescue GdsApi::HTTPNotFound => e
     raise ItemNotFound.build_from(e)

--- a/test/content_store_test.rb
+++ b/test/content_store_test.rb
@@ -1,6 +1,7 @@
 require "test_helper"
 require "gds_api/content_store"
 require "gds_api/test_helpers/content_store"
+require "minitest/mock"
 
 describe GdsApi::ContentStore do
   include GdsApi::TestHelpers::ContentStore
@@ -33,6 +34,21 @@ describe GdsApi::ContentStore do
 
       assert_raises(GdsApi::HTTPGone) do
         @api.content_item("/it-is-gone")
+      end
+    end
+
+    describe "when the base_path validator returns false" do
+      before do
+        mock = Minitest::Mock.new
+        def mock.valid? = false
+        def mock.errors = { mocked_error: ["always fails"] }
+        GdsApi::Validators::BasePathValidator.stubs(:new).returns(mock)
+      end
+
+      it "raises HTTPBadRequest and doesn't call content store" do
+        assert_raises(GdsApi::HTTPBadRequest) do
+          @api.content_item("/it-is-gone")
+        end
       end
     end
   end


### PR DESCRIPTION
- This method now raises a GdsApi::HTTPBadRequest if the base_path being requested isn't RFC-192 compliant (all items in the content store which are not handled directly by router - redirects and gone items without details - are already compliant, so no apps using this library should ever need to load non-compliant items).\

Apps which use GdsApi::ContentStore:
- collections - indirectly through govuk_content_item_loader, should handle bad requests as part of the normal rails stack.
- content-data-admin - Used solely in the LinkTitleResolver, which itself appears to be [unused](https://github.com/search?q=repo%3Aalphagov/content-data-admin%20LinkTitleResolver&type=code) 
- email-alert-api - used in EmailCriteriaQuery, which is called either by a rake task or by content-data-admin on known /controlled paths.
- email-alert-frontend - used for getting information about paths for subscription information. Should be known paths only, so safe.
- feedback - indirectly through govuk_content_item_loader, should handle bad requests as part of the normal rails stack.
- frontend - used mainly in content loader, which handles bad requests as part of the normal rails stack, and in three other places where we control the value being put in, so they shouldn't fail (and if they do it's a data issue to fix).
- govuk_content_item_loader: (deprecated, scheduled for archiving - see frontend/collections/feedback)
- [publishing-api](https://github.com/alphagov/publishing-api/blob/583173d9bbb3efbb86cb3e1526ef84667b735fd9/lib/data_hygiene/document_status_checker.rb#L8) which is only called by a manually called rake task.
- [smart-answers](https://github.com/alphagov/smart-answers/blob/ad7b65d3a636d1888827ffe44ac39816b6ecd886/app/services/content_item_retriever.rb#L4) in ContentItemRetriever: rescues from GdsApi::BaseError so will handle a bad request as well as it does anything else. 

https://gov-uk.atlassian.net/browse/PNP-10125

This repo is owned by the Content APIs team. Please let us know in [#govuk-content-apis](https://gds.slack.com/archives/C03D792LYJG) when you raise any PRs.
