### PR TITLE
[PP-7892] Remove restore conflict helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 103.4.4
 
 * Remove `stub_asset_manager_restore_asset_conflict` test helper ([PR](https://github.com/alphagov/gds-api-adapters/pull/XXXX))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Remove `stub_asset_manager_restore_asset_conflict` test helper ([PR](https://github.com/alphagov/gds-api-adapters/pull/XXXX))
+
 ## 103.4.3
 
 * Add yet more new test helpers for Asset Manager ([PR](https://github.com/alphagov/gds-api-adapters/pull/1417))

--- a/lib/gds_api/test_helpers/asset_manager.rb
+++ b/lib/gds_api/test_helpers/asset_manager.rb
@@ -166,11 +166,6 @@ module GdsApi
           .to_return(status: 404)
       end
 
-      def stub_asset_manager_restore_asset_conflict(asset_id)
-        stub_request(:post, "#{ASSET_MANAGER_ENDPOINT}/assets/#{asset_id}/restore")
-          .to_return(status: 409)
-      end
-
       def stub_asset_manager_restore_asset_failure(asset_id)
         stub_request(:post, "#{ASSET_MANAGER_ENDPOINT}/assets/#{asset_id}/restore")
           .to_return(status: 500)

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = "103.4.3".freeze
+  VERSION = "103.4.4".freeze
 end

--- a/test/test_helpers/asset_manager_test.rb
+++ b/test/test_helpers/asset_manager_test.rb
@@ -346,19 +346,6 @@ describe GdsApi::TestHelpers::AssetManager do
     end
   end
 
-  describe "#stub_asset_manager_restore_asset_conflict" do
-    describe "when the endpoint is requested with the given ID" do
-      it "raises GdsApi::HTTPConflict" do
-        asset_id = "some-id"
-        stub_asset_manager_restore_asset_conflict(asset_id)
-
-        assert_raises GdsApi::HTTPConflict do
-          stub_asset_manager.restore_asset(asset_id)
-        end
-      end
-    end
-  end
-
   describe "#stub_asset_manager_restore_asset_failure" do
     describe "when the endpoint is requested with the given ID" do
       it "raises GdsApi::HTTPInternalServerError" do


### PR DESCRIPTION
Asset Manager doesn't ever raise a conflict error on this path. There was a question about this in the draft HMRC Manuals API docs, but I can't evidence of it being looked into: https://github.com/alphagov/hmrc-manuals-api/pull/1291/changes#r3371782630 