### PR TITLE
[PP-7892] Add restore asset test helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add yet more new test helpers for Asset Manager ([PR](https://github.com/alphagov/gds-api-adapters/pull/1417))
   * `stub_asset_manager_restore_asset`
   * `stub_asset_manager_restore_asset_conflict`
+  * `stub_asset_manager_restore_asset_failure`
   * `stub_asset_manager_restore_asset_forbidden`
   * `stub_asset_manager_restore_asset_not_found`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 103.4.3
 
 * Add yet more new test helpers for Asset Manager ([PR](https://github.com/alphagov/gds-api-adapters/pull/1417))
   * `stub_asset_manager_restore_asset`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+* Add yet more new test helpers for Asset Manager ([PR](https://github.com/alphagov/gds-api-adapters/pull/1417))
+  * `stub_asset_manager_restore_asset`
+
 ## 103.4.2
 
 * Add even more new test helpers for Asset Manager ([PR](https://github.com/alphagov/gds-api-adapters/pull/1418))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add yet more new test helpers for Asset Manager ([PR](https://github.com/alphagov/gds-api-adapters/pull/1417))
   * `stub_asset_manager_restore_asset`
+  * `stub_asset_manager_restore_asset_forbidden`
 
 ## 103.4.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add yet more new test helpers for Asset Manager ([PR](https://github.com/alphagov/gds-api-adapters/pull/1417))
   * `stub_asset_manager_restore_asset`
+  * `stub_asset_manager_restore_asset_conflict`
   * `stub_asset_manager_restore_asset_forbidden`
   * `stub_asset_manager_restore_asset_not_found`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add yet more new test helpers for Asset Manager ([PR](https://github.com/alphagov/gds-api-adapters/pull/1417))
   * `stub_asset_manager_restore_asset`
   * `stub_asset_manager_restore_asset_forbidden`
+  * `stub_asset_manager_restore_asset_not_found`
 
 ## 103.4.2
 

--- a/lib/gds_api/test_helpers/asset_manager.rb
+++ b/lib/gds_api/test_helpers/asset_manager.rb
@@ -160,6 +160,11 @@ module GdsApi
         stub_request(:post, "#{ASSET_MANAGER_ENDPOINT}/assets/#{asset_id}/restore")
           .to_return(status: 403)
       end
+
+      def stub_asset_manager_restore_asset_not_found(asset_id)
+        stub_request(:post, "#{ASSET_MANAGER_ENDPOINT}/assets/#{asset_id}/restore")
+          .to_return(status: 404)
+      end
     end
   end
 end

--- a/lib/gds_api/test_helpers/asset_manager.rb
+++ b/lib/gds_api/test_helpers/asset_manager.rb
@@ -170,6 +170,11 @@ module GdsApi
         stub_request(:post, "#{ASSET_MANAGER_ENDPOINT}/assets/#{asset_id}/restore")
           .to_return(status: 409)
       end
+
+      def stub_asset_manager_restore_asset_failure(asset_id)
+        stub_request(:post, "#{ASSET_MANAGER_ENDPOINT}/assets/#{asset_id}/restore")
+          .to_return(status: 500)
+      end
     end
   end
 end

--- a/lib/gds_api/test_helpers/asset_manager.rb
+++ b/lib/gds_api/test_helpers/asset_manager.rb
@@ -165,6 +165,11 @@ module GdsApi
         stub_request(:post, "#{ASSET_MANAGER_ENDPOINT}/assets/#{asset_id}/restore")
           .to_return(status: 404)
       end
+
+      def stub_asset_manager_restore_asset_conflict(asset_id)
+        stub_request(:post, "#{ASSET_MANAGER_ENDPOINT}/assets/#{asset_id}/restore")
+          .to_return(status: 409)
+      end
     end
   end
 end

--- a/lib/gds_api/test_helpers/asset_manager.rb
+++ b/lib/gds_api/test_helpers/asset_manager.rb
@@ -150,6 +150,11 @@ module GdsApi
       def stub_asset_manager_delete_asset_failure(asset_id)
         stub_request(:delete, "#{ASSET_MANAGER_ENDPOINT}/assets/#{asset_id}").to_return(status: 500)
       end
+
+      def stub_asset_manager_restore_asset(asset_id, body = {})
+        stub_request(:post, "#{ASSET_MANAGER_ENDPOINT}/assets/#{asset_id}/restore")
+          .to_return(body: body.to_json, status: 200)
+      end
     end
   end
 end

--- a/lib/gds_api/test_helpers/asset_manager.rb
+++ b/lib/gds_api/test_helpers/asset_manager.rb
@@ -155,6 +155,11 @@ module GdsApi
         stub_request(:post, "#{ASSET_MANAGER_ENDPOINT}/assets/#{asset_id}/restore")
           .to_return(body: body.to_json, status: 200)
       end
+
+      def stub_asset_manager_restore_asset_forbidden(asset_id)
+        stub_request(:post, "#{ASSET_MANAGER_ENDPOINT}/assets/#{asset_id}/restore")
+          .to_return(status: 403)
+      end
     end
   end
 end

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = "103.4.2".freeze
+  VERSION = "103.4.3".freeze
 end

--- a/test/test_helpers/asset_manager_test.rb
+++ b/test/test_helpers/asset_manager_test.rb
@@ -319,4 +319,17 @@ describe GdsApi::TestHelpers::AssetManager do
       end
     end
   end
+
+  describe "#stub_asset_manager_restore_asset_forbidden" do
+    describe "when the endpoint is requested with the given ID" do
+      it "raises GdsApi::HTTPForbidden" do
+        asset_id = "some-id"
+        stub_asset_manager_restore_asset_forbidden(asset_id)
+
+        assert_raises GdsApi::HTTPForbidden do
+          stub_asset_manager.restore_asset(asset_id)
+        end
+      end
+    end
+  end
 end

--- a/test/test_helpers/asset_manager_test.rb
+++ b/test/test_helpers/asset_manager_test.rb
@@ -305,4 +305,18 @@ describe GdsApi::TestHelpers::AssetManager do
       end
     end
   end
+
+  describe "#stub_asset_manager_restore_asset" do
+    describe "when the endpoint is requested with the given ID" do
+      it "returns the given attributes" do
+        asset_id = "some-asset-id"
+        body = { key: "value" }
+        stub_asset_manager_restore_asset(asset_id, body)
+        response = stub_asset_manager.restore_asset(asset_id)
+
+        assert_equal 200, response.code
+        assert_equal body[:key], response["key"]
+      end
+    end
+  end
 end

--- a/test/test_helpers/asset_manager_test.rb
+++ b/test/test_helpers/asset_manager_test.rb
@@ -345,4 +345,17 @@ describe GdsApi::TestHelpers::AssetManager do
       end
     end
   end
+
+  describe "#stub_asset_manager_restore_asset_conflict" do
+    describe "when the endpoint is requested with the given ID" do
+      it "raises GdsApi::HTTPConflict" do
+        asset_id = "some-id"
+        stub_asset_manager_restore_asset_conflict(asset_id)
+
+        assert_raises GdsApi::HTTPConflict do
+          stub_asset_manager.restore_asset(asset_id)
+        end
+      end
+    end
+  end
 end

--- a/test/test_helpers/asset_manager_test.rb
+++ b/test/test_helpers/asset_manager_test.rb
@@ -358,4 +358,17 @@ describe GdsApi::TestHelpers::AssetManager do
       end
     end
   end
+
+  describe "#stub_asset_manager_restore_asset_failure" do
+    describe "when the endpoint is requested with the given ID" do
+      it "raises GdsApi::HTTPInternalServerError" do
+        asset_id = "some-id"
+        stub_asset_manager_restore_asset_failure(asset_id)
+
+        assert_raises GdsApi::HTTPInternalServerError do
+          stub_asset_manager.restore_asset(asset_id)
+        end
+      end
+    end
+  end
 end

--- a/test/test_helpers/asset_manager_test.rb
+++ b/test/test_helpers/asset_manager_test.rb
@@ -332,4 +332,17 @@ describe GdsApi::TestHelpers::AssetManager do
       end
     end
   end
+
+  describe "#stub_asset_manager_restore_asset_not_found" do
+    describe "when the endpoint is requested with the given ID" do
+      it "raises GdsApi::HTTPNotFound" do
+        asset_id = "some-id"
+        stub_asset_manager_restore_asset_not_found(asset_id)
+
+        assert_raises GdsApi::HTTPNotFound do
+          stub_asset_manager.restore_asset(asset_id)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
These will be used in HMRC Manuals API to stub successful and unsuccessful Asset Manager responses so that we can test the former deals with such responses properly