### PR TITLE
Add additional test helpers for asset manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## Unreleased
+## 103.4.1
 
-* Add extra test helpers to Asset Manager ([PR]https://github.com/alphagov/gds-api-adapters/pull/1415)
+* Add extra test helpers to Asset Manager ([PR](https://github.com/alphagov/gds-api-adapters/pull/1415))
 
 ## 103.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Add extra test helpers to Asset Manager ([PR]https://github.com/alphagov/gds-api-adapters/pull/1415)
+
 ## 103.4.0
 
 * Improve RFC-192 validator method ([PR](https://github.com/alphagov/gds-api-adapters/pull/1411))

--- a/lib/gds_api/test_helpers/asset_manager.rb
+++ b/lib/gds_api/test_helpers/asset_manager.rb
@@ -45,6 +45,23 @@ module GdsApi
           .to_return(body: response.to_json, status: 404)
       end
 
+      def stub_asset_manager_responds_forbidden(id)
+        response = {
+          "_response_info" => { "status" => "Forbidden. You don't have permission to access this resource." },
+        }
+
+        stub_request(:any, "#{ASSET_MANAGER_ENDPOINT}/assets/#{id}")
+          .to_return(body: response.to_json, status: 403)
+      end
+
+      def stub_asset_manager_responds_payload_too_large
+        stub_request(:any, %r{\A#{ASSET_MANAGER_ENDPOINT}}).to_return(status: 413)
+      end
+
+      def stub_asset_manager_responds_unprocessable
+        stub_request(:any, %r{\A#{ASSET_MANAGER_ENDPOINT}}).to_return(status: 422)
+      end
+
       # This can take a string of an exact url or a hash of options
       #
       # with a string:

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = "103.4.0".freeze
+  VERSION = "103.4.1".freeze
 end

--- a/test/test_helpers/asset_manager_test.rb
+++ b/test/test_helpers/asset_manager_test.rb
@@ -78,6 +78,39 @@ describe GdsApi::TestHelpers::AssetManager do
     end
   end
 
+  describe "#stub_asset_manager_responds_forbidden" do
+    it "raises a forbidden error" do
+      asset_id = "some-asset-id"
+      stub_asset_manager_responds_forbidden(asset_id)
+
+      assert_raises GdsApi::HTTPForbidden do
+        stub_asset_manager.asset(asset_id)
+      end
+    end
+  end
+
+  describe "#stub_asset_manager_responds_payload_too_large" do
+    it "raises a payload too large error" do
+      asset_id = "some-asset-id"
+      stub_asset_manager_responds_payload_too_large
+
+      assert_raises GdsApi::HTTPPayloadTooLarge do
+        stub_asset_manager.asset(asset_id)
+      end
+    end
+  end
+
+  describe "#stub_asset_manager_responds_unprocessable" do
+    it "raises an Unprocessable Entity  error" do
+      asset_id = "some-asset-id"
+      stub_asset_manager_responds_unprocessable
+
+      assert_raises GdsApi::HTTPUnprocessableEntity do
+        stub_asset_manager.asset(asset_id)
+      end
+    end
+  end
+
   describe "#stub_asset_manager_delete_asset_missing" do
     it "raises a not found error" do
       asset_id = "some-asset-id"


### PR DESCRIPTION
These are being added to support development of asset management endpoints in hmrc-manuals-api

This repo is owned by the Content APIs team. Please let us know in [#govuk-content-apis](https://gds.slack.com/archives/C03D792LYJG) when you raise any PRs.
