### PR TITLE
Release 103.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 103.5.0
 
 * Allow nil base_paths in validator ([PR](https://github.com/alphagov/gds-api-adapters/pull/1421))
 * Add RFC-192 Validation to ContentStore#content_item ([PR](https://github.com/alphagov/gds-api-adapters/pull/1414))

--- a/lib/gds_api/version.rb
+++ b/lib/gds_api/version.rb
@@ -1,3 +1,3 @@
 module GdsApi
-  VERSION = "103.4.4".freeze
+  VERSION = "103.5.0".freeze
 end


### PR DESCRIPTION

Included PRs:
* Allow nil base_paths in validator ([PR](https://github.com/alphagov/gds-api-adapters/pull/1421))
* Add RFC-192 Validation to ContentStore#content_item ([PR](https://github.com/alphagov/gds-api-adapters/pull/1414))

This repo is owned by the Content APIs team. Please let us know in [#govuk-content-apis](https://gds.slack.com/archives/C03D792LYJG) when you raise any PRs.
