### PR TITLE
[PP-7954] Add and update test helpers for Asset Manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 103.4.1
 
 * Add new test helpers for Asset Manager ([PR](https://github.com/alphagov/gds-api-adapters/pull/1416))
   * `stub_asset_manager_create_asset_too_large`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
   * `stub_asset_manager_create_asset_unprocessable`
   * `stub_asset_manager_request_to_asset_media`
   * `stub_asset_manager_request_to_get_asset`
+  * `stub_asset_manager_update_asset_forbidden`
+  * `stub_asset_manager_update_asset_not_found`
 * Rename `stub_asset_manager_receives_an_asset` test helper to `stub_asset_manager_create_asset`; the old name will be deprecated in a later release ([PR](https://github.com/alphagov/gds-api-adapters/pull/1416))
 
 ## 103.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add new test helpers for Asset Manager ([PR](https://github.com/alphagov/gds-api-adapters/pull/1416))
   * `stub_asset_manager_create_asset_too_large`
+  * `stub_asset_manager_create_asset_unprocessable`
   * `stub_asset_manager_request_to_asset_media`
   * `stub_asset_manager_request_to_get_asset`
 * Rename `stub_asset_manager_receives_an_asset` test helper to `stub_asset_manager_create_asset`; the old name will be deprecated in a later release ([PR](https://github.com/alphagov/gds-api-adapters/pull/1416))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+* Add new test helpers for Asset Manager ([PR](https://github.com/alphagov/gds-api-adapters/pull/1416))
+  * `stub_asset_manager_request_to_asset_media`
+  * `stub_asset_manager_request_to_get_asset`
+
 ## 103.4.0
 
 * Improve RFC-192 validator method ([PR](https://github.com/alphagov/gds-api-adapters/pull/1411))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   * `stub_asset_manager_update_asset_forbidden`
   * `stub_asset_manager_update_asset_not_found`
 * Rename `stub_asset_manager_receives_an_asset` test helper to `stub_asset_manager_create_asset`; the old name will be deprecated in a later release ([PR](https://github.com/alphagov/gds-api-adapters/pull/1416))
+* Allow `stub_asset_manager_create_asset` test helper to return a body ([PR](https://github.com/alphagov/gds-api-adapters/pull/1416))
 
 ## 103.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add new test helpers for Asset Manager ([PR](https://github.com/alphagov/gds-api-adapters/pull/1416))
   * `stub_asset_manager_request_to_asset_media`
   * `stub_asset_manager_request_to_get_asset`
+* Rename `stub_asset_manager_receives_an_asset` test helper to `stub_asset_manager_create_asset`; the old name will be deprecated in a later release ([PR](https://github.com/alphagov/gds-api-adapters/pull/1416))
 
 ## 103.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add new test helpers for Asset Manager ([PR](https://github.com/alphagov/gds-api-adapters/pull/1416))
   * `stub_asset_manager_create_asset_too_large`
   * `stub_asset_manager_create_asset_unprocessable`
+  * `stub_asset_manager_get_asset_forbidden`
   * `stub_asset_manager_request_to_asset_media`
   * `stub_asset_manager_request_to_get_asset`
   * `stub_asset_manager_update_asset_forbidden`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Add new test helpers for Asset Manager ([PR](https://github.com/alphagov/gds-api-adapters/pull/1416))
+  * `stub_asset_manager_create_asset_too_large`
   * `stub_asset_manager_request_to_asset_media`
   * `stub_asset_manager_request_to_get_asset`
 * Rename `stub_asset_manager_receives_an_asset` test helper to `stub_asset_manager_create_asset`; the old name will be deprecated in a later release ([PR](https://github.com/alphagov/gds-api-adapters/pull/1416))

--- a/lib/gds_api/test_helpers/asset_manager.rb
+++ b/lib/gds_api/test_helpers/asset_manager.rb
@@ -91,6 +91,10 @@ module GdsApi
         stub_asset_manager_create_asset(response_url)
       end
 
+      def stub_asset_manager_create_asset_too_large
+        stub_request(:post, "#{ASSET_MANAGER_ENDPOINT}/assets").to_return(status: 413)
+      end
+
       def stub_asset_manager_upload_failure
         stub_request(:post, "#{ASSET_MANAGER_ENDPOINT}/assets").to_return(status: 500)
       end

--- a/lib/gds_api/test_helpers/asset_manager.rb
+++ b/lib/gds_api/test_helpers/asset_manager.rb
@@ -24,9 +24,16 @@ module GdsApi
       def stub_asset_manager_has_an_asset(id, atts, filename = "")
         response = atts.merge("_response_info" => { "status" => "ok" })
 
+        stub_asset_manager_request_to_get_asset(id, response)
+        stub_asset_manager_request_to_asset_media(id, filename)
+      end
+
+      def stub_asset_manager_request_to_get_asset(id, response)
         stub_request(:get, "#{ASSET_MANAGER_ENDPOINT}/assets/#{id}")
           .to_return(body: response.to_json, status: 200)
+      end
 
+      def stub_asset_manager_request_to_asset_media(id, filename)
         stub_request(:get, "#{ASSET_MANAGER_ENDPOINT}/media/#{id}/#{filename}")
           .to_return(body: "Some file content", status: 200)
       end

--- a/lib/gds_api/test_helpers/asset_manager.rb
+++ b/lib/gds_api/test_helpers/asset_manager.rb
@@ -55,17 +55,17 @@ module GdsApi
       # This can take a string of an exact url or a hash of options
       #
       # with a string:
-      # `stub_asset_manager_receives_an_asset("https://asset-manager/media/619ce797-b415-42e5-b2b1-2ffa0df52302/file.jpg")`
+      # `stub_asset_manager_create_asset("https://asset-manager/media/619ce797-b415-42e5-b2b1-2ffa0df52302/file.jpg")`
       #
       # with a hash:
-      # `stub_asset_manager_receives_an_asset(id: "20d04259-e3ae-4f71-8157-e6c843096e96", filename: "file.jpg")`
+      # `stub_asset_manager_create_asset(id: "20d04259-e3ae-4f71-8157-e6c843096e96", filename: "file.jpg")`
       # which would return a file url of "https://asset-manager/media/20d04259-e3ae-4f71-8157-e6c843096e96/file.jpg"
       #
       # with no argument
       #
-      # `stub_asset_manager_receives_an_asset`
+      # `stub_asset_manager_create_asset`
       # which would return a file url of "https://asset-manager/media/0053adbf-0737-4923-9d8a-8180f2c723af/0d19136c4a94f07"
-      def stub_asset_manager_receives_an_asset(response_url = {})
+      def stub_asset_manager_create_asset(response_url = {})
         stub_request(:post, "#{ASSET_MANAGER_ENDPOINT}/assets").to_return do
           if response_url.is_a?(String)
             file_url = response_url
@@ -79,6 +79,16 @@ module GdsApi
           end
           { body: { file_url: }.to_json, status: 200 }
         end
+      end
+
+      def stub_asset_manager_receives_an_asset(response_url = {})
+        warn <<~WARNING
+          stub_asset_manager_receives_an_asset is deprecated and will be removed
+          in a future version of gds-api-adapters. Replace calls to this method with
+          stub_asset_manager_create_asset.
+        WARNING
+
+        stub_asset_manager_create_asset(response_url)
       end
 
       def stub_asset_manager_upload_failure

--- a/lib/gds_api/test_helpers/asset_manager.rb
+++ b/lib/gds_api/test_helpers/asset_manager.rb
@@ -95,6 +95,10 @@ module GdsApi
         stub_request(:post, "#{ASSET_MANAGER_ENDPOINT}/assets").to_return(status: 413)
       end
 
+      def stub_asset_manager_create_asset_unprocessable(body = "")
+        stub_request(:post, "#{ASSET_MANAGER_ENDPOINT}/assets").to_return(body:, status: 422)
+      end
+
       def stub_asset_manager_upload_failure
         stub_request(:post, "#{ASSET_MANAGER_ENDPOINT}/assets").to_return(status: 500)
       end

--- a/lib/gds_api/test_helpers/asset_manager.rb
+++ b/lib/gds_api/test_helpers/asset_manager.rb
@@ -69,7 +69,7 @@ module GdsApi
       #
       # `stub_asset_manager_create_asset`
       # which would return a file url of "https://asset-manager/media/0053adbf-0737-4923-9d8a-8180f2c723af/0d19136c4a94f07"
-      def stub_asset_manager_create_asset(response_url = {})
+      def stub_asset_manager_create_asset(response_url = {}, response_body = {})
         stub_request(:post, "#{ASSET_MANAGER_ENDPOINT}/assets").to_return do
           if response_url.is_a?(String)
             file_url = response_url
@@ -81,7 +81,7 @@ module GdsApi
 
             file_url = "#{ASSET_MANAGER_ENDPOINT}/media/#{options[:id]}/#{options[:filename]}"
           end
-          { body: { file_url: }.to_json, status: 200 }
+          { body: response_body.merge(file_url:).to_json, status: 200 }
         end
       end
 

--- a/lib/gds_api/test_helpers/asset_manager.rb
+++ b/lib/gds_api/test_helpers/asset_manager.rb
@@ -108,6 +108,14 @@ module GdsApi
           .to_return(body: body.to_json, status: 200)
       end
 
+      def stub_asset_manager_update_asset_forbidden(asset_id)
+        stub_request(:put, "#{ASSET_MANAGER_ENDPOINT}/assets/#{asset_id}").to_return(status: 403)
+      end
+
+      def stub_asset_manager_update_asset_not_found(asset_id)
+        stub_request(:put, "#{ASSET_MANAGER_ENDPOINT}/assets/#{asset_id}").to_return(status: 404)
+      end
+
       def stub_asset_manager_update_asset_failure(asset_id)
         stub_request(:put, "#{ASSET_MANAGER_ENDPOINT}/assets/#{asset_id}").to_return(status: 500)
       end

--- a/lib/gds_api/test_helpers/asset_manager.rb
+++ b/lib/gds_api/test_helpers/asset_manager.rb
@@ -52,6 +52,10 @@ module GdsApi
           .to_return(body: response.to_json, status: 404)
       end
 
+      def stub_asset_manager_get_asset_forbidden(id)
+        stub_request(:get, "#{ASSET_MANAGER_ENDPOINT}/assets/#{id}").to_return(status: 403)
+      end
+
       # This can take a string of an exact url or a hash of options
       #
       # with a string:

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = "103.4.0".freeze
+  VERSION = "103.4.1".freeze
 end

--- a/test/test_helpers/asset_manager_test.rb
+++ b/test/test_helpers/asset_manager_test.rb
@@ -186,4 +186,26 @@ describe GdsApi::TestHelpers::AssetManager do
       end
     end
   end
+
+  describe "#stub_asset_manager_create_asset_unprocessable" do
+    describe "when the endpoint is requested" do
+      it "raises GdsApi::HTTPUnprocessableEntity" do
+        stub_asset_manager_create_asset_unprocessable
+
+        assert_raises GdsApi::HTTPUnprocessableEntity do
+          stub_asset_manager.create_asset({})
+        end
+      end
+
+      it "includes the body when provided" do
+        stub_asset_manager_create_asset_unprocessable("Some output")
+
+        error = assert_raises GdsApi::HTTPUnprocessableEntity do
+          stub_asset_manager.create_asset({})
+        end
+
+        assert_includes error.message, "Some output"
+      end
+    end
+  end
 end

--- a/test/test_helpers/asset_manager_test.rb
+++ b/test/test_helpers/asset_manager_test.rb
@@ -63,6 +63,17 @@ describe GdsApi::TestHelpers::AssetManager do
         assert_match url_format, response["file_url"]
       end
     end
+
+    describe "when passed a response body" do
+      it "returns the body in the response" do
+        url = "https://assets.example.com/path/to/asset"
+        response_body = { "key": "value" }
+        stub_asset_manager_create_asset(url, response_body)
+        response = stub_asset_manager.create_asset({})
+
+        assert_equal "value", response["key"]
+      end
+    end
   end
 
   describe "#stub_asset_manager_receives_an_asset" do

--- a/test/test_helpers/asset_manager_test.rb
+++ b/test/test_helpers/asset_manager_test.rb
@@ -99,4 +99,59 @@ describe GdsApi::TestHelpers::AssetManager do
       end
     end
   end
+
+  describe "#stub_asset_manager_has_an_asset" do
+    describe "when the asset endpoint is requested" do
+      it "returns the given attributes" do
+        asset_id = "some-asset-id"
+        body = { key: "value" }
+        stub_asset_manager_has_an_asset(asset_id, body)
+        response = stub_asset_manager.asset(asset_id)
+
+        assert_equal 200, response.code
+        assert_equal body[:key], response["key"]
+      end
+    end
+
+    describe "when the media endpoint is requested" do
+      it "returns the file content" do
+        asset_id = "some-asset-id"
+        body = { key: "value" }
+        filename = "file.pdf"
+        stub_asset_manager_has_an_asset(asset_id, body, filename)
+        response = stub_asset_manager.media(asset_id, filename)
+
+        assert_equal 200, response.code
+        assert_equal "Some file content", response
+      end
+    end
+  end
+
+  describe "#stub_asset_manager_request_to_get_asset" do
+    describe "when the asset endpoint is requested" do
+      it "returns the given attributes" do
+        asset_id = "some-asset-id"
+        body = { key: "value" }
+        stub_asset_manager_request_to_get_asset(asset_id, body)
+        response = stub_asset_manager.asset(asset_id)
+
+        assert_equal 200, response.code
+        assert_equal body[:key], response["key"]
+      end
+    end
+  end
+
+  describe "#stub_asset_manager_request_to_asset_media" do
+    describe "when the media endpoint is requested" do
+      it "returns the file content" do
+        asset_id = "some-asset-id"
+        filename = "file.pdf"
+        stub_asset_manager_request_to_asset_media(asset_id, filename)
+        response = stub_asset_manager.media(asset_id, filename)
+
+        assert_equal 200, response.code
+        assert_equal "Some file content", response
+      end
+    end
+  end
 end

--- a/test/test_helpers/asset_manager_test.rb
+++ b/test/test_helpers/asset_manager_test.rb
@@ -208,4 +208,30 @@ describe GdsApi::TestHelpers::AssetManager do
       end
     end
   end
+
+  describe "#stub_asset_manager_update_asset_forbidden" do
+    describe "when the endpoint is requested with the given ID" do
+      it "raises GdsApi::HTTPForbidden" do
+        asset_id = "some-id"
+        stub_asset_manager_update_asset_forbidden(asset_id)
+
+        assert_raises GdsApi::HTTPForbidden do
+          stub_asset_manager.update_asset(asset_id, {})
+        end
+      end
+    end
+  end
+
+  describe "#stub_asset_manager_update_asset_not_found" do
+    describe "when the endpoint is requested with the given ID" do
+      it "raises GdsApi::HTTPNotFound" do
+        asset_id = "some-id"
+        stub_asset_manager_update_asset_not_found(asset_id)
+
+        assert_raises GdsApi::HTTPNotFound do
+          stub_asset_manager.update_asset(asset_id, {})
+        end
+      end
+    end
+  end
 end

--- a/test/test_helpers/asset_manager_test.rb
+++ b/test/test_helpers/asset_manager_test.rb
@@ -174,4 +174,16 @@ describe GdsApi::TestHelpers::AssetManager do
       end
     end
   end
+
+  describe "#stub_asset_manager_create_asset_too_large" do
+    describe "when the endpoint is requested" do
+      it "raises GdsApi::HTTPPayloadTooLarge" do
+        stub_asset_manager_create_asset_too_large
+
+        assert_raises GdsApi::HTTPPayloadTooLarge do
+          stub_asset_manager.create_asset({})
+        end
+      end
+    end
+  end
 end

--- a/test/test_helpers/asset_manager_test.rb
+++ b/test/test_helpers/asset_manager_test.rb
@@ -9,11 +9,11 @@ describe GdsApi::TestHelpers::AssetManager do
     GdsApi::AssetManager.new(Plek.find("asset-manager"))
   end
 
-  describe "#stub_asset_manager_receives_an_asset" do
+  describe "#stub_asset_manager_create_asset" do
     describe "when passed a string" do
       it "returns the string as the file url" do
         url = "https://assets.example.com/path/to/asset"
-        stub_asset_manager_receives_an_asset(url)
+        stub_asset_manager_create_asset(url)
         response = stub_asset_manager.create_asset({})
 
         assert_equal url, response["file_url"]
@@ -22,7 +22,7 @@ describe GdsApi::TestHelpers::AssetManager do
 
     describe "when passed no arguments" do
       it "returns a random, yet valid asset manager url" do
-        stub_asset_manager_receives_an_asset
+        stub_asset_manager_create_asset
         response = stub_asset_manager.create_asset({})
 
         url_format = %r{\Ahttp://asset-manager.dev.gov.uk/media/[^/]*/[^/]*\Z}
@@ -30,7 +30,7 @@ describe GdsApi::TestHelpers::AssetManager do
       end
 
       it "returns a different URL each call" do
-        stub_asset_manager_receives_an_asset
+        stub_asset_manager_create_asset
         response1 = stub_asset_manager.create_asset({})
         response2 = stub_asset_manager.create_asset({})
 
@@ -40,7 +40,7 @@ describe GdsApi::TestHelpers::AssetManager do
 
     describe "when passed a hash" do
       it "can specify the id of an asset" do
-        stub_asset_manager_receives_an_asset(id: "123")
+        stub_asset_manager_create_asset(id: "123")
         response = stub_asset_manager.create_asset({})
 
         url_format = %r{\Ahttp://asset-manager.dev.gov.uk/media/123/[^/]*\Z}
@@ -48,7 +48,7 @@ describe GdsApi::TestHelpers::AssetManager do
       end
 
       it "can specify the filename of an asset" do
-        stub_asset_manager_receives_an_asset(filename: "file.ext")
+        stub_asset_manager_create_asset(filename: "file.ext")
         response = stub_asset_manager.create_asset({})
 
         url_format = %r{\Ahttp://asset-manager.dev.gov.uk/media/[^/]*/file.ext\Z}
@@ -56,12 +56,32 @@ describe GdsApi::TestHelpers::AssetManager do
       end
 
       it "can specify both filename and id" do
-        stub_asset_manager_receives_an_asset(id: "123", filename: "file.ext")
+        stub_asset_manager_create_asset(id: "123", filename: "file.ext")
         response = stub_asset_manager.create_asset({})
 
         url_format = %r{\Ahttp://asset-manager.dev.gov.uk/media/123/file.ext\Z}
         assert_match url_format, response["file_url"]
       end
+    end
+  end
+
+  describe "#stub_asset_manager_receives_an_asset" do
+    it "includes a deprecation warning" do
+      expects(:warn).with(
+        <<~WARNING,
+          stub_asset_manager_receives_an_asset is deprecated and will be removed
+          in a future version of gds-api-adapters. Replace calls to this method with
+          stub_asset_manager_create_asset.
+        WARNING
+      )
+
+      stub_asset_manager_receives_an_asset
+    end
+
+    it "delegates to the new method" do
+      expects(:stub_asset_manager_create_asset).once
+
+      stub_asset_manager_receives_an_asset
     end
   end
 

--- a/test/test_helpers/asset_manager_test.rb
+++ b/test/test_helpers/asset_manager_test.rb
@@ -234,4 +234,17 @@ describe GdsApi::TestHelpers::AssetManager do
       end
     end
   end
+
+  describe "#stub_asset_manager_get_asset_forbidden" do
+    describe "when the endpoint is requested with the given ID" do
+      it "raises GdsApi::HTTPForbidden" do
+        asset_id = "some-id"
+        stub_asset_manager_get_asset_forbidden(asset_id)
+
+        assert_raises GdsApi::HTTPForbidden do
+          stub_asset_manager.asset(asset_id)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Whilst implementing asset management in HMRC Manuals API, it was found that some new and updated test helpers have been required.