### PR TITLE
Asset manager test helpers pt2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 103.4.2
 
 * Add even more new test helpers for Asset Manager ([PR](https://github.com/alphagov/gds-api-adapters/pull/1418))
   * `stub_asset_manager_delete_asset_forbidden`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+* Add even more new test helpers for Asset Manager ([PR](https://github.com/alphagov/gds-api-adapters/pull/1418))
+  * `stub_asset_manager_delete_asset_forbidden`
+
 ## 103.4.1
 
 * Add new test helpers for Asset Manager ([PR](https://github.com/alphagov/gds-api-adapters/pull/1416))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add even more new test helpers for Asset Manager ([PR](https://github.com/alphagov/gds-api-adapters/pull/1418))
   * `stub_asset_manager_delete_asset_forbidden`
+  * `stub_asset_manager_update_asset_too_large`
 
 ## 103.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add even more new test helpers for Asset Manager ([PR](https://github.com/alphagov/gds-api-adapters/pull/1418))
   * `stub_asset_manager_delete_asset_forbidden`
   * `stub_asset_manager_update_asset_too_large`
+  * `stub_asset_manager_update_asset_unprocessable`
 
 ## 103.4.1
 

--- a/lib/gds_api/test_helpers/asset_manager.rb
+++ b/lib/gds_api/test_helpers/asset_manager.rb
@@ -120,6 +120,10 @@ module GdsApi
         stub_request(:put, "#{ASSET_MANAGER_ENDPOINT}/assets/#{asset_id}").to_return(status: 404)
       end
 
+      def stub_asset_manager_update_asset_too_large(asset_id)
+        stub_request(:put, "#{ASSET_MANAGER_ENDPOINT}/assets/#{asset_id}").to_return(status: 413)
+      end
+
       def stub_asset_manager_update_asset_failure(asset_id)
         stub_request(:put, "#{ASSET_MANAGER_ENDPOINT}/assets/#{asset_id}").to_return(status: 500)
       end

--- a/lib/gds_api/test_helpers/asset_manager.rb
+++ b/lib/gds_api/test_helpers/asset_manager.rb
@@ -124,6 +124,10 @@ module GdsApi
         stub_request(:put, "#{ASSET_MANAGER_ENDPOINT}/assets/#{asset_id}").to_return(status: 413)
       end
 
+      def stub_asset_manager_update_asset_unprocessable(asset_id, body = "")
+        stub_request(:put, "#{ASSET_MANAGER_ENDPOINT}/assets/#{asset_id}").to_return(body:, status: 422)
+      end
+
       def stub_asset_manager_update_asset_failure(asset_id)
         stub_request(:put, "#{ASSET_MANAGER_ENDPOINT}/assets/#{asset_id}").to_return(status: 500)
       end

--- a/lib/gds_api/test_helpers/asset_manager.rb
+++ b/lib/gds_api/test_helpers/asset_manager.rb
@@ -129,6 +129,11 @@ module GdsApi
           .to_return(body: body.to_json, status: 200)
       end
 
+      def stub_asset_manager_delete_asset_forbidden(asset_id)
+        stub_request(:delete, "#{ASSET_MANAGER_ENDPOINT}/assets/#{asset_id}")
+          .to_return(status: 403)
+      end
+
       def stub_asset_manager_delete_asset_missing(asset_id)
         stub_request(:delete, "#{ASSET_MANAGER_ENDPOINT}/assets/#{asset_id}")
           .to_return(status: 404)

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = "103.4.1".freeze
+  VERSION = "103.4.2".freeze
 end

--- a/test/test_helpers/asset_manager_test.rb
+++ b/test/test_helpers/asset_manager_test.rb
@@ -231,6 +231,29 @@ describe GdsApi::TestHelpers::AssetManager do
     end
   end
 
+  describe "#stub_asset_manager_update_asset_unprocessable" do
+    describe "when the endpoint is requested with the given ID" do
+      let(:asset_id) { "some_id" }
+      it "raises GdsApi::HTTPUnprocessableEntity" do
+        stub_asset_manager_update_asset_unprocessable(asset_id)
+
+        assert_raises GdsApi::HTTPUnprocessableEntity do
+          stub_asset_manager.update_asset(asset_id, {})
+        end
+      end
+
+      it "includes the body when provided" do
+        stub_asset_manager_update_asset_unprocessable(asset_id, "Some output")
+
+        error = assert_raises GdsApi::HTTPUnprocessableEntity do
+          stub_asset_manager.update_asset(asset_id, {})
+        end
+
+        assert_includes error.message, "Some output"
+      end
+    end
+  end
+
   describe "#stub_asset_manager_update_asset_forbidden" do
     describe "when the endpoint is requested with the given ID" do
       it "raises GdsApi::HTTPForbidden" do

--- a/test/test_helpers/asset_manager_test.rb
+++ b/test/test_helpers/asset_manager_test.rb
@@ -120,6 +120,17 @@ describe GdsApi::TestHelpers::AssetManager do
     end
   end
 
+  describe "#stub_asset_manager_delete_asset_forbidden" do
+    it "raises a forbidden error" do
+      asset_id = "some-asset-id"
+      stub_asset_manager_delete_asset_forbidden(asset_id)
+
+      assert_raises GdsApi::HTTPForbidden do
+        stub_asset_manager.delete_asset(asset_id)
+      end
+    end
+  end
+
   describe "#stub_asset_manager_delete_asset_failure" do
     it "raises an internal server error" do
       asset_id = "some-asset-id"

--- a/test/test_helpers/asset_manager_test.rb
+++ b/test/test_helpers/asset_manager_test.rb
@@ -244,6 +244,19 @@ describe GdsApi::TestHelpers::AssetManager do
     end
   end
 
+  describe "#stub_asset_manager_update_asset_too_large" do
+    describe "when the endpoint is requested with the given ID" do
+      it "raises GdsApi::HTTPPayloadTooLarge" do
+        asset_id = "some-id"
+        stub_asset_manager_update_asset_too_large(asset_id)
+
+        assert_raises GdsApi::HTTPPayloadTooLarge do
+          stub_asset_manager.update_asset(asset_id, {})
+        end
+      end
+    end
+  end
+
   describe "#stub_asset_manager_update_asset_not_found" do
     describe "when the endpoint is requested with the given ID" do
       it "raises GdsApi::HTTPNotFound" do


### PR DESCRIPTION
Similar to https://github.com/alphagov/gds-api-adapters/pull/1416, some more test helpers for use with the new HMRC Manuals API endpoints