### PR TITLE
Allow nil base_paths in validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Allow nil base_paths in validator ([PR](https://github.com/alphagov/gds-api-adapters/pull/1421))
 * Add RFC-192 Validation to ContentStore#content_item ([PR](https://github.com/alphagov/gds-api-adapters/pull/1414))
 
 ## 103.4.4

--- a/lib/gds_api/validators/base_path_validator.rb
+++ b/lib/gds_api/validators/base_path_validator.rb
@@ -10,11 +10,13 @@ module GdsApi
       end
 
       def valid?
-        !(base_path.nil? || no_leading_slash? || too_long? || potential_path_traversal? || ends_with_a_period? || invalid_chars?)
+        return true unless base_path
+
+        !(no_leading_slash? || too_long? || potential_path_traversal? || ends_with_a_period? || invalid_chars?)
       end
 
       def errors
-        return { base_path_invalid: ["must not be nil"] } if base_path.nil?
+        return {} unless base_path
 
         errors = []
         errors << [:base_path_invalid, "must start with a /"] if no_leading_slash?

--- a/test/validators/base_path_validator_test.rb
+++ b/test/validators/base_path_validator_test.rb
@@ -4,6 +4,7 @@ require "gds_api/validators/base_path_validator"
 describe GdsApi::Validators::BasePathValidator do
   let(:valid_path_examples) do
     [
+      nil,
       "/",
       "/government/topical-event/heat-wave-2026",
       "/government/topical-event/heat-wave-2026.csv",
@@ -13,7 +14,6 @@ describe GdsApi::Validators::BasePathValidator do
 
   let(:invalid_path_examples) do
     [
-      nil,
       "government/topical-events",
       "//",
       "//govuk",
@@ -34,7 +34,6 @@ describe GdsApi::Validators::BasePathValidator do
 
   let(:invalid_path_examples_errors) do
     [
-      { base_path_invalid: ["must not be nil"] },
       { base_path_invalid: ["must start with a /"] },
       { base_path_invalid: ["must not include runs of . and or / characters, which could be penetration attempts"] },
       { base_path_invalid: ["must not include runs of . and or / characters, which could be penetration attempts"] },


### PR DESCRIPTION
- Nil as a base_path corresponds to items that will not be published to content store, but should still be allowed in publishing-api. This means that we can either maintain a complicated list of elements in publishing api that shouldn't be validated, or we can remove the nil check in the validator. We've chosen the second, since it's easy to check nils externally to the validator in  situations where they absolutely must be avoided.

This repo is owned by the Content APIs team. Please let us know in [#govuk-content-apis](https://gds.slack.com/archives/C03D792LYJG) when you raise any PRs.
